### PR TITLE
feat(babel-plugin-marko): support module-code tag

### DIFF
--- a/packages/babel-plugin-marko/src/hub.js
+++ b/packages/babel-plugin-marko/src/hub.js
@@ -27,6 +27,7 @@ export class Hub {
     this._imports = Object.create(null);
     this._componentClass = null;
     this._nextKey = 0;
+    this.isModuleCode = false;
 
     const {
       styleFile,

--- a/packages/babel-plugin-marko/src/plugins/translate/index.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/index.js
@@ -25,6 +25,10 @@ export const visitor = {
   },
   Program: {
     enter(path) {
+      if (path.hub.isModuleCode) {
+        return path.skip();
+      }
+
       // Move non static content into the renderBody.
       const [renderBlock] = path.pushContainer("body", t.blockStatement([]));
       path

--- a/packages/babel-plugin-marko/src/taglib/core/marko.json
+++ b/packages/babel-plugin-marko/src/taglib/core/marko.json
@@ -147,6 +147,16 @@
       }
     ]
   },
+  "<module-code>": {
+    "node-factory": "./parse-module-code",
+    "parse-options": {
+      "rootOnly": true,
+      "rawOpenTag": true,
+      "openTagOnly": true,
+      "ignoreAttributes": true,
+      "relaxRequireCommas": true
+    }
+  },
   "<*>": {
     "@key": {
       "type": "string",

--- a/packages/babel-plugin-marko/src/taglib/core/parse-module-code.js
+++ b/packages/babel-plugin-marko/src/taglib/core/parse-module-code.js
@@ -1,0 +1,27 @@
+import nodePath from "path";
+import resolveFrom from "resolve-from";
+
+const startOffset = "module-code".length;
+
+export default function parse(path) {
+  const {
+    hub,
+    node: { rawValue, start }
+  } = path;
+  const dirname = nodePath.dirname(hub.filename);
+  const relativeRequire = entry => require(resolveFrom(dirname, entry));
+  const fn = eval(rawValue.slice(startOffset));
+  const source = fn(relativeRequire);
+  const program = hub.parse(source, start + startOffset);
+  const programPath = path.parentPath;
+
+  if (programPath.node.body.length > 1) {
+    throw path.buildCodeFrameError(
+      "<module-code> tag should exist only by itself"
+    );
+  }
+
+  program.body.forEach(node => path.insertBefore(node));
+  path.remove();
+  hub.isModuleCode = true;
+}

--- a/packages/babel-plugin-marko/test/fixtures/module-code/env.js
+++ b/packages/babel-plugin-marko/test/fixtures/module-code/env.js
@@ -1,0 +1,1 @@
+exports.isDebug = true;

--- a/packages/babel-plugin-marko/test/fixtures/module-code/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/module-code/snapshots/generated.expected.marko
@@ -1,0 +1,1 @@
+module.exports = require("./src/index");

--- a/packages/babel-plugin-marko/test/fixtures/module-code/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/module-code/snapshots/translated-html.expected.js
@@ -1,0 +1,1 @@
+module.exports = require("./src/index");

--- a/packages/babel-plugin-marko/test/fixtures/module-code/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/module-code/snapshots/translated-vdom.expected.js
@@ -1,0 +1,1 @@
+module.exports = require("./src/index");

--- a/packages/babel-plugin-marko/test/fixtures/module-code/template.marko
+++ b/packages/babel-plugin-marko/test/fixtures/module-code/template.marko
@@ -1,0 +1,4 @@
+<module-code(function(require) {
+    var isDebug = require('./env').isDebug;
+    return `module.exports = require("./${isDebug ? 'src' : 'dist'}/index");\n`;
+})/>


### PR DESCRIPTION
## Description

Adds support for the `<module-code>` tag used as the entry point to the Marko runtime.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
