### PR TITLE
feat(babel-plugin-marko): dynamic shorthand parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,12 +69,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.0.tgz",
-			"integrity": "sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.2.tgz",
+			"integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.3.0",
+				"@babel/types": "^7.3.2",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.10",
 				"source-map": "^0.5.0",
@@ -112,9 +112,9 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.0.tgz",
-			"integrity": "sha512-DUsQNS2CGLZZ7I3W3fvh0YpPDd6BuWJlDl+qmZZpABZHza2ErE3LxtEzLJFHFC1ZwtlAXvHhbFYbtM5o5B0WBw==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.2.tgz",
+			"integrity": "sha512-tdW8+V8ceh2US4GsYdNVNoohq5uVwOf9k6krjwW4E1lINcHgttnWcNqgdoessn12dAy8QkbezlbQh2nXISNY+A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
@@ -322,9 +322,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.1.tgz",
-			"integrity": "sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.2.tgz",
+			"integrity": "sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -379,9 +379,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.1.tgz",
-			"integrity": "sha512-Nmmv1+3LqxJu/V5jU9vJmxR/KIRWFk2qLHmbB56yRRRFhlaSuOVXscX3gUmhaKgUhzA3otOHVubbIEVYsZ0eZg==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz",
+			"integrity": "sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -528,9 +528,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.2.0.tgz",
-			"integrity": "sha512-coVO2Ayv7g0qdDbrNiadE4bU7lvCd9H539m2gMknyVjjMdwF/iCOM7R+E8PkntoqLkltO0rk+3axhpp/0v68VQ==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.3.2.tgz",
+			"integrity": "sha512-Lrj/u53Ufqxl/sGxyjsJ2XNtNuEjDyjpqdhMNh5aZ+XFOdThL46KBj27Uem4ggoezSYBxKWAil6Hu8HtwqesYw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -884,9 +884,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.0.tgz",
-			"integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.2.tgz",
+			"integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -2061,9 +2061,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.6.tgz",
-			"integrity": "sha512-5M3G/A4uBSMIlfJ+h9W125vJvPFH/zirISsW5qfxF5YzEvXJCtolLoQvM5yZft0DvMcUrPGKPOlgEu55I6iUtA==",
+			"version": "6.0.7",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.7.tgz",
+			"integrity": "sha512-HNJNgE60C9eOTgn974Tlp3dpLZdUr+SoxxDwPaY9J/kDNOLQTkaDgwBUXAF4SSsrAwD9RpdxuHK/EbuF+W9Ahw==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -3677,9 +3677,9 @@
 			"dev": true
 		},
 		"duplexify": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-			"integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
@@ -3699,9 +3699,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.112",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.112.tgz",
-			"integrity": "sha512-FyVLdiRZnLw2WE5ECtveN0JJ7klyiz/HMfKE1/Rjff3l7pe4vfkYtBlcCqTckvR8E7asjJGh0m9gRPR3Anp/UA==",
+			"version": "1.3.113",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz",
+			"integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -4210,13 +4210,26 @@
 			}
 		},
 		"flush-write-stream": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.0.tgz",
+			"integrity": "sha512-6MHED/cmsyux1G4/Cek2Z776y9t7WCNd3h2h/HW91vFeU7pzMhA8XvAlDhHcanG5IWuIh/xcC7JASY4WQpG6xg==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.4"
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+					"integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"fn-name": {
@@ -6196,15 +6209,15 @@
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-			"integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+			"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
 			"dev": true
 		},
 		"istanbul-lib-instrument": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
-			"integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+			"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
 			"dev": true,
 			"requires": {
 				"@babel/generator": "^7.0.0",
@@ -6212,7 +6225,7 @@
 				"@babel/template": "^7.0.0",
 				"@babel/traverse": "^7.0.0",
 				"@babel/types": "^7.0.0",
-				"istanbul-lib-coverage": "^2.0.1",
+				"istanbul-lib-coverage": "^2.0.3",
 				"semver": "^5.5.0"
 			}
 		},
@@ -7411,9 +7424,9 @@
 			}
 		},
 		"npm-bundled": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
