### PR TITLE
fix(babel-plugin-marko): whitespace now prints properly

### DIFF
--- a/packages/babel-plugin-marko/src/parser.js
+++ b/packages/babel-plugin-marko/src/parser.js
@@ -3,6 +3,9 @@ import parseArguments from "./util/parse-arguments";
 import parseParams from "./util/parse-params";
 import * as t from "./definitions";
 const EMPTY_OBJECT = {};
+const htmlTrimStart = t => t.replace(/^[\n\r]\s*/, "");
+const htmlTrimEnd = t => t.replace(/[\n\r]\s*$/, "");
+const htmlTrim = t => htmlTrimStart(htmlTrimEnd(t));
 
 export function parse(hub) {
   const { code, filename, htmlParseOptions = {} } = hub;
@@ -17,55 +20,70 @@ export function parse(hub) {
     {
       onDocumentType({ value, pos, endPos }) {
         const node = hub.createNode("htmlDocumentType", pos, endPos, value);
-        onNext = onNext && onNext(node);
         context.push(node);
+        onNext = onNext && onNext(node);
       },
 
       onDeclaration({ value, pos, endPos }) {
         const node = hub.createNode("htmlDeclaration", pos, endPos, value);
-        onNext = onNext && onNext(node);
         context.push(node);
+        onNext = onNext && onNext(node);
       },
 
       onComment({ value, pos, endPos }) {
         const node = hub.createNode("htmlComment", pos, endPos, value);
-        onNext = onNext && onNext(node);
         context.push(node);
+        onNext = onNext && onNext(node);
       },
 
       onCDATA({ value, pos, endPos }) {
         const node = hub.createNode("htmlCDATA", pos, endPos, value);
-        onNext = onNext && onNext(node);
         context.push(node);
+        onNext = onNext && onNext(node);
       },
 
       onText({ value }, { pos }) {
         const shouldTrim = !preservingWhitespaceUntil;
 
         if (shouldTrim) {
-          value = value.replace(/\s+/g, " ");
-
-          if (value.trim() === "") {
+          if (htmlTrim(value) === "") {
             return;
           }
 
-          const prev = context[context.length - 1];
-          if (!prev || !t.isHTMLPlaceholder(prev)) {
-            value = value.trimStart();
+          // Find previous non-scriptlet.
+          let prev;
+          let prevIndex = context.length;
+          while (prevIndex > 0) {
+            prev = context[--prevIndex];
+
+            if (t.isHTMLScriptlet(prev)) {
+              prev = undefined;
+            } else {
+              break;
+            }
           }
 
-          pos = value.indexOf(value);
+          if (!prev) {
+            const originalValue = value;
+            value = htmlTrimStart(value);
+            pos += originalValue.indexOf(value);
+          }
         }
 
         const endPos = pos + value.length;
         const node = hub.createNode("htmlText", pos, endPos, value);
-        onNext && onNext(node);
-        onNext = next => {
-          if (!next || !t.isHTMLPlaceholder(next)) {
-            node.value = node.value.trimEnd();
-          }
-        };
+        const prevContext = context;
         context.push(node);
+        onNext && onNext(node);
+        onNext =
+          shouldTrim &&
+          (next => {
+            if (!next || prevContext.indexOf(next) === -1) {
+              node.value = htmlTrimEnd(node.value);
+            }
+
+            node.value = node.value.replace(/\s+/g, " ");
+          });
       },
 
       onPlaceholder({ escape, value, withinBody, pos, endPos }) {
@@ -81,8 +99,8 @@ export function parse(hub) {
             escape
           );
 
-          onNext = onNext && onNext(node);
           context.push(node);
+          onNext = onNext && onNext(node);
         }
       },
 
@@ -94,14 +112,15 @@ export function parse(hub) {
           );
         }
 
-        const node = hub.createNode(
-          "HTMLScriptlet",
-          pos,
-          endPos,
-          hub.parse(value, pos).body
+        // Scriptlets are ignored as content and don't call `onNext`.
+        context.push(
+          hub.createNode(
+            "HTMLScriptlet",
+            pos,
+            endPos,
+            hub.parse(value, pos).body
+          )
         );
-        onNext = onNext && onNext(node);
-        context.push(node);
       },
 
       onOpenTagName(event) {
@@ -122,7 +141,11 @@ export function parse(hub) {
           }
         }
 
-        stack.push({ tagDef });
+        const node = { tagName, tagDef, context: [] };
+        stack.push(node);
+        context.push(node);
+        onNext = onNext && onNext(node);
+        context = node.context;
       },
 
       onOpenTag(event, parser) {
@@ -283,8 +306,6 @@ export function parse(hub) {
           attributes,
           rawValue
         );
-        curElement.context = context = [];
-        onNext = onNext && onNext(curElement);
 
         if (!preservingWhitespaceUntil && parseOptions.preserveWhitespace) {
           preservingWhitespaceUntil = curElement.startTag;
@@ -295,6 +316,7 @@ export function parse(hub) {
         let { tagName, pos, endPos } = event;
         const { tagDef, startTag, context: children } = stack.pop();
         context = stack[stack.length - 1].context;
+        context.pop();
 
         if (preservingWhitespaceUntil === startTag) {
           preservingWhitespaceUntil = preserveWhitespace;

--- a/packages/babel-plugin-marko/src/taglib/html/marko.json
+++ b/packages/babel-plugin-marko/src/taglib/html/marko.json
@@ -657,9 +657,11 @@
     "attribute-groups": ["html-attributes"]
   },
   "<pre>": {
-    "preserve-whitespace": true,
     "html": true,
-    "attribute-groups": ["html-attributes"]
+    "attribute-groups": ["html-attributes"],
+    "parse-options": {
+      "preserveWhitespace": true
+    }
   },
   "<progress>": {
     "@form": "#html-form",
@@ -703,7 +705,6 @@
     "attribute-groups": ["html-attributes"]
   },
   "<script>": {
-    "preserve-whitespace": true,
     "@marko-init": "boolean",
     "@template-helpers": "boolean",
     "@*": {
@@ -721,7 +722,10 @@
     "@src": "#html-src",
     "@type": "#html-type",
     "html": true,
-    "attribute-groups": ["html-attributes"]
+    "attribute-groups": ["html-attributes"],
+    "parse-options": {
+      "preserveWhitespace": true
+    }
   },
   "<section>": {
     "html": true,
@@ -768,7 +772,6 @@
     "attribute-groups": ["html-attributes"]
   },
   "<style>": {
-    "preserve-whitespace": true,
     "@disabled": "#html-disabled",
     "@media": "#html-media",
     "@scoped": "#html-scoped",
@@ -779,7 +782,10 @@
         "snippet": "style media=\"screen\""
       }
     ],
-    "attribute-groups": ["html-attributes"]
+    "attribute-groups": ["html-attributes"],
+    "parse-options": {
+      "preserveWhitespace": true
+    }
   },
   "<sub>": {
     "html": true,
@@ -810,7 +816,6 @@
     "attribute-groups": ["html-attributes"]
   },
   "<textarea>": {
-    "preserve-whitespace": true,
     "@autofocus": "#html-autofocus",
     "@cols": "#html-cols",
     "@dirname": "#html-dirname",
@@ -830,7 +835,10 @@
         "snippet": "textarea name=\"${1:name}\" rows=\"${2:8}\" cols=\"${3:40}\""
       }
     ],
-    "attribute-groups": ["html-attributes"]
+    "attribute-groups": ["html-attributes"],
+    "parse-options": {
+      "preserveWhitespace": true
+    }
   },
   "<tfoot>": {
     "html": true,

--- a/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/generated.expected.marko
@@ -1,5 +1,5 @@
 <div>
-  Here is a CDATA section:
+  Here is a CDATA section: 
   <![CDATA[ < > & ]]>
-  with all kinds of unescaped text.
+   with all kinds of unescaped text.
 </div>

--- a/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ const _marko_template = _t(__filename),
       _marko_componentType = "49meNcug";
 
 _marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
-  out.w("<div>Here is a CDATA section:<![CDATA[ < > & ]]>with all kinds of unescaped text.</div>")
+  out.w("<div>Here is a CDATA section: <![CDATA[ < > & ]]> with all kinds of unescaped text.</div>")
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/translated-vdom.expected.js
@@ -6,9 +6,9 @@ const _marko_template = _t(__filename),
 
 _marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
   out.be("div", {}, "0", component, 0, 0)
-  out.t("Here is a CDATA section:")
+  out.t("Here is a CDATA section: ")
   out.t(" < > & ")
-  out.t("with all kinds of unescaped text.")
+  out.t(" with all kinds of unescaped text.")
   out.ee()
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/generated.expected.marko
@@ -2,6 +2,6 @@
   c
 }|>
   <div>
-    ${a}${b}${c}
+    ${a} ${b} ${c}
   </div>
 </custom-tag>

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-html.expected.js
@@ -14,7 +14,7 @@ _marko_template._ = _marko_renderer(function (input, out, __component, component
     "renderBody": (out, a, b, {
       c
     }) => {
-      out.w(`<div>${_marko_escapeXml(a)}${_marko_escapeXml(b)}${_marko_escapeXml(c)}</div>`);
+      out.w(`<div>${_marko_escapeXml(a)} ${_marko_escapeXml(b)} ${_marko_escapeXml(c)}</div>`);
     }
   }, out, "0")
 }, {

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-vdom.expected.js
@@ -16,7 +16,9 @@ _marko_template._ = _marko_renderer(function (input, out, __component, component
     }) => {
       out.be("div", {}, "1", component, 0, 0);
       out.t(a);
+      out.t(" ");
       out.t(b);
+      out.t(" ");
       out.t(c);
       out.ee();
     }

--- a/packages/babel-plugin-marko/test/fixtures/error-at-tags-missing-parent/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/error-at-tags-missing-parent/snapshots/generated.expected.marko
@@ -2,7 +2,7 @@
   <@header class="my-header">
     Header content
   </@header>
-   Body content 
+  Body content
   <@footer class="my-footer">
     Footer content
   </@footer>

--- a/packages/babel-plugin-marko/test/fixtures/error-at-tags-missing-parent/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/error-at-tags-missing-parent/snapshots/generated.expected.marko
@@ -2,7 +2,7 @@
   <@header class="my-header">
     Header content
   </@header>
-  Body content
+   Body content 
   <@footer class="my-footer">
     Footer content
   </@footer>

--- a/packages/babel-plugin-marko/test/fixtures/macros/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/macros/snapshots/generated.expected.marko
@@ -1,5 +1,5 @@
 <macro|node| name="renderTree">
-  Name: ${node.name} Children:
+  Name: ${node.name} Children: 
   <if(node.children)>
     <ul>
       <for|child| of=node.children>

--- a/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-html.expected.js
@@ -1,5 +1,5 @@
 function _renderTree(node, out) {
-  out.w(`Name: ${_marko_escapeXml(node.name)} Children:`);
+  out.w(`Name: ${_marko_escapeXml(node.name)} Children: `);
 
   if (node.children) {
     out.w("<ul>");

--- a/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-vdom.expected.js
@@ -1,7 +1,7 @@
 function _renderTree(node, out) {
   out.t("Name: ");
   out.t(node.name);
-  out.t(" Children:");
+  out.t(" Children: ");
 
   if (node.children) {
     out.be("ul", {}, "2", component, 0, 0);

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/generated.expected.marko
@@ -2,10 +2,16 @@ import a from "b";
 export { a };
 <style/>
 <style>
-  div { color: ${x}; }
+
+  div {
+    color: ${x};
+  }
+
 </style>
 <script>
+
   var y = ${x};
+
 </script>
 static {
   doThings();

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
@@ -24,7 +24,13 @@ const _marko_template = _t2(__filename),
       _marko_componentType = "8f1lFGb_";
 
 _marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
-  out.w(`<style>div { color: ${_marko_escapeStyle(x)}; }</style><script>var y = ${_marko_escapeScript(x)};</script>`)
+  out.w(`<style>
+  div {
+    color: ${_marko_escapeStyle(x)};
+  }
+</style><script>
+  var y = ${_marko_escapeScript(x)};
+</script>`)
   var b = thing;
   let c = thing;
   out.w(`<div${_marko_attr("b", b)}${_marko_attr("c", c)}>`)

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
@@ -33,14 +33,14 @@ const _marko_template = _t2(__filename),
 
 _marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
   out.be("style", {}, "0", component, 0, 0)
-  out.t("div { color: ")
+  out.t("\n  div {\n    color: ")
   out.t(x)
-  out.t("; }")
+  out.t(";\n  }\n")
   out.ee()
   out.be("script", {}, "1", component, 0, 0)
-  out.t("var y = ")
+  out.t("\n  var y = ")
   out.t(x)
-  out.t(";")
+  out.t(";\n")
   out.ee()
   var b = thing;
   let c = thing;

--- a/packages/babel-plugin-marko/test/fixtures/simple/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/simple/snapshots/generated.expected.marko
@@ -1,4 +1,4 @@
--- Hello ${input.name}!
+-- Hello ${input.name}! 
 <if(input.colors.length)>
   <ul>
     <for|color| of=input.colors>

--- a/packages/babel-plugin-marko/test/fixtures/simple/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/simple/snapshots/translated-vdom.expected.js
@@ -7,7 +7,7 @@ const _marko_template = _t(__filename),
 _marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
   out.t("Hello ")
   out.t(input.name)
-  out.t("!")
+  out.t("! ")
 
   if (input.colors.length) {
     out.be("ul", {}, "1", component, 0, 0);

--- a/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/generated.expected.marko
@@ -1,0 +1,31 @@
+<div>
+  <div>
+    Hello 
+    <div>
+       
+    </div>
+     World
+  </div>
+  <div>
+     Hello
+  </div>
+  <pre>
+
+    This should  
+      be preserved
+  
+  </pre>
+  <div>
+    <div>
+      Hello 
+    </div>
+  </div>
+</div>
+<div>
+  $ scriptletA();
+  $ scriptletB();
+  Hello 
+  $ scriptletC();
+   World
+  $ scriptletD();
+</div>

--- a/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-html.expected.js
@@ -1,24 +1,18 @@
-import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers";
 import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
 const _marko_template = _t(__filename),
-      _marko_componentType = "hXm4QTQF";
+      _marko_componentType = "f5PlznI-";
 
 _marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
-  out.w(`Hello ${_marko_escapeXml(input.name)}! `)
-
-  if (input.colors.length) {
-    out.w("<ul>");
-
-    for (const color of input.colors) {
-      out.w(`<li>${_marko_escapeXml(color)}</li>`);
-    }
-
-    out.w("</ul>");
-  } else {
-    out.w("<div>No colors!</div>");
-  }
+  out.w("<div><div>Hello <div> </div> World</div><div> Hello</div><pre>\n    This should  \n      be preserved\n  </pre><div><div>Hello </div></div></div><div>")
+  scriptletA();
+  scriptletB();
+  out.w("Hello ")
+  scriptletC();
+  out.w(" World")
+  scriptletD();
+  out.w("</div>")
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-vdom.expected.js
@@ -1,0 +1,44 @@
+import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/components/helpers";
+import { t as _t } from "marko/src/runtime/vdom";
+
+const _marko_template = _t(__filename),
+      _marko_componentType = "f5PlznI-";
+
+_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+  out.be("div", {}, "0", component, 0, 0)
+  out.be("div", {}, "1", component, 0, 0)
+  out.t("Hello ")
+  out.be("div", {}, "2", component, 0, 0)
+  out.t(" ")
+  out.ee()
+  out.t(" World")
+  out.ee()
+  out.be("div", {}, "3", component, 0, 0)
+  out.t(" Hello")
+  out.ee()
+  out.be("pre", {}, "4", component, 0, 0)
+  out.t("\n    This should  \n      be preserved\n  ")
+  out.ee()
+  out.be("div", {}, "5", component, 0, 0)
+  out.be("div", {}, "6", component, 0, 0)
+  out.t("Hello ")
+  out.ee()
+  out.ee()
+  out.ee()
+  out.be("div", {}, "7", component, 0, 0)
+  scriptletA();
+  scriptletB();
+  out.t("Hello ")
+  scriptletC();
+  out.t(" World")
+  scriptletD();
+  out.ee()
+}, {
+  ___type: _marko_componentType,
+  ___implicit: true
+})
+_marko_template.Component = _marko_defineComponent(null, _marko_template._)
+_marko_template.meta = {
+  id: _marko_componentType
+}
+export default _marko_template;

--- a/packages/babel-plugin-marko/test/fixtures/white-space-test/template.marko
+++ b/packages/babel-plugin-marko/test/fixtures/white-space-test/template.marko
@@ -1,0 +1,31 @@
+<div>
+  <div>
+    Hello
+    <div> </div>
+    World
+  </div>
+
+  <div> 
+    Hello
+  </div>
+
+  <pre>
+    This should  
+      be preserved
+  </pre>
+
+  <div>
+    <div>
+      Hello 
+    </div>
+  </div>
+</div>
+
+<div>
+  $ scriptletA();
+  $ scriptletB();
+  Hello
+  $ scriptletC();
+  World
+  $ scriptletD();
+</div>


### PR DESCRIPTION
## Description
Normalizes whitespace the same as Marko 4.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
