### PR TITLE
refactor(babel-plugin-marko): tag ast put more common nodes first

### DIFF
--- a/packages/babel-plugin-marko/src/definitions/types.js
+++ b/packages/babel-plugin-marko/src/definitions/types.js
@@ -127,10 +127,10 @@ export default {
   MarkoTag: {
     builder: [
       "name",
-      "arguments",
-      "params",
       "attributes",
       "body",
+      "params",
+      "arguments",
       "properties"
     ],
     aliases: ["Marko", "Statement"],
@@ -138,17 +138,6 @@ export default {
     fields: {
       name: {
         validate: assertNodeType("Expression")
-      },
-      arguments: {
-        validate: chain(
-          assertValueType("array"),
-          assertEach(assertNodeType("Expression", "SpreadElement"))
-        ),
-        default: []
-      },
-      params: {
-        ...functionCommon.params,
-        default: []
       },
       attributes: {
         validate: arrayOfType(["MarkoAttribute", "MarkoSpreadAttribute"]),
@@ -163,6 +152,17 @@ export default {
           "MarkoScriptlet",
           "MarkoComment"
         ]),
+        default: []
+      },
+      params: {
+        ...functionCommon.params,
+        default: []
+      },
+      arguments: {
+        validate: chain(
+          assertValueType("array"),
+          assertEach(assertNodeType("Expression", "SpreadElement"))
+        ),
         default: []
       },
       properties: {

--- a/packages/babel-plugin-marko/src/taglib/core/attributes/directives/no-update.js
+++ b/packages/babel-plugin-marko/src/taglib/core/attributes/directives/no-update.js
@@ -25,9 +25,7 @@ export default function(path, attr, opts = EMPTY_OBJECT) {
     replacementAttrs.push(t.markoAttribute("bodyOnly", t.booleanLiteral(true)));
   }
 
-  const replacement = t.markoTag(name, undefined, undefined, replacementAttrs, [
-    node
-  ]);
+  const replacement = t.markoTag(name, replacementAttrs, [node]);
   replacement.key = normalizeTemplateLiteral(["#", ""], [keyIdentifier]);
 
   insertBeforeInRenderBody(


### PR DESCRIPTION
## Description

Reorganizes the MarkoTag AST node's builder to have the more common options first.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