-			"integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+			"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 			"dev": true
 		},
 		"npm-lifecycle": {
@@ -7544,54 +7557,37 @@
 			"dev": true
 		},
 		"nyc": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/nyc/-/nyc-13.1.0.tgz",
-			"integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-13.2.0.tgz",
+			"integrity": "sha512-gQBlOqvfpYt9b2PZ7qElrHWt8x4y8ApNfbMBoDPdl3sY4/4RJwCxDGTSqhA9RnaguZjS5nW7taW8oToe86JLgQ==",
 			"dev": true,
 			"requires": {
 				"archy": "^1.0.0",
 				"arrify": "^1.0.1",
-				"caching-transform": "^2.0.0",
+				"caching-transform": "^3.0.1",
 				"convert-source-map": "^1.6.0",
-				"debug-log": "^1.0.1",
 				"find-cache-dir": "^2.0.0",
 				"find-up": "^3.0.0",
 				"foreground-child": "^1.5.6",
 				"glob": "^7.1.3",
-				"istanbul-lib-coverage": "^2.0.1",
-				"istanbul-lib-hook": "^2.0.1",
-				"istanbul-lib-instrument": "^3.0.0",
-				"istanbul-lib-report": "^2.0.2",
-				"istanbul-lib-source-maps": "^2.0.1",
-				"istanbul-reports": "^2.0.1",
+				"istanbul-lib-coverage": "^2.0.3",
+				"istanbul-lib-hook": "^2.0.3",
+				"istanbul-lib-instrument": "^3.0.1",
+				"istanbul-lib-report": "^2.0.4",
+				"istanbul-lib-source-maps": "^3.0.2",
+				"istanbul-reports": "^2.1.0",
 				"make-dir": "^1.3.0",
 				"merge-source-map": "^1.1.0",
 				"resolve-from": "^4.0.0",
-				"rimraf": "^2.6.2",
+				"rimraf": "^2.6.3",
 				"signal-exit": "^3.0.2",
 				"spawn-wrap": "^1.4.2",
-				"test-exclude": "^5.0.0",
+				"test-exclude": "^5.1.0",
 				"uuid": "^3.3.2",
-				"yargs": "11.1.0",
-				"yargs-parser": "^9.0.2"
+				"yargs": "^12.0.5",
+				"yargs-parser": "^11.1.1"
 			},
 			"dependencies": {
-				"align-text": {
-					"version": "0.1.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"kind-of": "^3.0.2",
-						"longest": "^1.0.1",
-						"repeat-string": "^1.5.2"
-					}
-				},
-				"amdefine": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
 				"ansi-regex": {
 					"version": "3.0.0",
 					"bundled": true,
@@ -7616,9 +7612,12 @@
 					"dev": true
 				},
 				"async": {
-					"version": "1.5.2",
+					"version": "2.6.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.10"
+					}
 				},
 				"balanced-match": {
 					"version": "1.0.0",
@@ -7640,55 +7639,41 @@
 					"dev": true
 				},
 				"caching-transform": {
-					"version": "2.0.0",
+					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"make-dir": "^1.0.0",
-						"md5-hex": "^2.0.0",
-						"package-hash": "^2.0.0",
-						"write-file-atomic": "^2.0.0"
+						"hasha": "^3.0.0",
+						"make-dir": "^1.3.0",
+						"package-hash": "^3.0.0",
+						"write-file-atomic": "^2.3.0"
 					}
 				},
 				"camelcase": {
-					"version": "1.2.1",
+					"version": "5.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"center-align": {
-					"version": "0.1.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"align-text": "^0.1.3",
-						"lazy-cache": "^1.0.3"
-					}
+					"dev": true
 				},
 				"cliui": {
-					"version": "2.1.0",
+					"version": "4.1.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"center-align": "^0.1.1",
-						"right-align": "^0.1.1",
-						"wordwrap": "0.0.2"
-					},
-					"dependencies": {
-						"wordwrap": {
-							"version": "0.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
 					"dev": true
+				},
+				"commander": {
+					"version": "2.17.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
 				},
 				"commondir": {
 					"version": "1.0.1",
@@ -7718,17 +7703,12 @@
 					}
 				},
 				"debug": {
-					"version": "3.1.0",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
-				},
-				"debug-log": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
@@ -7741,6 +7721,14 @@
 					"dev": true,
 					"requires": {
 						"strip-bom": "^3.0.0"
+					}
+				},
+				"end-of-stream": {
+					"version": "1.4.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"once": "^1.4.0"
 					}
 				},
 				"error-ex": {
@@ -7757,12 +7745,12 @@
 					"dev": true
 				},
 				"execa": {
-					"version": "0.7.0",
+					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
 						"is-stream": "^1.1.0",
 						"npm-run-path": "^2.0.0",
 						"p-finally": "^1.0.0",
@@ -7771,11 +7759,13 @@
 					},
 					"dependencies": {
 						"cross-spawn": {
-							"version": "5.1.0",
+							"version": "6.0.5",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"lru-cache": "^4.0.1",
+								"nice-try": "^1.0.4",
+								"path-key": "^2.0.1",
+								"semver": "^5.5.0",
 								"shebang-command": "^1.2.0",
 								"which": "^1.2.9"
 							}
@@ -7820,9 +7810,12 @@
 					"dev": true
 				},
 				"get-stream": {
-					"version": "3.0.0",
+					"version": "4.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
 				},
 				"glob": {
 					"version": "7.1.3",
@@ -7838,28 +7831,25 @@
 					}
 				},
 				"graceful-fs": {
-					"version": "4.1.11",
+					"version": "4.1.15",
 					"bundled": true,
 					"dev": true
 				},
 				"handlebars": {
-					"version": "4.0.11",
+					"version": "4.0.12",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"async": "^1.4.0",
+						"async": "^2.5.0",
 						"optimist": "^0.6.1",
-						"source-map": "^0.4.4",
-						"uglify-js": "^2.6"
+						"source-map": "^0.6.1",
+						"uglify-js": "^3.1.4"
 					},
 					"dependencies": {
 						"source-map": {
-							"version": "0.4.4",
+							"version": "0.6.1",
 							"bundled": true,
-							"dev": true,
-							"requires": {
-								"amdefine": ">=0.0.4"
-							}
+							"dev": true
 						}
 					}
 				},
