### PR TITLE
refactor(babel-plugin-marko): rename ast nodes to be prefixed with Marko

### DIFF
--- a/packages/babel-plugin-marko/src/definitions/types.js
+++ b/packages/babel-plugin-marko/src/definitions/types.js
@@ -14,38 +14,38 @@ const valueFieldCommon = {
 };
 
 export default {
-  HTMLDocumentType: {
+  MarkoDocumentType: {
     builder: ["value"],
     aliases: ["Marko", "Statement"],
     fields: { ...valueFieldCommon }
   },
 
-  HTMLDeclaration: {
+  MarkoDeclaration: {
     builder: ["value"],
     aliases: ["Marko", "Statement"],
     fields: { ...valueFieldCommon }
   },
 
-  HTMLCDATA: {
+  MarkoCDATA: {
     builder: ["value"],
     aliases: ["Marko", "Statement"],
     fields: { ...valueFieldCommon }
   },
 
-  HTMLComment: {
+  MarkoComment: {
     builder: ["value"],
     aliases: ["Marko", "Statement"],
     fields: { ...valueFieldCommon }
   },
 
-  HTMLText: {
+  MarkoText: {
     visitor: ["value"],
     builder: ["value"],
     aliases: ["Marko", "Statement"],
     fields: { ...valueFieldCommon }
   },
 
-  HTMLPlaceholder: {
+  MarkoPlaceholder: {
     visitor: ["value"],
     builder: ["value", "escape"],
     aliases: ["Marko", "Statement"],
@@ -60,7 +60,7 @@ export default {
     }
   },
 
-  HTMLScriptlet: {
+  MarkoScriptlet: {
     visitor: ["body"],
     builder: ["body", "static"],
     aliases: ["Marko", "Statement"],
@@ -75,7 +75,7 @@ export default {
     }
   },
 
-  HTMLClass: {
+  MarkoClass: {
     builder: ["body"],
     visitor: ["body"],
     aliases: ["Marko", "Statement"],
@@ -86,7 +86,7 @@ export default {
     }
   },
 
-  HTMLAttribute: {
+  MarkoAttribute: {
     builder: ["name", "value", "modifier", "arguments"],
     visitor: ["value"],
     aliases: ["Marko", "Expression"],
@@ -112,10 +112,10 @@ export default {
     }
   },
 
-  HTMLSpreadAttribute: {
+  MarkoSpreadAttribute: {
     builder: ["value"],
     visitor: ["value"],
-    aliases: ["Marko", "HTMLAttribute"],
+    aliases: ["Marko", "MarkoAttribute"],
     fields: {
       value: {
         validate: assertNodeType("Expression"),
@@ -124,7 +124,7 @@ export default {
     }
   },
 
-  HTMLTag: {
+  MarkoTag: {
     builder: [
       "name",
       "arguments",
@@ -151,17 +151,17 @@ export default {
         default: []
       },
       attributes: {
-        validate: arrayOfType(["HTMLAttribute", "HTMLSpreadAttribute"]),
+        validate: arrayOfType(["MarkoAttribute", "MarkoSpreadAttribute"]),
         default: []
       },
       body: {
         validate: arrayOfType([
-          "HTMLTag",
-          "HTMLCDATA",
-          "HTMLText",
-          "HTMLPlaceholder",
-          "HTMLScriptlet",
-          "HTMLComment"
+          "MarkoTag",
+          "MarkoCDATA",
+          "MarkoText",
+          "MarkoPlaceholder",
+          "MarkoScriptlet",
+          "MarkoComment"
         ]),
         default: []
       },

--- a/packages/babel-plugin-marko/src/generators/index.js
+++ b/packages/babel-plugin-marko/src/generators/index.js
@@ -13,31 +13,31 @@ const UNENCLOSED_WHITESPACE_TYPES = [
 ];
 
 Object.assign(Printer.prototype, {
-  HTMLDocumentType(node) {
+  MarkoDocumentType(node) {
     this.token("<!");
     this.token(node.value);
     this.token(">");
   },
-  HTMLDeclaration(node) {
+  MarkoDeclaration(node) {
     this.token("<?");
     this.token(node.value);
     this.token("?>");
   },
-  HTMLCDATA(node) {
+  MarkoCDATA(node) {
     this.token("<![CDATA[");
     this.token(node.value);
     this.token("]]>");
   },
-  HTMLComment(node) {
+  MarkoComment(node) {
     this.token("<!--");
     this.token(node.value);
     this.token("-->");
   },
-  HTMLPlaceholder(node, parent) {
+  MarkoPlaceholder(node, parent) {
     const parentBody = parent.body;
     const prev = parentBody[parentBody.indexOf(node) - 1];
 
-    if (prev && (t.isHTMLText(prev) || t.isHTMLPlaceholder(prev))) {
+    if (prev && (t.isMarkoText(prev) || t.isMarkoPlaceholder(prev))) {
       this.removeTrailingNewline();
     }
 
@@ -45,7 +45,7 @@ Object.assign(Printer.prototype, {
     this.print(node.value, node);
     this.token("}");
   },
-  HTMLScriptlet(node, parent) {
+  MarkoScriptlet(node, parent) {
     this.removeTrailingNewline();
 
     if (!(t.isProgram(parent) && parent.body.indexOf(node) === 0)) {
@@ -66,12 +66,12 @@ Object.assign(Printer.prototype, {
       this.token("}");
     }
   },
-  HTMLClass(node) {
+  MarkoClass(node) {
     this.token("class");
     this.token(" ");
     this.print(node.body, node);
   },
-  HTMLAttribute(node) {
+  MarkoAttribute(node) {
     this.token(node.name);
 
     if (node.modifier) {
@@ -93,14 +93,14 @@ Object.assign(Printer.prototype, {
       }
     }
   },
-  HTMLSpreadAttribute(node) {
+  MarkoSpreadAttribute(node) {
     this.token("...");
     printWithParansIfNeeded.call(this, node.value, node);
   },
-  HTMLText(node, parent) {
+  MarkoText(node, parent) {
     const parentBody = parent.body;
     const prev = parentBody[parentBody.indexOf(node) - 1];
-    const concatToPrev = prev && t.isHTMLPlaceholder(prev);
+    const concatToPrev = prev && t.isMarkoPlaceholder(prev);
     let { value } = node;
 
     if (concatToPrev) {
@@ -124,7 +124,7 @@ Object.assign(Printer.prototype, {
       this.token("\n---");
     }
   },
-  HTMLTag(node) {
+  MarkoTag(node) {
     const isDynamicTag = !t.isStringLiteral(node.name);
     const tagName = !isDynamicTag && node.name.value;
     const selfClosing = !node.body.length || SELF_CLOSING.includes(tagName);

--- a/packages/babel-plugin-marko/src/parser.js
+++ b/packages/babel-plugin-marko/src/parser.js
@@ -21,25 +21,25 @@ export function parse(hub) {
   createParser(
     {
       onDocumentType({ value, pos, endPos }) {
-        const node = hub.createNode("htmlDocumentType", pos, endPos, value);
+        const node = hub.createNode("markoDocumentType", pos, endPos, value);
         body.push(node);
         onNext = onNext && onNext(node);
       },
 
       onDeclaration({ value, pos, endPos }) {
-        const node = hub.createNode("htmlDeclaration", pos, endPos, value);
+        const node = hub.createNode("markoDeclaration", pos, endPos, value);
         body.push(node);
         onNext = onNext && onNext(node);
       },
 
       onComment({ value, pos, endPos }) {
-        const node = hub.createNode("htmlComment", pos, endPos, value);
+        const node = hub.createNode("markoComment", pos, endPos, value);
         body.push(node);
         onNext = onNext && onNext(node);
       },
 
       onCDATA({ value, pos, endPos }) {
-        const node = hub.createNode("htmlCDATA", pos, endPos, value);
+        const node = hub.createNode("markoCDATA", pos, endPos, value);
         body.push(node);
         onNext = onNext && onNext(node);
       },
@@ -58,7 +58,7 @@ export function parse(hub) {
           while (prevIndex > 0) {
             prev = body[--prevIndex];
 
-            if (t.isHTMLScriptlet(prev) || isNestedTag(prev)) {
+            if (t.isMarkoScriptlet(prev) || isNestedTag(prev)) {
               prev = undefined;
             } else {
               break;
@@ -73,7 +73,7 @@ export function parse(hub) {
         }
 
         const endPos = pos + value.length;
-        const node = hub.createNode("htmlText", pos, endPos, value);
+        const node = hub.createNode("markoText", pos, endPos, value);
         const prevBody = body;
         body.push(node);
         onNext && onNext(node);
@@ -91,7 +91,7 @@ export function parse(hub) {
       onPlaceholder({ escape, value, withinBody, pos, endPos }) {
         if (withinBody) {
           const node = hub.createNode(
-            "htmlPlaceholder",
+            "markoPlaceholder",
             pos,
             endPos,
             hub.parseExpression(
@@ -117,7 +117,7 @@ export function parse(hub) {
         // Scriptlets are ignored as content and don't call `onNext`.
         body.push(
           hub.createNode(
-            "htmlScriptlet",
+            "markoScriptlet",
             pos,
             endPos,
             hub.parse(value, pos).body
@@ -132,7 +132,7 @@ export function parse(hub) {
         const tagDef = !tagNameExpression && hub.lookup.getTag(tagName);
         const tagNameStartPos = pos + (event.concise ? 0 : 1); // Account for leading `<`.
         const node = hub.createNode(
-          "HTMLTag",
+          "markoTag",
           pos,
           endPos,
           tagNameExpression
@@ -210,7 +210,7 @@ export function parse(hub) {
               // TODO: Inline merge object literals.
               node.attributes.push(
                 hub.createNode(
-                  "htmlSpreadAttribute",
+                  "markoSpreadAttribute",
                   attrStartPos,
                   attrEndPos,
                   value
@@ -244,7 +244,7 @@ export function parse(hub) {
 
             node.attributes.push(
               hub.createNode(
-                "htmlAttribute",
+                "markoAttribute",
                 attrStartPos,
                 attrEndPos,
                 attr.name,
@@ -265,7 +265,7 @@ export function parse(hub) {
           if (!classAttr) {
             node.attributes.unshift(
               hub.createNode(
-                "htmlAttribute",
+                "markoAttribute",
                 pos,
                 tagNameEndPos,
                 "class",
@@ -298,7 +298,7 @@ export function parse(hub) {
 
           node.attributes.unshift(
             hub.createNode(
-              "htmlAttribute",
+              "markoAttribute",
               pos,
               tagNameEndPos,
               "id",

--- a/packages/babel-plugin-marko/src/plugins/transform.js
+++ b/packages/babel-plugin-marko/src/plugins/transform.js
@@ -4,7 +4,7 @@ import * as t from "../definitions";
  * Applies custom transformers on tags.
  */
 export const visitor = {
-  HTMLTag(path) {
+  MarkoTag(path) {
     const { hub, node } = path;
     const { lookup, macros } = hub;
     const { name } = node;

--- a/packages/babel-plugin-marko/src/plugins/translate/index.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/index.js
@@ -1,24 +1,24 @@
 import * as t from "../../definitions";
 import normalizeTemplateLiteral from "../../util/normalize-template-string";
-import HTMLDocumentType from "./document-type";
-import HTMLDeclaration from "./declaration";
-import HTMLCDATA from "./cdata";
-import HTMLTag from "./tag";
-import HTMLText from "./text";
-import HTMLPlaceholder from "./placeholder";
-import HTMLScriptlet from "./scriptlet";
-import HTMLClass from "./html-class";
+import MarkoDocumentType from "./document-type";
+import MarkoDeclaration from "./declaration";
+import MarkoCDATA from "./cdata";
+import MarkoTag from "./tag";
+import MarkoText from "./text";
+import MarkoPlaceholder from "./placeholder";
+import MarkoScriptlet from "./scriptlet";
+import MarkoClass from "./html-class";
 
 export const visitor = {
-  HTMLDocumentType,
-  HTMLDeclaration,
-  HTMLCDATA,
-  HTMLTag,
-  HTMLText,
-  HTMLPlaceholder,
-  HTMLScriptlet,
-  HTMLClass,
-  HTMLComment(path) {
+  MarkoDocumentType,
+  MarkoDeclaration,
+  MarkoCDATA,
+  MarkoTag,
+  MarkoText,
+  MarkoPlaceholder,
+  MarkoScriptlet,
+  MarkoClass,
+  MarkoComment(path) {
     path.remove();
   },
   Program: {

--- a/packages/babel-plugin-marko/src/plugins/translate/placeholder/index[html].js
+++ b/packages/babel-plugin-marko/src/plugins/translate/placeholder/index[html].js
@@ -46,7 +46,7 @@ function findParentTagName(path) {
       return;
     }
 
-    if (t.isHTMLTag(path.node)) {
+    if (t.isMarkoTag(path.node)) {
       const { tagDef = EMPTY_OBJECT } = path.node;
       return (
         tagDef.html &&

--- a/packages/babel-plugin-marko/src/plugins/translate/tag/attribute-tag.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/tag/attribute-tag.js
@@ -19,7 +19,7 @@ export default function(path) {
 
   assertNoArgs(path);
 
-  if (!parent || !t.isHTMLTag(parent)) {
+  if (!parent || !t.isMarkoTag(parent)) {
     throw namePath.buildCodeFrameError(
       "@tags must be nested within another element."
     );
@@ -45,7 +45,7 @@ export default function(path) {
       );
     }
 
-    parentAttributes.push(t.htmlAttribute(targetProperty, getAttrs(path)));
+    parentAttributes.push(t.markoAttribute(targetProperty, getAttrs(path)));
 
     path.remove();
     return;
@@ -67,7 +67,7 @@ export default function(path) {
       ])
     );
 
-    parentAttributes.push(t.htmlAttribute(targetProperty, identifier));
+    parentAttributes.push(t.markoAttribute(targetProperty, identifier));
   }
 
   if (isRepeated) {
@@ -104,7 +104,7 @@ function findParentTag(path) {
   while (cur.node) {
     const { node } = cur;
 
-    if (!t.isHTMLTag(node)) {
+    if (!t.isMarkoTag(node)) {
       cur = undefined;
       break;
     }

--- a/packages/babel-plugin-marko/src/plugins/translate/tag/native-tag[html]/index.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/tag/native-tag[html]/index.js
@@ -59,7 +59,7 @@ export default function(path) {
   if (tagProperties.length) {
     // TODO: prevent escaping this with the attr helper.
     node.attributes.push(
-      t.htmlAttribute("data-marko", t.objectExpression(tagProperties))
+      t.markoAttribute("data-marko", t.objectExpression(tagProperties))
     );
 
     // TODO: Hack to push to existing attributes path, should revisit,

--- a/packages/babel-plugin-marko/src/taglib/core/attributes/directives/no-update.js
+++ b/packages/babel-plugin-marko/src/taglib/core/attributes/directives/no-update.js
@@ -15,17 +15,17 @@ export default function(path, attr, opts = EMPTY_OBJECT) {
   ]);
   const keyIdentifier = path.scope.generateUidIdentifier("noUpdateKey");
   const name = t.stringLiteral("no-update");
-  const replacementAttrs = [t.htmlAttribute("cid", keyIdentifier)];
+  const replacementAttrs = [t.markoAttribute("cid", keyIdentifier)];
 
   if (opts.if) {
-    replacementAttrs.push(t.htmlAttribute("if", opts.if));
+    replacementAttrs.push(t.markoAttribute("if", opts.if));
   }
 
   if (opts.bodyOnly) {
-    replacementAttrs.push(t.htmlAttribute("bodyOnly", t.booleanLiteral(true)));
+    replacementAttrs.push(t.markoAttribute("bodyOnly", t.booleanLiteral(true)));
   }
 
-  const replacement = t.htmlTag(name, undefined, undefined, replacementAttrs, [
+  const replacement = t.markoTag(name, undefined, undefined, replacementAttrs, [
     node
   ]);
   replacement.key = normalizeTemplateLiteral(["#", ""], [keyIdentifier]);

--- a/packages/babel-plugin-marko/src/taglib/core/conditional/util.js
+++ b/packages/babel-plugin-marko/src/taglib/core/conditional/util.js
@@ -25,12 +25,12 @@ export function buildIfStatement(path, args) {
     let removePath;
 
     // Remove empty whitespace between blocks.
-    if (t.isHTMLText(nextPath.node) && /^\s*$/.test(nextPath.node.value)) {
+    if (t.isMarkoText(nextPath.node) && /^\s*$/.test(nextPath.node.value)) {
       removePath = nextPath;
       nextPath = nextPath.getNextSibling();
     }
 
-    if (t.isHTMLTag(nextPath.node)) {
+    if (t.isMarkoTag(nextPath.node)) {
       const { node } = nextPath;
       const { name } = node;
 

--- a/packages/babel-plugin-marko/src/taglib/core/parse-class.js
+++ b/packages/babel-plugin-marko/src/taglib/core/parse-class.js
@@ -34,5 +34,5 @@ export default function(path) {
     );
   }
 
-  return withPreviousLocation(t.htmlClass(parsed.body), node);
+  return withPreviousLocation(t.markoClass(parsed.body), node);
 }

--- a/packages/babel-plugin-marko/src/taglib/core/parse-static.js
+++ b/packages/babel-plugin-marko/src/taglib/core/parse-static.js
@@ -10,5 +10,5 @@ export default function(path) {
     body = body[0].body;
   }
 
-  return t.HTMLScriptlet(body, true);
+  return t.MarkoScriptlet(body, true);
 }

--- a/packages/babel-plugin-marko/src/taglib/core/transform-body.js
+++ b/packages/babel-plugin-marko/src/taglib/core/transform-body.js
@@ -2,8 +2,8 @@ import * as t from "../../definitions";
 
 export default function(path) {
   const body = path.get("body");
-  body[0].insertBefore(t.htmlTag(t.stringLiteral("component-globals")));
+  body[0].insertBefore(t.markoTag(t.stringLiteral("component-globals")));
   body[body.length - 1].insertAfter(
-    t.htmlTag(t.stringLiteral("init-components"))
+    t.markoTag(t.stringLiteral("init-components"))
   );
 }

--- a/packages/babel-plugin-marko/src/taglib/core/transform-fragment.js
+++ b/packages/babel-plugin-marko/src/taglib/core/transform-fragment.js
@@ -30,7 +30,7 @@ export default function(path) {
   );
 
   body
-    .filter(child => t.isHTMLTag(child))
+    .filter(child => t.isMarkoTag(child))
     .forEach(child => (child.key = keyValue));
 
   replaceInRenderBody(path, body);


### PR DESCRIPTION
## Description

Renames all custom AST nodes and helpers to be prefixed with `Marko` instead of `HTML`.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
