### PR TITLE
fix(babel-plugin-marko): marko-tag node position contain body

### DIFF
--- a/packages/babel-plugin-marko/src/plugins/translate/class.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/class.js
@@ -8,12 +8,6 @@ export default function(path) {
     }
   } = path;
 
-  if (hub._componentClass || hub.componentFiles.componentFile) {
-    throw path.buildCodeFrameError(
-      "A Marko component can only have one top level class."
-    );
-  }
-
   const classProperties = [];
   let onCreateMethod = body.find(
     prop =>

--- a/packages/babel-plugin-marko/src/plugins/translate/index.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/index.js
@@ -7,7 +7,7 @@ import MarkoTag from "./tag";
 import MarkoText from "./text";
 import MarkoPlaceholder from "./placeholder";
 import MarkoScriptlet from "./scriptlet";
-import MarkoClass from "./html-class";
+import MarkoClass from "./class";
 
 export const visitor = {
   MarkoDocumentType,

--- a/packages/babel-plugin-marko/src/plugins/translate/tag/index.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/tag/index.js
@@ -54,7 +54,7 @@ export default {
     function assertNoAttributeTags() {
       if (hasAttributeTag) {
         throw hub.buildError(
-          hasAttributeTag,
+          hasAttributeTag.name,
           "@tags must be within a custom element."
         );
       }

--- a/packages/babel-plugin-marko/src/taglib/core/parse-class.js
+++ b/packages/babel-plugin-marko/src/taglib/core/parse-class.js
@@ -6,9 +6,19 @@ export default function(path) {
   const { rawValue: code, start } = node;
 
   if (hub.componentFiles.componentFile) {
-    throw path.buildCodeFrameError(
-      'A Marko file can either have an inline class, or an external "component.js", but not both.'
-    );
+    throw path
+      .get("name")
+      .buildCodeFrameError(
+        'A Marko file can either have an inline class, or an external "component.js", but not both.'
+      );
+  }
+
+  if (hub._componentClass) {
+    throw path
+      .get("name")
+      .buildCodeFrameError(
+        "A Marko component can only have one top level class."
+      );
   }
 
   const parsed = hub.parseExpression(code, start);
@@ -34,5 +44,6 @@ export default function(path) {
     );
   }
 
+  hub._componentClass = true;
   return withPreviousLocation(t.markoClass(parsed.body), node);
 }

--- a/packages/babel-plugin-marko/test/fixtures/error-at-tags-missing-parent/snapshots/translated-html-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/error-at-tags-missing-parent/snapshots/translated-html-error.expected.txt
@@ -1,8 +1,8 @@
-packages/babel-plugin-marko/test/fixtures/error-at-tags-missing-parent/template.marko(9,5): @tags must be within a custom element.
+packages/babel-plugin-marko/test/fixtures/error-at-tags-missing-parent/template.marko(9,6): @tags must be within a custom element.
    7 |     Body content
    8 | 
 >  9 |     <@footer class="my-footer">
-     |     ^^^^^^^^
+     |      ^^^^^^^
   10 |         Footer content
   11 |     </@footer>
   12 | </div>

--- a/packages/babel-plugin-marko/test/fixtures/error-at-tags-missing-parent/snapshots/translated-vdom-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/error-at-tags-missing-parent/snapshots/translated-vdom-error.expected.txt
@@ -1,8 +1,8 @@
-packages/babel-plugin-marko/test/fixtures/error-at-tags-missing-parent/template.marko(9,5): @tags must be within a custom element.
+packages/babel-plugin-marko/test/fixtures/error-at-tags-missing-parent/template.marko(9,6): @tags must be within a custom element.
    7 |     Body content
    8 | 
 >  9 |     <@footer class="my-footer">
-     |     ^^^^^^^^
+     |      ^^^^^^^
   10 |         Footer content
   11 |     </@footer>
   12 | </div>

--- a/packages/babel-plugin-marko/test/fixtures/error-multiple-inline-class/snapshots/generated-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/error-multiple-inline-class/snapshots/generated-error.expected.txt
@@ -1,0 +1,8 @@
+packages/babel-plugin-marko/test/fixtures/error-multiple-inline-class/template.marko(7,1): A Marko component can only have one top level class.
+   5 | }
+   6 | 
+>  7 | class {
+     | ^^^^^
+   8 |   onMount() {
+   9 | 
+  10 |   }


### PR DESCRIPTION
## Description

Updates the `MarkoTag` node position to contain the entire contents of the tag, previously was just up to attributes.

This PR also moves the multiple MarkoClass error to be earlier (caught at parse time now).

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