@@ -7867,6 +7857,14 @@
 					"version": "3.0.0",
 					"bundled": true,
 					"dev": true
+				},
+				"hasha": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-stream": "^1.0.1"
+					}
 				},
 				"hosted-git-info": {
 					"version": "2.7.1",
@@ -7893,7 +7891,7 @@
 					"dev": true
 				},
 				"invert-kv": {
-					"version": "1.0.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -7901,12 +7899,6 @@
 					"version": "0.2.1",
 					"bundled": true,
 					"dev": true
-				},
-				"is-buffer": {
-					"version": "1.1.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
@@ -7932,12 +7924,12 @@
 					"dev": true
 				},
 				"istanbul-lib-coverage": {
-					"version": "2.0.1",
+					"version": "2.0.3",
 					"bundled": true,
 					"dev": true
 				},
 				"istanbul-lib-hook": {
-					"version": "2.0.1",
+					"version": "2.0.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -7945,22 +7937,32 @@
 					}
 				},
 				"istanbul-lib-report": {
-					"version": "2.0.2",
+					"version": "2.0.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"istanbul-lib-coverage": "^2.0.1",
+						"istanbul-lib-coverage": "^2.0.3",
 						"make-dir": "^1.3.0",
-						"supports-color": "^5.4.0"
+						"supports-color": "^6.0.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "6.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
 					}
 				},
 				"istanbul-lib-source-maps": {
-					"version": "2.0.1",
+					"version": "3.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debug": "^3.1.0",
-						"istanbul-lib-coverage": "^2.0.1",
+						"debug": "^4.1.1",
+						"istanbul-lib-coverage": "^2.0.3",
 						"make-dir": "^1.3.0",
 						"rimraf": "^2.6.2",
 						"source-map": "^0.6.1"
@@ -7974,7 +7976,7 @@
 					}
 				},
 				"istanbul-reports": {
-					"version": "2.0.1",
+					"version": "2.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -7986,27 +7988,12 @@
 					"bundled": true,
 					"dev": true
 				},
