### PR TITLE
refactor(babel-plugin-marko): macro calls become dynamic tags

### DIFF
--- a/packages/babel-plugin-marko/src/plugins/translate/tag/macro-tag.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/tag/macro-tag.js
@@ -1,12 +1,7 @@
-import * as t from "../../../definitions";
-import { replaceInRenderBody, assertNoArgs } from "../../../taglib/core/util";
-import { getAttrs } from "./util";
+import { assertNoArgs } from "../../../taglib/core/util";
 
 export default function(path, tagIdentifier) {
   assertNoArgs(path);
-  // TODO: look into macro keying.
-  replaceInRenderBody(
-    path,
-    t.callExpression(tagIdentifier, [getAttrs(path), t.identifier("out")])
-  );
+  path.set("name", tagIdentifier);
+  path.requeue();
 }

--- a/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-html.expected.js
@@ -7,8 +7,8 @@ function _renderTree(node, out) {
     for (const child of node.children) {
       out.w("<li>");
 
-      _renderTree({ ...child
-      }, out);
+      _marko_dynamicTag(_renderTree, { ...child
+      }, out, __component, "0");
 
       out.w("</li>");
     }
@@ -17,7 +17,7 @@ function _renderTree(node, out) {
   }
 }
 
-import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers";
+import { x as _marko_escapeXml, d as _marko_dynamicTag } from "marko/src/runtime/html/helpers";
 import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
@@ -25,8 +25,8 @@ const _marko_template = _t(__filename),
       _marko_componentType = "9QKeN8cm";
 
 _marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
-  _renderTree({ ...input.node
-  }, out)
+  _marko_dynamicTag(_renderTree, { ...input.node
+  }, out, __component, "6")
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-vdom.expected.js
@@ -9,8 +9,8 @@ function _renderTree(node, out) {
     for (const child of node.children) {
       out.be("li", null, "1", component, 0, 0);
 
-      _renderTree({ ...child
-      }, out);
+      _marko_dynamicTag(_renderTree, { ...child
+      }, out, __component, "0");
 
       out.ee();
     }
@@ -19,6 +19,7 @@ function _renderTree(node, out) {
   }
 }
 
+import { d as _marko_dynamicTag } from "marko/src/runtime/vdom/helpers";
 import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
@@ -26,8 +27,8 @@ const _marko_template = _t(__filename),
       _marko_componentType = "9QKeN8cm";
 
 _marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
-  _renderTree({ ...input.node
-  }, out)
+  _marko_dynamicTag(_renderTree, { ...input.node
+  }, out, __component, "6")
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
@@ -54,9 +54,9 @@ _marko_template._ = _marko_renderer(function (input, out, __component, component
     }
   }, out, __component, "@x")
 
-  _thing({
+  _marko_dynamicTag(_thing, {
     "x": 1
-  }, out)
+  }, out, __component, "11")
 
   _other_tag({
     "renderBody": (out, a) => {

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
@@ -87,9 +87,9 @@ _marko_template._ = _marko_renderer(function (input, out, __component, component
     }
   }, out, __component, "@x")
 
-  _thing({
+  _marko_dynamicTag(_thing, {
     "x": 1
-  }, out)
+  }, out, __component, "11")
 
   _other_tag({
     "renderBody": (out, a) => {


### PR DESCRIPTION
## Description

Output dynamic tags instead of direct function calls for Macros (allows them to be auto keyed and can improve performance).

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
