### PR TITLE
fix(babel-plugin-marko): prevent override component-def param

### DIFF
--- a/packages/babel-plugin-marko/src/plugins/finalize.js
+++ b/packages/babel-plugin-marko/src/plugins/finalize.js
@@ -90,7 +90,7 @@ export const visitor = {
             [
               t.identifier("input"),
               t.identifier("out"),
-              t.identifier("__component"), // TODO: convert to generated var and store reference.
+              hub._componentDefIdentifier,
               t.identifier("component"),
               t.identifier("state")
             ],

--- a/packages/babel-plugin-marko/src/plugins/transform.js
+++ b/packages/babel-plugin-marko/src/plugins/transform.js
@@ -6,6 +6,9 @@ import * as t from "../definitions";
 export const visitor = {
   Program(path) {
     const [renderBlock] = path.pushContainer("body", t.blockStatement([]));
+    path.hub._componentDefIdentifier = path.scope.generateUidIdentifier(
+      "component"
+    );
     path.hub._renderBlock = renderBlock;
   },
   MarkoTag(path) {

--- a/packages/babel-plugin-marko/src/plugins/translate/tag/dynamic-tag.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/tag/dynamic-tag.js
@@ -28,7 +28,7 @@ export default function(path) {
       expression,
       foundAttrs.properties.length ? foundAttrs : t.nullLiteral(),
       t.identifier("out"),
-      t.identifier("__component"),
+      hub._componentDefIdentifier,
       key,
       ...buildEventHandlerArray(path)
     ]

--- a/packages/babel-plugin-marko/src/plugins/translate/tag/native-tag[html]/index.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/tag/native-tag[html]/index.js
@@ -17,7 +17,7 @@ export default function(path) {
   assertNoParams(path);
   assertNoArgs(path);
 
-  const { node } = path;
+  const { hub, node } = path;
   const {
     name: { value: tagName },
     body,
@@ -43,7 +43,7 @@ export default function(path) {
             t.stringLiteral(`on${eventName}`),
             t.callExpression(
               t.memberExpression(
-                t.identifier("__component"),
+                hub._componentDefIdentifier,
                 t.identifier("d")
               ),
               delegateArgs

--- a/packages/babel-plugin-marko/src/plugins/translate/tag/native-tag[vdom]/index.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/tag/native-tag[vdom]/index.js
@@ -13,7 +13,7 @@ import { getAttrs } from "../util";
  * Translates the html streaming version of a standard html element.
  */
 export default function(path) {
-  const { node } = path;
+  const { hub, node } = path;
   const {
     name: { value: tagName },
     key,
@@ -56,7 +56,7 @@ export default function(path) {
             t.stringLiteral(`on${eventName}`),
             t.callExpression(
               t.memberExpression(
-                t.identifier("__component"),
+                hub._componentDefIdentifier,
                 t.identifier("d")
               ),
               delegateArgs

--- a/packages/babel-plugin-marko/src/taglib/core/attributes/directives/no-update.js
+++ b/packages/babel-plugin-marko/src/taglib/core/attributes/directives/no-update.js
@@ -7,7 +7,7 @@ export default function(path, attr, opts = EMPTY_OBJECT) {
   attr.remove();
   const { hub, node } = path;
   const nextKeyMember = t.memberExpression(
-    t.identifier("__component"),
+    hub._componentDefIdentifier,
     t.identifier("___nextKey")
   );
   const nextKeyCall = t.callExpression(nextKeyMember, [

--- a/packages/babel-plugin-marko/src/taglib/core/attributes/modifiers/scoped.js
+++ b/packages/babel-plugin-marko/src/taglib/core/attributes/modifiers/scoped.js
@@ -1,10 +1,11 @@
 import * as t from "../../../../definitions";
 
 export default function(path, attr) {
+  const { hub } = path;
   const value = attr.get("value");
   value.replaceWith(
     t.callExpression(
-      t.memberExpression(t.identifier("__component"), t.identifier("elId")),
+      t.memberExpression(hub._componentDefIdentifier, t.identifier("elId")),
       [value.node]
     )
   );

--- a/packages/babel-plugin-marko/test/fixtures/at-tag-inside-if-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tag-inside-if-tag/snapshots/translated-html.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "pVNVWkgr";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   let _thing = null;
 
   if (x) {

--- a/packages/babel-plugin-marko/test/fixtures/at-tag-inside-if-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tag-inside-if-tag/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "pVNVWkgr";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   let _thing = null;
 
   if (x) {

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-html.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "jk52ETtv";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   const _cols = [];
   const _items = [];
 

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "jk52ETtv";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   const _cols = [];
   const _items = [];
 

--- a/packages/babel-plugin-marko/test/fixtures/at-tags/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags/snapshots/translated-html.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "M1Eai0XC";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _hello_tag({
     "foo": {
       "renderBody": out => {

--- a/packages/babel-plugin-marko/test/fixtures/at-tags/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "M1Eai0XC";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _hello_tag({
     "foo": {
       "renderBody": out => {

--- a/packages/babel-plugin-marko/test/fixtures/attr-body-only-if/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-body-only-if/snapshots/translated-html.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "M5ooyXS3";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   const _dynamic_tag_renderBody = out => {
     out.w("<div>Hello World</div>");
   };
@@ -29,7 +29,7 @@ _marko_template._ = _marko_renderer(function (input, out, __component, component
   }
 
   if (x) {
-    _marko_dynamicTag(_test_tag_renderBody, null, out, __component, "5")
+    _marko_dynamicTag(_test_tag_renderBody, null, out, _component, "5")
   } else {
     _test_tag({
       "renderBody": _test_tag_renderBody
@@ -37,11 +37,11 @@ _marko_template._ = _marko_renderer(function (input, out, __component, component
   }
 
   if (x) {
-    _marko_dynamicTag(_dynamic_tag_renderBody, null, out, __component, "6")
+    _marko_dynamicTag(_dynamic_tag_renderBody, null, out, _component, "6")
   } else {
     _marko_dynamicTag(test, {
       "renderBody": _dynamic_tag_renderBody
-    }, out, __component, "4");
+    }, out, _component, "4");
   }
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/attr-body-only-if/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-body-only-if/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "M5ooyXS3";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   const _dynamic_tag_renderBody = out => {
     out.be("div", null, "3", component, 0, 0);
     out.t("Hello World");
@@ -33,7 +33,7 @@ _marko_template._ = _marko_renderer(function (input, out, __component, component
   }
 
   if (x) {
-    _marko_dynamicTag(_test_tag_renderBody, null, out, __component, "5")
+    _marko_dynamicTag(_test_tag_renderBody, null, out, _component, "5")
   } else {
     _test_tag({
       "renderBody": _test_tag_renderBody
@@ -41,11 +41,11 @@ _marko_template._ = _marko_renderer(function (input, out, __component, component
   }
 
   if (x) {
-    _marko_dynamicTag(_dynamic_tag_renderBody, null, out, __component, "6")
+    _marko_dynamicTag(_dynamic_tag_renderBody, null, out, _component, "6")
   } else {
     _marko_dynamicTag(test, {
       "renderBody": _dynamic_tag_renderBody
-    }, out, __component, "4");
+    }, out, _component, "4");
   }
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/attr-class/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-class/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "N6_faHEU";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div${_marko_attr("class", _marko_class_merge(["a", {
     b: c,
     d

--- a/packages/babel-plugin-marko/test/fixtures/attr-class/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-class/snapshots/translated-vdom.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "N6_faHEU";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "class": _marko_class_merge(["a", {
       b: c,

--- a/packages/babel-plugin-marko/test/fixtures/attr-escape/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-escape/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "FBD_GyAf";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div${_marko_attr("class", _marko_class_merge(input.className))}${_marko_attr("foo", 'a' + input.foo + 'b')}${_marko_attr("bar", `a ${input.foo} b`)}></div>`)
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/attr-escape/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-escape/snapshots/translated-vdom.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "FBD_GyAf";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "class": _marko_class_merge(input.className),
     "foo": 'a' + input.foo + 'b',

--- a/packages/babel-plugin-marko/test/fixtures/attr-scoped/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-scoped/snapshots/translated-html.expected.js
@@ -5,8 +5,8 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "jQhg94Tg";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
-  out.w(`<div${_marko_attr("id", __component.elId("1"))}${_marko_attr("aria-described-by", __component.elId("b"))}></div>`)
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
+  out.w(`<div${_marko_attr("id", _component.elId("1"))}${_marko_attr("aria-described-by", _component.elId("b"))}></div>`)
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/attr-scoped/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-scoped/snapshots/translated-vdom.expected.js
@@ -4,10 +4,10 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "jQhg94Tg";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
-    "id": __component.elId("1"),
-    "aria-described-by": __component.elId("b")
+    "id": _component.elId("1"),
+    "aria-described-by": _component.elId("b")
   }, "0", component, 0, 0)
   out.ee()
 }, {

--- a/packages/babel-plugin-marko/test/fixtures/attr-style/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-style/snapshots/translated-html.expected.js
@@ -6,7 +6,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "Q4DAGn8u";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div${_marko_attr("style", _marko_style_merge({
     color: "green"
   }))}></div>`)

--- a/packages/babel-plugin-marko/test/fixtures/attr-style/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-style/snapshots/translated-vdom.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "Q4DAGn8u";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "style": _marko_style_merge({
       color: "green"

--- a/packages/babel-plugin-marko/test/fixtures/attr-template-literal-escape/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-template-literal-escape/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "mMDF7Duo";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div${_marko_attr("foo", `Hello ${input.name}`)}></div>`)
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/attr-template-literal-escape/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-template-literal-escape/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "mMDF7Duo";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "foo": `Hello ${input.name}`
   }, "0", component, 0, 0)

--- a/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/translated-html.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "49meNcug";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div>Here is a CDATA section: <![CDATA[ < > & ]]> with all kinds of unescaped text.</div>")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "49meNcug";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "0", component, 0, 0)
   out.t("Here is a CDATA section: ")
   out.t(" < > & ")

--- a/packages/babel-plugin-marko/test/fixtures/class-external-component-index/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-external-component-index/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "TtHlZ7aS";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div></div>")
 }, {
   ___type: _marko_componentType

--- a/packages/babel-plugin-marko/test/fixtures/class-external-component-index/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-external-component-index/snapshots/translated-vdom.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "TtHlZ7aS";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "0", component, 0, 0)
   out.ee()
 }, {

--- a/packages/babel-plugin-marko/test/fixtures/class-external-component/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-external-component/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "0hrcFohB";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div></div>")
 }, {
   ___type: _marko_componentType

--- a/packages/babel-plugin-marko/test/fixtures/class-external-component/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-external-component/snapshots/translated-vdom.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "0hrcFohB";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "0", component, 0, 0)
   out.ee()
 }, {

--- a/packages/babel-plugin-marko/test/fixtures/class-inline-class-props-without-on-create/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-inline-class-props-without-on-create/snapshots/translated-html.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "ei0Mhp4E";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div></div>")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/class-inline-class-props-without-on-create/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-inline-class-props-without-on-create/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "ei0Mhp4E";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "0", component, 0, 0)
   out.ee()
 }, {

--- a/packages/babel-plugin-marko/test/fixtures/class-inline/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-inline/snapshots/translated-html.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "rBg9zhFf";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div></div>")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/class-inline/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-inline/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "rBg9zhFf";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "0", component, 0, 0)
   out.ee()
 }, {

--- a/packages/babel-plugin-marko/test/fixtures/comments/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/comments/snapshots/translated-html.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "cmjBZ1aK";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div><!--abc--></div>")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/comments/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/comments/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "cmjBZ1aK";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "1", component, 0, 0)
 
   _htmlComment_tag({

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-data/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-data/snapshots/translated-html.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "9G-EElad";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _customTagData_tag({
     "name": "Frank".toUpperCase(),
     "age": 32

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-data/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-data/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "9G-EElad";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _customTagData_tag({
     "name": "Frank".toUpperCase(),
     "age": 32

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-html.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "ZPxK-KiM";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _customTag_tag({
     "renderBody": (out, a, b, {
       c

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "ZPxK-KiM";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _customTag_tag({
     "renderBody": (out, a, b, {
       c

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-render-body/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-render-body/snapshots/translated-html.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "2EFrUtzo";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _testBodyFunction_tag({
     "name": "World",
     "renderBody": out => {

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-render-body/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-render-body/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "2EFrUtzo";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _testBodyFunction_tag({
     "name": "World",
     "renderBody": out => {

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-separate-assets/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-separate-assets/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "VBJ9cK7S";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div></div>")
 }, {
   ___type: _marko_componentType

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-separate-assets/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-separate-assets/snapshots/translated-vdom.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "VBJ9cK7S";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "0", component, 0, 0)
   out.ee()
 }, {

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-template/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-template/snapshots/translated-html.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "OYtT0PES";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _hello_tag({
     "name": "Frank"
   }, out, "0")

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-template/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-template/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "OYtT0PES";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _hello_tag({
     "name": "Frank"
   }, out, "0")

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag/snapshots/translated-html.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "J6ObXtms";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _testHello_tag({
     "name": "World"
   }, out, "0")

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "J6ObXtms";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _testHello_tag({
     "name": "World"
   }, out, "0")

--- a/packages/babel-plugin-marko/test/fixtures/declaration/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/declaration/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "wx7UfmNS";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("contact-info", null, "1", component, 0, 0)
   out.be("name", null, "0", component, 0, 0)
   out.t("Hello World")

--- a/packages/babel-plugin-marko/test/fixtures/doctype/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/doctype/snapshots/translated-html.expected.js
@@ -13,7 +13,7 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "Fr76d7a7";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<!DOCTYPE html><html><head><title>Title of the document</title></head><body>")
 
   _componentGlobals_tag({}, out, "2")

--- a/packages/babel-plugin-marko/test/fixtures/doctype/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/doctype/snapshots/translated-vdom.expected.js
@@ -13,7 +13,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "Fr76d7a7";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("html", null, "5", component, 0, 0)
   out.be("head", null, "1", component, 0, 0)
   out.be("title", null, "0", component, 0, 0)

--- a/packages/babel-plugin-marko/test/fixtures/entities/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/entities/snapshots/translated-html.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "OLzQeSa9";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("Hello John &amp; Suzy Invalid Entity: &b ; Valid Numeric Entity: &#34; Valid Hexadecimal Entity: &#x00A2;")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/entities/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/entities/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "OLzQeSa9";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.t("Hello John &amp; Suzy Invalid Entity: &b ; Valid Numeric Entity: &#34; Valid Hexadecimal Entity: &#x00A2;")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/event-handlers/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/event-handlers/snapshots/translated-html.expected.js
@@ -9,13 +9,13 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "SSsZKEJG";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div${_marko_attr("data-marko", {
-    "onclick": __component.d("click", "handleClick", [a, b, ...d], false)
+    "onclick": _component.d("click", "handleClick", [a, b, ...d], false)
   })}></div><div${_marko_attr("data-marko", {
-    "onDashed-cased-Event": __component.d("Dashed-cased-Event", "handle", false)
+    "onDashed-cased-Event": _component.d("Dashed-cased-Event", "handle", false)
   })}></div><div${_marko_attr("data-marko", {
-    "oncamelcasedevent": __component.d("camelcasedevent", "handle", false)
+    "oncamelcasedevent": _component.d("camelcasedevent", "handle", false)
   })}></div>`)
 
   _customTag_tag({}, out, "3", ["thing", "handleThing", false, [a, b, ...d]])

--- a/packages/babel-plugin-marko/test/fixtures/event-handlers/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/event-handlers/snapshots/translated-vdom.expected.js
@@ -9,17 +9,17 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "SSsZKEJG";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "0", component, 0, 0, {
-    "onclick": __component.d("click", "handleClick", [a, b, ...d], false)
+    "onclick": _component.d("click", "handleClick", [a, b, ...d], false)
   })
   out.ee()
   out.be("div", null, "1", component, 0, 0, {
-    "onDashed-cased-Event": __component.d("Dashed-cased-Event", "handle", false)
+    "onDashed-cased-Event": _component.d("Dashed-cased-Event", "handle", false)
   })
   out.ee()
   out.be("div", null, "2", component, 0, 0, {
-    "oncamelcasedevent": __component.d("camelcasedevent", "handle", false)
+    "oncamelcasedevent": _component.d("camelcasedevent", "handle", false)
   })
   out.ee()
 

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "lqIjMHgX";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   let _i = -1;
 
   for (const val of arr) {

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "lqIjMHgX";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   let _i = -1;
 
   for (const val of arr) {

--- a/packages/babel-plugin-marko/test/fixtures/hello-dynamic/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/hello-dynamic/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "Lt7mJiby";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`Hello ${_marko_escapeXml(input.name)}! Hello ${input.name}! Hello ${input.missing}!`)
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/hello-dynamic/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/hello-dynamic/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "Lt7mJiby";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.t("Hello ")
   out.t(input.name)
   out.t("! Hello ")

--- a/packages/babel-plugin-marko/test/fixtures/html-comment/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/html-comment/snapshots/translated-html.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "Vfg6Efpl";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<!--test-->")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/html-comment/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/html-comment/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "Vfg6Efpl";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _htmlComment_tag({
     "renderBody": out => {
       out.t("test");

--- a/packages/babel-plugin-marko/test/fixtures/import-tag-conflict/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/import-tag-conflict/snapshots/translated-html.expected.js
@@ -6,7 +6,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "0kf6vBvn";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {}, {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,
   ___implicit: true
 })

--- a/packages/babel-plugin-marko/test/fixtures/import-tag-conflict/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/import-tag-conflict/snapshots/translated-vdom.expected.js
@@ -6,7 +6,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "0kf6vBvn";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {}, {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,
   ___implicit: true
 })

--- a/packages/babel-plugin-marko/test/fixtures/import-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/import-tag/snapshots/translated-html.expected.js
@@ -6,7 +6,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "bMwM8SrD";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {}, {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,
   ___implicit: true
 })

--- a/packages/babel-plugin-marko/test/fixtures/import-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/import-tag/snapshots/translated-vdom.expected.js
@@ -6,7 +6,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "bMwM8SrD";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {}, {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,
   ___implicit: true
 })

--- a/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-html.expected.js
@@ -8,7 +8,7 @@ function _renderTree(node, out) {
       out.w("<li>");
 
       _marko_dynamicTag(_renderTree, { ...child
-      }, out, __component, "0");
+      }, out, _component, "0");
 
       out.w("</li>");
     }
@@ -24,9 +24,9 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "9QKeN8cm";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _marko_dynamicTag(_renderTree, { ...input.node
-  }, out, __component, "6")
+  }, out, _component, "6")
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-vdom.expected.js
@@ -10,7 +10,7 @@ function _renderTree(node, out) {
       out.be("li", null, "1", component, 0, 0);
 
       _marko_dynamicTag(_renderTree, { ...child
-      }, out, __component, "0");
+      }, out, _component, "0");
 
       out.ee();
     }
@@ -26,9 +26,9 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "9QKeN8cm";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _marko_dynamicTag(_renderTree, { ...input.node
-  }, out, __component, "6")
+  }, out, _component, "6")
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/no-update-directives/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-directives/snapshots/translated-html.expected.js
@@ -13,14 +13,14 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "FaQWPoit";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
-  const _noUpdateKey4 = __component.___nextKey("3");
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
+  const _noUpdateKey4 = _component.___nextKey("3");
 
-  const _noUpdateKey3 = __component.___nextKey("2");
+  const _noUpdateKey3 = _component.___nextKey("2");
 
-  const _noUpdateKey2 = __component.___nextKey("1");
+  const _noUpdateKey2 = _component.___nextKey("1");
 
-  const _noUpdateKey = __component.___nextKey("0");
+  const _noUpdateKey = _component.___nextKey("0");
 
   _noUpdate_tag({
     "cid": _noUpdateKey,

--- a/packages/babel-plugin-marko/test/fixtures/no-update-directives/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-directives/snapshots/translated-vdom.expected.js
@@ -13,14 +13,14 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "FaQWPoit";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
-  const _noUpdateKey4 = __component.___nextKey("3");
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
+  const _noUpdateKey4 = _component.___nextKey("3");
 
-  const _noUpdateKey3 = __component.___nextKey("2");
+  const _noUpdateKey3 = _component.___nextKey("2");
 
-  const _noUpdateKey2 = __component.___nextKey("1");
+  const _noUpdateKey2 = _component.___nextKey("1");
 
-  const _noUpdateKey = __component.___nextKey("0");
+  const _noUpdateKey = _component.___nextKey("0");
 
   _noUpdate_tag({
     "cid": _noUpdateKey,

--- a/packages/babel-plugin-marko/test/fixtures/no-update-modifier-multiple/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-modifier-multiple/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "i58_DLy_";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div><input${_marko_attr("value", input.defaultValue)}${_marko_attr("data-marko", {
     noupdate: ["value"]
   })}><input type="checkbox"${_marko_attr("value", input.defaultValue)}${_marko_attr("checked", input.checked)}${_marko_attr("data-marko", {

--- a/packages/babel-plugin-marko/test/fixtures/no-update-modifier-multiple/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-modifier-multiple/snapshots/translated-vdom.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "i58_DLy_";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "2", component, 0, 0)
   out.e("input", {
     "value": input.defaultValue

--- a/packages/babel-plugin-marko/test/fixtures/no-update-modifier/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-modifier/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "AwMFg6kF";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<input${_marko_attr("value", input.defaultValue)}${_marko_attr("data-marko", {
     noupdate: ["value"]
   })}>`)

--- a/packages/babel-plugin-marko/test/fixtures/no-update-modifier/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-modifier/snapshots/translated-vdom.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "AwMFg6kF";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.e("input", {
     "value": input.defaultValue
   }, "0", component, 0, 0, {

--- a/packages/babel-plugin-marko/test/fixtures/prevent-override-component-def/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/prevent-override-component-def/snapshots/generated.expected.marko
@@ -1,0 +1,2 @@
+$ const _component = "test";
+<div/>

--- a/packages/babel-plugin-marko/test/fixtures/prevent-override-component-def/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/prevent-override-component-def/snapshots/translated-html.expected.js
@@ -2,10 +2,11 @@ import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/com
 import { t as _t } from "marko/src/runtime/html";
 
 const _marko_template = _t(__filename),
-      _marko_componentType = "wx7UfmNS";
+      _marko_componentType = "yxFtiAwF";
 
-_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
-  out.w("<?xml version=\"1.0\" encoding=\"utf-8\"?><contact-info><name>Hello World</name></contact-info>")
+_marko_template._ = _marko_renderer(function (input, out, _component2, component, state) {
+  const _component = "test";
+  out.w("<div></div>")
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/prevent-override-component-def/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/prevent-override-component-def/snapshots/translated-vdom.expected.js
@@ -1,11 +1,13 @@
 import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/components/helpers";
-import { t as _t } from "marko/src/runtime/html";
+import { t as _t } from "marko/src/runtime/vdom";
 
 const _marko_template = _t(__filename),
-      _marko_componentType = "wx7UfmNS";
+      _marko_componentType = "yxFtiAwF";
 
-_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
-  out.w("<?xml version=\"1.0\" encoding=\"utf-8\"?><contact-info><name>Hello World</name></contact-info>")
+_marko_template._ = _marko_renderer(function (input, out, _component2, component, state) {
+  const _component = "test";
+  out.be("div", null, "0", component, 0, 0)
+  out.ee()
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/prevent-override-component-def/template.marko
+++ b/packages/babel-plugin-marko/test/fixtures/prevent-override-component-def/template.marko
@@ -1,0 +1,2 @@
+$ const _component = "test";
+<div/>

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
@@ -23,7 +23,7 @@ import { t as _t2 } from "marko/src/runtime/html";
 const _marko_template = _t2(__filename),
       _marko_componentType = "8f1lFGb_";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<style>
   div {
     color: ${_marko_escapeStyle(x)};
@@ -40,8 +40,8 @@ _marko_template._ = _marko_renderer(function (input, out, __component, component
     out.w(`<div${_marko_attr("d", d)}${_marko_attr("e", e)}></div>`);
   }
   out.w(`</div><div${_marko_attr("data-marko", {
-    "onclick": __component.d("click", "handleClick", [a, b, ...d], false)
-  })}></div><div${_marko_attr("id", __component.elId("1"))}></div><div${_marko_attr("class", _marko_class_merge(["a", {
+    "onclick": _component.d("click", "handleClick", [a, b, ...d], false)
+  })}></div><div${_marko_attr("id", _component.elId("1"))}></div><div${_marko_attr("class", _marko_class_merge(["a", {
     b: c,
     d
   }]))}${_marko_attr("style", _marko_style_merge({
@@ -52,11 +52,11 @@ _marko_template._ = _marko_renderer(function (input, out, __component, component
     "renderBody": out => {
       out.w("<div></div>");
     }
-  }, out, __component, "@x")
+  }, out, _component, "@x")
 
   _marko_dynamicTag(_thing, {
     "x": 1
-  }, out, __component, "11")
+  }, out, _component, "11")
 
   _other_tag({
     "renderBody": (out, a) => {

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
@@ -31,7 +31,7 @@ import { t as _t2 } from "marko/src/runtime/vdom";
 const _marko_template = _t2(__filename),
       _marko_componentType = "8f1lFGb_";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("style", null, "0", component, 0, 0)
   out.t("\n  div {\n    color: ")
   out.t(x)
@@ -59,11 +59,11 @@ _marko_template._ = _marko_renderer(function (input, out, __component, component
   }
   out.ee()
   out.be("div", null, "6", component, 0, 0, {
-    "onclick": __component.d("click", "handleClick", [a, b, ...d], false)
+    "onclick": _component.d("click", "handleClick", [a, b, ...d], false)
   })
   out.ee()
   out.be("div", {
-    "id": __component.elId("1")
+    "id": _component.elId("1")
   }, "7", component, 0, 0)
   out.ee()
   out.be("div", {
@@ -85,11 +85,11 @@ _marko_template._ = _marko_renderer(function (input, out, __component, component
       out.be("div", null, "10", component, 0, 0);
       out.ee();
     }
-  }, out, __component, "@x")
+  }, out, _component, "@x")
 
   _marko_dynamicTag(_thing, {
     "x": 1
-  }, out, __component, "11")
+  }, out, _component, "11")
 
   _other_tag({
     "renderBody": (out, a) => {

--- a/packages/babel-plugin-marko/test/fixtures/scriptlet-line-block/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/scriptlet-line-block/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "C_B82F6C";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   var foo = 123;
 
   function bar() {}

--- a/packages/babel-plugin-marko/test/fixtures/scriptlet-line-block/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/scriptlet-line-block/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "C_B82F6C";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   var foo = 123;
 
   function bar() {}

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "OQLZ1bnz";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div class="shorthand"></div><div class="shorthand1 shorthand2"></div><div class="shorthand1 shorthand2 inline"></div><div${_marko_attr("class", _marko_class_merge(["shorthand1 shorthand2", dynamic1]))}></div><div${_marko_attr("class", _marko_class_merge([dynamic1, "inline"]))}></div><div${_marko_attr("class", _marko_class_merge([dynamic1, "shorthand2", "inline"]))}></div><div${_marko_attr("class", _marko_class_merge([dynamic1, "shorthand2", dynamic2]))}></div><div${_marko_attr("class", _marko_class_merge([dynamic1, "shorthand2", dynamic2, dynamic3]))}></div><div${_marko_attr("class", _marko_class_merge(["partially-" + dynamic1, "shorthand2", dynamic2]))}></div>`)
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/translated-vdom.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "OQLZ1bnz";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "class": "shorthand"
   }, "0", component, 0, 0)

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "cFDIY1TL";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div id="shorthand"></div><div${_marko_attr("id", dynamic)}></div><div${_marko_attr("id", "partial-" + dynamic)}></div>`)
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "cFDIY1TL";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "id": "shorthand"
   }, "0", component, 0, 0)

--- a/packages/babel-plugin-marko/test/fixtures/simple/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/simple/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "hXm4QTQF";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`Hello ${_marko_escapeXml(input.name)}! `)
 
   if (input.colors.length) {

--- a/packages/babel-plugin-marko/test/fixtures/simple/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/simple/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "hXm4QTQF";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.t("Hello ")
   out.t(input.name)
   out.t("! ")

--- a/packages/babel-plugin-marko/test/fixtures/split-component-with-component/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/split-component-with-component/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "9b_ZSA-h";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div></div>")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/split-component-with-component/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/split-component-with-component/snapshots/translated-vdom.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "9b_ZSA-h";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "0", component, 0, 0)
   out.ee()
 }, {

--- a/packages/babel-plugin-marko/test/fixtures/split-component/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/split-component/snapshots/translated-html.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "prO3cwdD";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div></div>")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/split-component/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/split-component/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "prO3cwdD";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "0", component, 0, 0)
   out.ee()
 }, {

--- a/packages/babel-plugin-marko/test/fixtures/static-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/static-tag/snapshots/translated-html.expected.js
@@ -9,7 +9,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "POLyS7AN";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {}, {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,
   ___implicit: true
 })

--- a/packages/babel-plugin-marko/test/fixtures/static-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/static-tag/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "POLyS7AN";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {}, {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,
   ___implicit: true
 })

--- a/packages/babel-plugin-marko/test/fixtures/static/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/static/snapshots/translated-html.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "DEx6jt9w";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("Hello John")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/static/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/static/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "DEx6jt9w";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.t("Hello John")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/style-block-empty/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/style-block-empty/snapshots/translated-html.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "k7Oc1u-Y";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div class=\"test\"></div>")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/style-block-empty/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/style-block-empty/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "k7Oc1u-Y";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "class": "test"
   }, "0", component, 0, 0)

--- a/packages/babel-plugin-marko/test/fixtures/style-block-with-styles/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/style-block-with-styles/snapshots/translated-html.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "bZPuqO3U";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div class=\"test\"></div>")
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/style-block-with-styles/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/style-block-with-styles/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "bZPuqO3U";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "class": "test"
   }, "0", component, 0, 0)

--- a/packages/babel-plugin-marko/test/fixtures/tag-block-scoping/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/tag-block-scoping/snapshots/translated-html.expected.js
@@ -5,7 +5,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "HxdBTLNA";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   var b = thing;
   let c = thing;
   out.w(`<div${_marko_attr("b", b)}${_marko_attr("c", c)}>`)

--- a/packages/babel-plugin-marko/test/fixtures/tag-block-scoping/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/tag-block-scoping/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "HxdBTLNA";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   var b = thing;
   let c = thing;
   out.be("div", {

--- a/packages/babel-plugin-marko/test/fixtures/while-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/while-tag/snapshots/translated-html.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "7_cIMGIq";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   let i = 0;
 
   while (i < 10) {

--- a/packages/babel-plugin-marko/test/fixtures/while-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/while-tag/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "7_cIMGIq";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   let i = 0;
 
   while (i < 10) {

--- a/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-html.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/html";
 const _marko_template = _t(__filename),
       _marko_componentType = "f5PlznI-";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div><div>Hello <div> </div> World</div><div> Hello</div><pre>\n    This should  \n      be preserved\n  </pre><div><div>Hello </div></div></div><div>")
   scriptletA();
   scriptletB();

--- a/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-vdom.expected.js
@@ -4,7 +4,7 @@ import { t as _t } from "marko/src/runtime/vdom";
 const _marko_template = _t(__filename),
       _marko_componentType = "f5PlznI-";
 
-_marko_template._ = _marko_renderer(function (input, out, __component, component, state) {
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "6", component, 0, 0)
   out.be("div", null, "1", component, 0, 0)
   out.t("Hello ")


### PR DESCRIPTION
## Description

Currently if you do the following in a template:
```marko
$ var __component = "test";
```

The component def var that we put into the renderBody params will be shadowed and cause issues. This PR updates this identifier to be unique.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