-				"kind-of": {
-					"version": "3.2.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"lazy-cache": {
-					"version": "1.0.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
 				"lcid": {
-					"version": "1.0.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"invert-kv": "^1.0.0"
+						"invert-kv": "^2.0.0"
 					}
 				},
 				"load-json-file": {
@@ -8029,19 +8016,18 @@
 						"path-exists": "^3.0.0"
 					}
 				},
+				"lodash": {
+					"version": "4.17.11",
+					"bundled": true,
+					"dev": true
+				},
 				"lodash.flattendeep": {
 					"version": "4.4.0",
 					"bundled": true,
 					"dev": true
 				},
-				"longest": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
 				"lru-cache": {
-					"version": "4.1.3",
+					"version": "4.1.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -8057,25 +8043,22 @@
 						"pify": "^3.0.0"
 					}
 				},
-				"md5-hex": {
-					"version": "2.0.0",
+				"map-age-cleaner": {
+					"version": "0.1.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "^0.1.1"
+						"p-defer": "^1.0.0"
 					}
 				},
-				"md5-o-matic": {
-					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
-				},
 				"mem": {
-					"version": "1.1.0",
+					"version": "4.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mimic-fn": "^1.0.0"
+						"map-age-cleaner": "^0.1.1",
+						"mimic-fn": "^1.0.0",
+						"p-is-promise": "^1.1.0"
 					}
 				},
 				"merge-source-map": {
@@ -8127,7 +8110,12 @@
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"nice-try": {
+					"version": "1.0.5",
 					"bundled": true,
 					"dev": true
 				},
@@ -8178,22 +8166,32 @@
 					"dev": true
 				},
 				"os-locale": {
-					"version": "2.1.0",
+					"version": "3.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
+						"execa": "^1.0.0",
+						"lcid": "^2.0.0",
+						"mem": "^4.0.0"
 					}
+				},
+				"p-defer": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
 				},
 				"p-finally": {
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true
 				},
+				"p-is-promise": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
 				"p-limit": {
-					"version": "2.0.0",
+					"version": "2.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -8214,13 +8212,13 @@
 					"dev": true
 				},
 				"package-hash": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.11",
+						"graceful-fs": "^4.1.15",
+						"hasha": "^3.0.0",
 						"lodash.flattendeep": "^4.4.0",
-						"md5-hex": "^2.0.0",
 						"release-zalgo": "^1.0.0"
 					}
 				},
@@ -8274,6 +8272,15 @@
 					"bundled": true,
 					"dev": true
 				},
+				"pump": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"bundled": true,
@@ -8301,12 +8308,6 @@
 						"es6-error": "^4.0.1"
 					}
 				},
-				"repeat-string": {
-					"version": "1.6.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
 				"require-directory": {
 					"version": "2.1.1",
 					"bundled": true,
@@ -8322,21 +8323,12 @@
 					"bundled": true,
 					"dev": true
 				},
-				"right-align": {
-					"version": "0.1.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"align-text": "^0.1.1"
-					}
-				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
@@ -8345,7 +8337,7 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.6.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -8372,12 +8364,6 @@
 					"bundled": true,
 					"dev": true
 				},
-				"source-map": {
-					"version": "0.5.7",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
@@ -8392,7 +8378,7 @@
 					}
 				},
 				"spdx-correct": {
-					"version": "3.0.0",
+					"version": "3.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -8401,7 +8387,7 @@
 					}
 				},
 				"spdx-exceptions": {
-					"version": "2.1.0",
+					"version": "2.2.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -8415,7 +8401,7 @@
 					}
 				},
 				"spdx-license-ids": {
-					"version": "3.0.0",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true
 				},
@@ -8446,16 +8432,8 @@
 					"bundled": true,
 					"dev": true
 				},
-				"supports-color": {
-					"version": "5.4.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
 				"test-exclude": {
-					"version": "5.0.0",
+					"version": "5.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -8466,35 +8444,22 @@
 					}
 				},
 				"uglify-js": {
-					"version": "2.8.29",
+					"version": "3.4.9",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"source-map": "~0.5.1",
-						"uglify-to-browserify": "~1.0.0",
-						"yargs": "~3.10.0"
+						"commander": "~2.17.1",
+						"source-map": "~0.6.1"
 					},
 					"dependencies": {
-						"yargs": {
-							"version": "3.10.0",
+						"source-map": {
+							"version": "0.6.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
-							"requires": {
-								"camelcase": "^1.0.2",
-								"cliui": "^2.1.0",
-								"decamelize": "^1.0.0",
-								"window-size": "0.1.0"
-							}
+							"optional": true
 						}
 					}
-				},
-				"uglify-to-browserify": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"uuid": {
 					"version": "3.3.2",
@@ -8502,7 +8467,7 @@
 					"dev": true
 				},
 				"validate-npm-package-license": {
-					"version": "3.0.3",
+					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -8522,12 +8487,6 @@
 					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
-				},
-				"window-size": {
-					"version": "0.1.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
@@ -8582,7 +8541,7 @@
 					"dev": true
 				},
 				"write-file-atomic": {
-					"version": "2.3.0",
+					"version": "2.4.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -8592,7 +8551,7 @@
 					}
 				},
 				"y18n": {
-					"version": "3.2.1",
+					"version": "4.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -8602,87 +8561,31 @@
 					"dev": true
 				},
 				"yargs": {
-					"version": "11.1.0",
+					"version": "12.0.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
 						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
+						"os-locale": "^3.0.0",
 						"require-directory": "^2.1.1",
 						"require-main-filename": "^1.0.1",
 						"set-blocking": "^2.0.0",
 						"string-width": "^2.0.0",
 						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
-					},
-					"dependencies": {
-						"cliui": {
-							"version": "4.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"string-width": "^2.1.1",
-								"strip-ansi": "^4.0.0",
-								"wrap-ansi": "^2.0.0"
-							}
-						},
-						"find-up": {
-							"version": "2.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"locate-path": "^2.0.0"
-							}
-						},
-						"locate-path": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"p-locate": "^2.0.0",
-								"path-exists": "^3.0.0"
-							}
-						},
-						"p-limit": {
-							"version": "1.3.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"p-try": "^1.0.0"
-							}
-						},
-						"p-locate": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"p-limit": "^1.1.0"
-							}
-						},
-						"p-try": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
-						}
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^11.1.1"
 					}
 				},
 				"yargs-parser": {
-					"version": "9.0.2",
+					"version": "11.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
-					},
-					"dependencies": {
-						"camelcase": {
-							"version": "4.1.0",
-							"bundled": true,
-							"dev": true
-						}
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -10328,9 +10231,9 @@
 			}
 		},
 		"test-exclude": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.0.0.tgz",
-			"integrity": "sha512-bO3Lj5+qFa9YLfYW2ZcXMOV1pmQvw+KS/DpjqhyX6Y6UZ8zstpZJ+mA2ERkXfpOqhxsJlQiLeVXD3Smsrs6oLw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
+			"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
 			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/plugin-proposal-class-properties": "^7.3.0",
     "@babel/plugin-proposal-export-default-from": "^7.2.0",
     "@babel/plugin-proposal-export-namespace-from": "^7.2.0",
-    "@babel/plugin-proposal-object-rest-spread": "^7.3.1",
+    "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.3.1",
     "@babel/register": "^7.0.0",
@@ -27,7 +27,7 @@
     "lerna": "3.10.8",
     "lint-staged": "^8.1.3",
     "mocha": "^5.2.0",
-    "nyc": "^13.1.0",
+    "nyc": "^13.2.0",
     "prettier": "^1.16.4"
   },
   "scripts": {

--- a/packages/babel-plugin-marko/src/util/parse-id-shorthand.js
+++ b/packages/babel-plugin-marko/src/util/parse-id-shorthand.js
@@ -13,8 +13,19 @@ export default (hub, shorthand, attributes) => {
     throw hub.buildError(idAttr, "Cannot have shorthand id and id attribute.");
   }
 
+  const idParts = shorthand.rawParts.map(part =>
+    part.expression
+      ? hub.parseExpression(part.expression, part.pos)
+      : hub.createNode("stringLiteral", part.pos, part.endPos, part.text)
+  );
+
   attributes.unshift(
-    t.markoAttribute("id", t.stringLiteral(shorthand.value.slice(1, -1)))
+    t.markoAttribute(
+      "id",
+      idParts.length === 1
+        ? idParts[0]
+        : idParts.reduce((a, b) => t.binaryExpression("+", a, b))
+    )
   );
 
   return attributes;

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/generated.expected.marko
@@ -1,0 +1,9 @@
+<div class="shorthand"/>
+<div class="shorthand1 shorthand2"/>
+<div class="shorthand1 shorthand2 inline"/>
+<div class=["shorthand1 shorthand2", dynamic1]/>
+<div class=[dynamic1, "inline"]/>
+<div class=[dynamic1, "shorthand2", "inline"]/>
+<div class=[dynamic1, "shorthand2", dynamic2]/>
+<div class=[dynamic1, "shorthand2", dynamic2, dynamic3]/>
+<div class=["partially-" + dynamic1, "shorthand2", dynamic2]/>

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/translated-html.expected.js
@@ -1,0 +1,18 @@
+import { cl as _marko_class_merge, a as _marko_attr } from "marko/src/runtime/html/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/components/helpers";
+import { t as _t } from "marko/src/runtime/html";
+
+const _marko_template = _t(__filename),
+      _marko_componentType = "OQLZ1bnz";
+
+_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+  out.w(`<div class="shorthand"></div><div class="shorthand1 shorthand2"></div><div class="shorthand1 shorthand2 inline"></div><div${_marko_attr("class", _marko_class_merge(["shorthand1 shorthand2", dynamic1]))}></div><div${_marko_attr("class", _marko_class_merge([dynamic1, "inline"]))}></div><div${_marko_attr("class", _marko_class_merge([dynamic1, "shorthand2", "inline"]))}></div><div${_marko_attr("class", _marko_class_merge([dynamic1, "shorthand2", dynamic2]))}></div><div${_marko_attr("class", _marko_class_merge([dynamic1, "shorthand2", dynamic2, dynamic3]))}></div><div${_marko_attr("class", _marko_class_merge(["partially-" + dynamic1, "shorthand2", dynamic2]))}></div>`)
+}, {
+  ___type: _marko_componentType,
+  ___implicit: true
+})
+_marko_template.Component = _marko_defineComponent(null, _marko_template._)
+_marko_template.meta = {
+  id: _marko_componentType
+}
+export default _marko_template;

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/translated-vdom.expected.js
@@ -1,0 +1,53 @@
+import { cl as _marko_class_merge } from "marko/src/runtime/html/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/components/helpers";
+import { t as _t } from "marko/src/runtime/vdom";
+
+const _marko_template = _t(__filename),
+      _marko_componentType = "OQLZ1bnz";
+
+_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+  out.be("div", {
+    "class": "shorthand"
+  }, "0", component, 0, 0)
+  out.ee()
+  out.be("div", {
+    "class": "shorthand1 shorthand2"
+  }, "1", component, 0, 0)
+  out.ee()
+  out.be("div", {
+    "class": "shorthand1 shorthand2 inline"
+  }, "2", component, 0, 0)
+  out.ee()
+  out.be("div", {
+    "class": _marko_class_merge(["shorthand1 shorthand2", dynamic1])
+  }, "3", component, 0, 0)
+  out.ee()
+  out.be("div", {
+    "class": _marko_class_merge([dynamic1, "inline"])
+  }, "4", component, 0, 0)
+  out.ee()
+  out.be("div", {
+    "class": _marko_class_merge([dynamic1, "shorthand2", "inline"])
+  }, "5", component, 0, 0)
+  out.ee()
+  out.be("div", {
+    "class": _marko_class_merge([dynamic1, "shorthand2", dynamic2])
+  }, "6", component, 0, 0)
+  out.ee()
+  out.be("div", {
+    "class": _marko_class_merge([dynamic1, "shorthand2", dynamic2, dynamic3])
+  }, "7", component, 0, 0)
+  out.ee()
+  out.be("div", {
+    "class": _marko_class_merge(["partially-" + dynamic1, "shorthand2", dynamic2])
+  }, "8", component, 0, 0)
+  out.ee()
+}, {
+  ___type: _marko_componentType,
+  ___implicit: true
+})
+_marko_template.Component = _marko_defineComponent(null, _marko_template._)
+_marko_template.meta = {
+  id: _marko_componentType
+}
+export default _marko_template;

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-classname/template.marko
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-classname/template.marko
@@ -1,0 +1,9 @@
+<div.shorthand/>
+<div.shorthand1.shorthand2/>
+<div.shorthand1.shorthand2 class="inline"/>
+<div.shorthand1.shorthand2 class=dynamic1/>
+<div.${dynamic1} class="inline"/>
+<div.${dynamic1}.shorthand2 class="inline"/>
+<div.${dynamic1}.shorthand2 class=dynamic2/>
+<div.${dynamic1}.shorthand2 class=[dynamic2, dynamic3]/>
+<div.partially-${dynamic1}.shorthand2 class=dynamic2/>

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/generated.expected.marko
@@ -1,0 +1,3 @@
+<div id="shorthand"/>
+<div id=dynamic/>
+<div id=("partial-" + dynamic)/>

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-html-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-html-error.expected.txt
@@ -1,0 +1,1 @@
+Property arguments[1] of CallExpression expected node to be of a type ["Expression","SpreadElement","JSXNamespacedName"] but instead got null

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-html.expected.js
@@ -1,0 +1,18 @@
+import { a as _marko_attr } from "marko/src/runtime/html/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/components/helpers";
+import { t as _t } from "marko/src/runtime/html";
+
+const _marko_template = _t(__filename),
+      _marko_componentType = "cFDIY1TL";
+
+_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+  out.w(`<div id="shorthand"></div><div${_marko_attr("id", dynamic)}></div><div${_marko_attr("id", "partial-" + dynamic)}></div>`)
+}, {
+  ___type: _marko_componentType,
+  ___implicit: true
+})
+_marko_template.Component = _marko_defineComponent(null, _marko_template._)
+_marko_template.meta = {
+  id: _marko_componentType
+}
+export default _marko_template;

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-vdom-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-vdom-error.expected.txt
@@ -1,0 +1,1 @@
+Property value of ObjectProperty expected node to be of a type ["Expression","PatternLike"] but instead got null

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-vdom.expected.js
@@ -1,0 +1,28 @@
+import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/components/helpers";
+import { t as _t } from "marko/src/runtime/vdom";
+
+const _marko_template = _t(__filename),
+      _marko_componentType = "cFDIY1TL";
+
+_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+  out.be("div", {
+    "id": "shorthand"
+  }, "0", component, 0, 0)
+  out.ee()
+  out.be("div", {
+    "id": dynamic
+  }, "1", component, 0, 0)
+  out.ee()
+  out.be("div", {
+    "id": "partial-" + dynamic
+  }, "2", component, 0, 0)
+  out.ee()
+}, {
+  ___type: _marko_componentType,
+  ___implicit: true
+})
+_marko_template.Component = _marko_defineComponent(null, _marko_template._)
+_marko_template.meta = {
+  id: _marko_componentType
+}
+export default _marko_template;

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-id/template.marko
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-id/template.marko
@@ -1,0 +1,3 @@
+<div#shorthand/>
+<div#${dynamic}/>
+<div#partial-${dynamic}/>


### PR DESCRIPTION
## Description
Upgrades htmljs parser which allows for parsing shorthand id & classnames with positional information.

This PR also adds support for dynamic variants of the two `<div.${dynamic}.shorthand>` and `<div#${dynamic}>`.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
