### PR TITLE
Enter exit hooks & for loop keying

### DIFF
--- a/packages/babel-plugin-marko/src/index.js
+++ b/packages/babel-plugin-marko/src/index.js
@@ -26,6 +26,7 @@ export default (api, options) => {
 
       const nodePath = new NodePath(hub);
       nodePath.node = hub.file;
+      hub.program = nodePath.get("program");
       parse(nodePath);
 
       // TODO: this package should be split into 3:

--- a/packages/babel-plugin-marko/src/plugins/translate/attribute/directives/no-update.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/attribute/directives/no-update.js
@@ -13,7 +13,6 @@ export default function(tag, attr, opts = EMPTY_OBJECT) {
     node.key || hub.nextKey()
   ]);
   const keyIdentifier = tag.scope.generateUidIdentifier("noUpdateKey");
-  const name = t.stringLiteral("no-update");
   const replacementAttrs = [t.markoAttribute("cid", keyIdentifier)];
 
   if (opts.if) {
@@ -24,7 +23,11 @@ export default function(tag, attr, opts = EMPTY_OBJECT) {
     replacementAttrs.push(t.markoAttribute("bodyOnly", t.booleanLiteral(true)));
   }
 
-  const replacement = t.markoTag(name, replacementAttrs, [node]);
+  const replacement = t.markoTag(
+    t.stringLiteral("no-update"),
+    replacementAttrs,
+    [node]
+  );
   replacement.key = normalizeTemplateLiteral(["#", ""], [keyIdentifier]);
 
   tag.insertBefore(
@@ -33,5 +36,5 @@ export default function(tag, attr, opts = EMPTY_OBJECT) {
     ])
   );
 
-  tag.replaceWith(replacement);
+  tag.replaceWith(replacement)[0].visit();
 }

--- a/packages/babel-plugin-marko/src/plugins/translate/tag/custom-tag.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/tag/custom-tag.js
@@ -21,7 +21,9 @@ export default function(path, tagDef) {
   if (!relativePath) {
     throw path
       .get("name")
-      .buildCodeFrameError("Unable to find entry point for custom tag.");
+      .buildCodeFrameError(
+        `Unable to find entry point for custom tag <${name}>.`
+      );
   }
 
   let tagIdentifierLookup = TAG_IDENTIFIER_LOOKUPS.get(hub);

--- a/packages/babel-plugin-marko/src/plugins/translate/tag/custom-tag.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/tag/custom-tag.js
@@ -21,7 +21,7 @@ export default function(path, tagDef) {
   if (!relativePath) {
     throw path
       .get("name")
-      .buildCodeFrameError(`Unable to find entry point tag.`);
+      .buildCodeFrameError("Unable to find entry point for custom tag.");
   }
 
   let tagIdentifierLookup = TAG_IDENTIFIER_LOOKUPS.get(hub);

--- a/packages/babel-plugin-marko/src/plugins/translate/tag/index.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/tag/index.js
@@ -14,9 +14,7 @@ export default {
     const { options, macros } = hub;
     const name = path.get("name");
 
-    if (!path.get("key").node) {
-      path.set("key", hub.nextKey());
-    }
+    hub.resolveKey(path);
 
     if (!name.isStringLiteral()) {
       dynamicTag(path);

--- a/packages/babel-plugin-marko/src/plugins/translate/tag/util.js
+++ b/packages/babel-plugin-marko/src/plugins/translate/tag/util.js
@@ -1,5 +1,5 @@
 import * as t from "../../../definitions";
-const transparentTags = new Set(["for", "if", "else", "no-update"]);
+const transparentTags = new Set(["for", "while", "if", "else", "no-update"]);
 
 export function getAttrs(path, skipRenderBody) {
   const { node } = path;

--- a/packages/babel-plugin-marko/src/taglib/core/conditional/translate-else-if.js
+++ b/packages/babel-plugin-marko/src/taglib/core/conditional/translate-else-if.js
@@ -1,7 +1,7 @@
 import { buildIfStatement } from "./util";
 import { assertNoAttributes } from "../util";
 
-export default function translate(path) {
+export function exit(path) {
   assertNoAttributes(path);
 
   const { ifStatement, arguments: args } = path.node;

--- a/packages/babel-plugin-marko/src/taglib/core/conditional/translate-else.js
+++ b/packages/babel-plugin-marko/src/taglib/core/conditional/translate-else.js
@@ -1,7 +1,7 @@
 import * as t from "../../../definitions";
 import { assertNoArgs, assertNoAttributes } from "../util";
 
-export default function translate(path) {
+export function exit(path) {
   assertNoArgs(path);
   assertNoAttributes(path);
 

--- a/packages/babel-plugin-marko/src/taglib/core/conditional/translate-if.js
+++ b/packages/babel-plugin-marko/src/taglib/core/conditional/translate-if.js
@@ -1,7 +1,7 @@
 import { buildIfStatement } from "./util";
 import { assertNoAttributes } from "../util";
 
-export default function(path) {
+export function exit(path) {
   assertNoAttributes(path);
   path.replaceWith(buildIfStatement(path, path.node.arguments));
 }

--- a/packages/babel-plugin-marko/src/taglib/core/macro/transform.js
+++ b/packages/babel-plugin-marko/src/taglib/core/macro/transform.js
@@ -1,4 +1,4 @@
-export default function(path) {
+export function enter(path) {
   const {
     hub: { macros },
     node

--- a/packages/babel-plugin-marko/src/taglib/core/macro/translate.js
+++ b/packages/babel-plugin-marko/src/taglib/core/macro/translate.js
@@ -1,7 +1,7 @@
 import * as t from "../../../definitions";
 import withPreviousLocation from "../../../util/with-previous-location";
 
-export default function(path) {
+export function exit(path) {
   const { node } = path;
   const { _macroId: id, body } = node;
   const params = node.params.concat(t.identifier("out"));

--- a/packages/babel-plugin-marko/src/taglib/core/transform-await.js
+++ b/packages/babel-plugin-marko/src/taglib/core/transform-await.js
@@ -1,6 +1,6 @@
 import * as t from "../../definitions";
 
-export default function(path) {
+export function exit(path) {
   const args = path.get("arguments");
 
   if (!args.length) {

--- a/packages/babel-plugin-marko/src/taglib/core/transform-body.js
+++ b/packages/babel-plugin-marko/src/taglib/core/transform-body.js
@@ -1,6 +1,6 @@
 import * as t from "../../definitions";
 
-export default function(path) {
+export function exit(path) {
   const body = path.get("body");
   const firstChild = body[0];
   const lastChild = body[body.length - 1];

--- a/packages/babel-plugin-marko/src/taglib/core/transform-fragment.js
+++ b/packages/babel-plugin-marko/src/taglib/core/transform-fragment.js
@@ -1,7 +1,7 @@
 import * as t from "../../definitions";
 import normalizeTemplateLiteral from "../../util/normalize-template-string";
 
-export default function(path) {
+export function exit(path) {
   const namePath = path.get("name");
   const attributes = path.get("attributes");
   const { body } = path.node;

--- a/packages/babel-plugin-marko/src/taglib/core/translate-for.js
+++ b/packages/babel-plugin-marko/src/taglib/core/translate-for.js
@@ -79,15 +79,15 @@ export default function(path) {
     allowedAttributes.push("from", "to", "step");
 
     const stepAttr = findName(attributes, "step");
-    const [keyParam] = node.params;
+    const [indexParam] = node.params;
     const indexName = path.scope.generateUidIdentifier(
-      keyParam ? keyParam.name : "i"
+      indexParam ? indexParam.name : "i"
     );
 
-    if (keyParam) {
+    if (indexParam) {
       block.body.unshift(
         t.variableDeclaration("const", [
-          t.variableDeclarator(keyParam, indexName)
+          t.variableDeclarator(indexParam, indexName)
         ])
       );
     }

--- a/packages/babel-plugin-marko/src/taglib/core/translate-for.js
+++ b/packages/babel-plugin-marko/src/taglib/core/translate-for.js
@@ -1,7 +1,7 @@
 import * as t from "../../definitions";
 import { assertAllowedAttributes } from "./util";
 
-export default function(path) {
+export function exit(path) {
   const { node } = path;
   const { attributes, body } = node;
   const namePath = path.get("name");

--- a/packages/babel-plugin-marko/src/taglib/core/translate-html-comment.js
+++ b/packages/babel-plugin-marko/src/taglib/core/translate-html-comment.js
@@ -1,7 +1,7 @@
 import { assertNoArgs, assertNoParams, assertNoAttributes } from "./util";
 import write from "../../util/html-out-write";
 
-export default function(path) {
+export function enter(path) {
   const { hub } = path;
   assertNoArgs(path);
   assertNoParams(path);

--- a/packages/babel-plugin-marko/src/taglib/core/translate-style.js
+++ b/packages/babel-plugin-marko/src/taglib/core/translate-style.js
@@ -1,6 +1,6 @@
 import { basename } from "path";
 
-export default function(path) {
+export function exit(path) {
   const { hub, node } = path;
   const { _styleType: type, _styleCode: code } = node;
 

--- a/packages/babel-plugin-marko/src/taglib/core/translate-while.js
+++ b/packages/babel-plugin-marko/src/taglib/core/translate-while.js
@@ -1,6 +1,6 @@
 import * as t from "../../definitions";
 
-export default function(path) {
+export function exit(path) {
   const { node, hub } = path;
   const { rawValue, start, body } = node;
   const [whileNode] = hub.parse(rawValue + ";", start).body;

--- a/packages/babel-plugin-marko/test/fixtures/at-tag-inside-if-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tag-inside-if-tag/snapshots/translated-html.expected.js
@@ -24,7 +24,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   _customTag_tag({
     "thing": _thing
-  }, out, "2");
+  }, out, "0");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/at-tag-inside-if-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tag-inside-if-tag/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/html/helpers";
 
 const _customTag_tag = _t(_customTag);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "pVNVWkgr",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("pVNVWkgr", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   let _thing = null;

--- a/packages/babel-plugin-marko/test/fixtures/at-tag-inside-if-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tag-inside-if-tag/snapshots/translated-vdom.expected.js
@@ -24,7 +24,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   _customTag_tag({
     "thing": _thing
-  }, out, "2");
+  }, out, "0");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/at-tag-inside-if-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tag-inside-if-tag/snapshots/translated-vdom.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/vdom/helpers";
 
 const _customTag_tag = _t(_customTag);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "pVNVWkgr",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("pVNVWkgr", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   let _thing = null;

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic-tag-parent/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic-tag-parent/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { d as _marko_dynamicTag } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "TWYgfCZi",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("TWYgfCZi", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _marko_dynamicTag(input.x, {

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic-tag-parent/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic-tag-parent/snapshots/translated-html.expected.js
@@ -23,7 +23,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "renderBody": out => {
       out.w("Body content");
     }
-  }, out, _component, "2");
+  }, out, _component, "0");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic-tag-parent/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic-tag-parent/snapshots/translated-vdom.expected.js
@@ -1,10 +1,10 @@
 import { d as _marko_dynamicTag } from "marko/src/runtime/vdom/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "TWYgfCZi",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("TWYgfCZi", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _marko_dynamicTag(input.x, {

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic-tag-parent/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic-tag-parent/snapshots/translated-vdom.expected.js
@@ -23,7 +23,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "renderBody": out => {
       out.t("Body content");
     }
-  }, out, _component, "2");
+  }, out, _component, "0");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/generated.expected.marko
@@ -16,6 +16,12 @@
         </@item>
       </else>
     </for>
+    $ let i = 10;
+    <while(i--)>
+      <@item>
+        ${i}
+      </@item>
+    </while>
   </@list>
   <for|col| of=input.table>
     <@col x=y>

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ import _hello from "./components/hello/index.marko";
 
 const _hello_tag = _t(_hello);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "jk52ETtv",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("jk52ETtv", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   const _cols = [];

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-html.expected.js
@@ -73,7 +73,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
       "items": _items
     },
     "cols": _cols
-  }, out, "12");
+  }, out, "0");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-html.expected.js
@@ -36,6 +36,16 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     }
   }
 
+  let i = 10;
+
+  while (i--) {
+    _items.push({
+      "renderBody": out => {
+        out.w(_marko_escapeXml(i));
+      }
+    });
+  }
+
   for (const col of input.table) {
     const _rows = [];
 

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-vdom.expected.js
@@ -73,7 +73,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
       "items": _items
     },
     "cols": _cols
-  }, out, "12");
+  }, out, "0");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-vdom.expected.js
@@ -36,6 +36,16 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     }
   }
 
+  let i = 10;
+
+  while (i--) {
+    _items.push({
+      "renderBody": out => {
+        out.t(i);
+      }
+    });
+  }
+
   for (const col of input.table) {
     const _rows = [];
 

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/snapshots/translated-vdom.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/vdom/helpers";
 
 const _hello_tag = _t(_hello);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "jk52ETtv",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("jk52ETtv", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   const _cols = [];

--- a/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/template.marko
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags-dynamic/template.marko
@@ -8,6 +8,11 @@
                 <@item style={ color }>bar</@item>
             </else>
         </for>
+
+        $ let i = 10;
+        <while(i--)>
+            <@item>${i}</@item>
+        </while>
     </@list>
 
     <for|col| of=input.table>

--- a/packages/babel-plugin-marko/test/fixtures/at-tags/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/html/helpers";
 
 const _hello_tag = _t(_hello);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "M1Eai0XC",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("M1Eai0XC", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _hello_tag({

--- a/packages/babel-plugin-marko/test/fixtures/at-tags/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags/snapshots/translated-html.expected.js
@@ -17,7 +17,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
         out.w("Foo!");
       }
     }
-  }, out, "1");
+  }, out, "0");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/at-tags/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags/snapshots/translated-vdom.expected.js
@@ -17,7 +17,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
         out.t("Foo!");
       }
     }
-  }, out, "1");
+  }, out, "0");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/at-tags/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/at-tags/snapshots/translated-vdom.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/vdom/helpers";
 
 const _hello_tag = _t(_hello);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "M1Eai0XC",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("M1Eai0XC", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _hello_tag({

--- a/packages/babel-plugin-marko/test/fixtures/attr-body-only-if/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-body-only-if/snapshots/translated-html.expected.js
@@ -21,7 +21,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   if (x) _marko_dynamicTag(_test_tag_renderBody, null, out, _component, "3");else _test_tag({
     "renderBody": _test_tag_renderBody
-  }, out, "2");
+  }, out, "1");
 
   const _dynamic_tag_renderBody = out => {
     out.w("<div>Hello World</div>");
@@ -29,7 +29,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   if (a, b) _marko_dynamicTag(_dynamic_tag_renderBody, null, out, _component, "6");else _marko_dynamicTag(test, {
     "renderBody": _dynamic_tag_renderBody
-  }, out, _component, "5");
+  }, out, _component, "4");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/attr-body-only-if/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-body-only-if/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ import { t as _t, d as _marko_dynamicTag } from "marko/src/runtime/html/helpers"
 
 const _test_tag = _t(_test);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "M5ooyXS3",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("M5ooyXS3", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   if (!x) out.w("<div>");

--- a/packages/babel-plugin-marko/test/fixtures/attr-body-only-if/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-body-only-if/snapshots/translated-vdom.expected.js
@@ -16,24 +16,24 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   if (!x) out.ee();
 
   const _test_tag_renderBody = out => {
-    out.be("div", null, "1", component, null, 0);
+    out.be("div", null, "2", component, null, 0);
     out.t("Hello");
     out.ee();
   };
 
   if (x) _marko_dynamicTag(_test_tag_renderBody, null, out, _component, "3");else _test_tag({
     "renderBody": _test_tag_renderBody
-  }, out, "2");
+  }, out, "1");
 
   const _dynamic_tag_renderBody = out => {
-    out.be("div", null, "4", component, null, 0);
+    out.be("div", null, "5", component, null, 0);
     out.t("Hello World");
     out.ee();
   };
 
   if (a, b) _marko_dynamicTag(_dynamic_tag_renderBody, null, out, _component, "6");else _marko_dynamicTag(test, {
     "renderBody": _dynamic_tag_renderBody
-  }, out, _component, "5");
+  }, out, _component, "4");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/attr-body-only-if/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-body-only-if/snapshots/translated-vdom.expected.js
@@ -3,12 +3,12 @@ import { t as _t, d as _marko_dynamicTag } from "marko/src/runtime/vdom/helpers"
 
 const _test_tag = _t(_test);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "M5ooyXS3",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("M5ooyXS3", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   if (!x) out.be("div", null, "0", component, null, 0);

--- a/packages/babel-plugin-marko/test/fixtures/attr-boolean/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-boolean/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "VTOpbGWq",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("VTOpbGWq", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<input checked>");

--- a/packages/babel-plugin-marko/test/fixtures/attr-boolean/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-boolean/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "VTOpbGWq",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("VTOpbGWq", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.e("input", {

--- a/packages/babel-plugin-marko/test/fixtures/attr-class/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-class/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ import _customTag from "./components/custom-tag.marko";
 
 const _customTag_tag = _t(_customTag);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "N6_faHEU",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("N6_faHEU", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div${_marko_attr("class", _marko_class_merge(["a", {

--- a/packages/babel-plugin-marko/test/fixtures/attr-class/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-class/snapshots/translated-html.expected.js
@@ -37,7 +37,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
         out.w("Hello");
       }
     }
-  }, out, _component, "4");
+  }, out, _component, "3");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/attr-class/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-class/snapshots/translated-vdom.expected.js
@@ -45,7 +45,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
         out.t("Hello");
       }
     }
-  }, out, _component, "4");
+  }, out, _component, "3");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/attr-class/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-class/snapshots/translated-vdom.expected.js
@@ -4,12 +4,12 @@ import { t as _t, d as _marko_dynamicTag } from "marko/src/runtime/vdom/helpers"
 
 const _customTag_tag = _t(_customTag);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "N6_faHEU",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("N6_faHEU", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
@@ -17,11 +17,11 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
       b: c,
       d
     }])
-  }, "0", component, 0, 4);
+  }, "0", component, 0, 1);
   out.ee();
   out.be("div", {
     "class": "a b c"
-  }, "1", component, 0, 4);
+  }, "1", component, 0, 1);
   out.ee();
 
   _customTag_tag({

--- a/packages/babel-plugin-marko/test/fixtures/attr-escape/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-escape/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { cl as _marko_class_merge, a as _marko_attr } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "FBD_GyAf",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("FBD_GyAf", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div${_marko_attr("class", _marko_class_merge(input.className))}${_marko_attr("foo", 'a' + input.foo + 'b')}${_marko_attr("bar", `a ${input.foo} b`)}></div>`);

--- a/packages/babel-plugin-marko/test/fixtures/attr-escape/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-escape/snapshots/translated-vdom.expected.js
@@ -1,10 +1,10 @@
 import { cl as _marko_class_merge } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "FBD_GyAf",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("FBD_GyAf", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {

--- a/packages/babel-plugin-marko/test/fixtures/attr-falsey/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-falsey/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "ufpKo5n_",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("ufpKo5n_", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div d=\"0\" y=\"1\"></div>");

--- a/packages/babel-plugin-marko/test/fixtures/attr-falsey/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-falsey/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "ufpKo5n_",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("ufpKo5n_", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {

--- a/packages/babel-plugin-marko/test/fixtures/attr-scoped/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-scoped/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { a as _marko_attr } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "jQhg94Tg",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("jQhg94Tg", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div${_marko_attr("id", _component.elId("1"))}${_marko_attr("aria-described-by", _component.elId("b"))}></div>`);

--- a/packages/babel-plugin-marko/test/fixtures/attr-scoped/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-scoped/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "jQhg94Tg",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("jQhg94Tg", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {

--- a/packages/babel-plugin-marko/test/fixtures/attr-style/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-style/snapshots/translated-html.expected.js
@@ -34,7 +34,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
         out.w("Hello");
       }
     }
-  }, out, _component, "4");
+  }, out, _component, "3");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/attr-style/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-style/snapshots/translated-html.expected.js
@@ -4,12 +4,12 @@ import _customTag from "./components/custom-tag.marko";
 
 const _customTag_tag = _t(_customTag);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "Q4DAGn8u",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("Q4DAGn8u", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div${_marko_attr("style", _marko_style_merge({

--- a/packages/babel-plugin-marko/test/fixtures/attr-style/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-style/snapshots/translated-vdom.expected.js
@@ -4,23 +4,23 @@ import { t as _t, d as _marko_dynamicTag } from "marko/src/runtime/vdom/helpers"
 
 const _customTag_tag = _t(_customTag);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "Q4DAGn8u",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("Q4DAGn8u", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "style": _marko_style_merge({
       color: "green"
     })
-  }, "0", component, 0, 4);
+  }, "0", component, 0, 1);
   out.ee();
   out.be("div", {
     "style": "color: green"
-  }, "1", component, 0, 4);
+  }, "1", component, 0, 1);
   out.ee();
 
   _customTag_tag({

--- a/packages/babel-plugin-marko/test/fixtures/attr-style/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-style/snapshots/translated-vdom.expected.js
@@ -41,7 +41,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
         out.t("Hello");
       }
     }
-  }, out, _component, "4");
+  }, out, _component, "3");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/attr-template-literal-escape/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-template-literal-escape/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { a as _marko_attr } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "mMDF7Duo",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("mMDF7Duo", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div${_marko_attr("foo", `Hello ${input.name}`)}></div>`);

--- a/packages/babel-plugin-marko/test/fixtures/attr-template-literal-escape/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/attr-template-literal-escape/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "mMDF7Duo",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("mMDF7Duo", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {

--- a/packages/babel-plugin-marko/test/fixtures/await-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/await-tag/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ import _await from "marko/src/core-tags/core/await/renderer.js";
 
 const _await_tag = _t(_await);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "soLLeMUj",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("soLLeMUj", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _await_tag({

--- a/packages/babel-plugin-marko/test/fixtures/await-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/await-tag/snapshots/translated-html.expected.js
@@ -19,7 +19,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
         out.w(_marko_escapeXml(result));
       }
     }
-  }, out, "1");
+  }, out, "0");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/await-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/await-tag/snapshots/translated-vdom.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/vdom/helpers";
 
 const _await_tag = _t(_await);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "soLLeMUj",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("soLLeMUj", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _await_tag({

--- a/packages/babel-plugin-marko/test/fixtures/await-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/await-tag/snapshots/translated-vdom.expected.js
@@ -19,7 +19,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
         out.t(result);
       }
     }
-  }, out, "1");
+  }, out, "0");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "49meNcug",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("49meNcug", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div>Here is a CDATA section: <![CDATA[ < > & ]]> with all kinds of unescaped text.</div>");

--- a/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/cdata/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "49meNcug",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("49meNcug", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "0", component, null, 0);

--- a/packages/babel-plugin-marko/test/fixtures/class-external-component-index/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-external-component-index/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
 import _marko_component from "./component.js";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "TtHlZ7aS",
-      _marko_template = _t(__filename),
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("TtHlZ7aS", () => _marko_template),
       _marko_component2 = _marko_component;
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {

--- a/packages/babel-plugin-marko/test/fixtures/class-external-component-index/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-external-component-index/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
 import _marko_component from "./component.js";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "TtHlZ7aS",
-      _marko_template = _t(__filename),
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("TtHlZ7aS", () => _marko_template),
       _marko_component2 = _marko_component;
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {

--- a/packages/babel-plugin-marko/test/fixtures/class-external-component/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-external-component/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
 import _marko_component from "./template.component.js";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "0hrcFohB",
-      _marko_template = _t(__filename),
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("0hrcFohB", () => _marko_template),
       _marko_component2 = _marko_component;
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {

--- a/packages/babel-plugin-marko/test/fixtures/class-external-component/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-external-component/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
 import _marko_component from "./template.component.js";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "0hrcFohB",
-      _marko_template = _t(__filename),
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("0hrcFohB", () => _marko_template),
       _marko_component2 = _marko_component;
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {

--- a/packages/babel-plugin-marko/test/fixtures/class-inline-class-props-without-on-create/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-inline-class-props-without-on-create/snapshots/translated-html.expected.js
@@ -1,8 +1,8 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "ei0Mhp4E",
-      _marko_template = _t(__filename),
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("ei0Mhp4E", () => _marko_template),
       _marko_component = {
   onCreate() {
     this.x = 1

--- a/packages/babel-plugin-marko/test/fixtures/class-inline-class-props-without-on-create/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-inline-class-props-without-on-create/snapshots/translated-vdom.expected.js
@@ -1,8 +1,8 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "ei0Mhp4E",
-      _marko_template = _t(__filename),
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("ei0Mhp4E", () => _marko_template),
       _marko_component = {
   onCreate() {
     this.x = 1

--- a/packages/babel-plugin-marko/test/fixtures/class-inline/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-inline/snapshots/translated-html.expected.js
@@ -1,8 +1,8 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "rBg9zhFf",
-      _marko_template = _t(__filename),
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("rBg9zhFf", () => _marko_template),
       _marko_component = {
   onCreate() {
     this.x = 1

--- a/packages/babel-plugin-marko/test/fixtures/class-inline/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/class-inline/snapshots/translated-vdom.expected.js
@@ -1,8 +1,8 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "rBg9zhFf",
-      _marko_template = _t(__filename),
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("rBg9zhFf", () => _marko_template),
       _marko_component = {
   onCreate() {
     this.x = 1

--- a/packages/babel-plugin-marko/test/fixtures/comments/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/comments/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "cmjBZ1aK",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("cmjBZ1aK", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div><!--abc--><!--[if lt IE 9]><script src=\"...\"></script><![endif]--></div>");

--- a/packages/babel-plugin-marko/test/fixtures/comments/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/comments/snapshots/translated-vdom.expected.js
@@ -6,7 +6,7 @@ const _marko_template = _t(__filename),
       _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
-  out.be("div", null, "2", component, 0, 0);
+  out.be("div", null, "0", component, 0, 0);
   out.ee();
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/comments/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/comments/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "cmjBZ1aK",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("cmjBZ1aK", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "2", component, 0, 0);

--- a/packages/babel-plugin-marko/test/fixtures/custom-element-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-element-tag/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "TQAbtBLq",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("TQAbtBLq", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<hello></hello>");

--- a/packages/babel-plugin-marko/test/fixtures/custom-element-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-element-tag/snapshots/translated-vdom.expected.js
@@ -1,12 +1,12 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "TQAbtBLq",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("TQAbtBLq", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
-  out.be("hello", null, "0", component, 0, 16);
+  out.be("hello", null, "0", component, 0, 4);
   out.ee();
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-data/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-data/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/html/helpers";
 
 const _customTagData_tag = _t(_customTagData);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "9G-EElad",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("9G-EElad", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _customTagData_tag({

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-data/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-data/snapshots/translated-vdom.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/vdom/helpers";
 
 const _customTagData_tag = _t(_customTagData);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "9G-EElad",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("9G-EElad", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _customTagData_tag({

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ import _customTag from "./components/custom-tag.marko";
 
 const _customTag_tag = _t(_customTag);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "ZPxK-KiM",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("ZPxK-KiM", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _customTag_tag({

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-html.expected.js
@@ -17,7 +17,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     }) => {
       out.w(`<div>${_marko_escapeXml(a)} ${_marko_escapeXml(b)} ${_marko_escapeXml(c)}</div>`);
     }
-  }, out, "1");
+  }, out, "0");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-vdom.expected.js
@@ -15,7 +15,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "renderBody": (out, a, b, {
       c
     }) => {
-      out.be("div", null, "0", component, null, 0);
+      out.be("div", null, "1", component, null, 0);
       out.t(a);
       out.t(" ");
       out.t(b);
@@ -23,7 +23,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
       out.t(c);
       out.ee();
     }
-  }, out, "1");
+  }, out, "0");
 }, {
   ___type: _marko_componentType,
   ___implicit: true

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-parameters/snapshots/translated-vdom.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/vdom/helpers";
 
 const _customTag_tag = _t(_customTag);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "ZPxK-KiM",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("ZPxK-KiM", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _customTag_tag({

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-render-body/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-render-body/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/html/helpers";
 
 const _testBodyFunction_tag = _t(_testBodyFunction);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "2EFrUtzo",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("2EFrUtzo", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _testBodyFunction_tag({

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-render-body/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-render-body/snapshots/translated-vdom.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/vdom/helpers";
 
 const _testBodyFunction_tag = _t(_testBodyFunction);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "2EFrUtzo",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("2EFrUtzo", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _testBodyFunction_tag({

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-separate-assets/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-separate-assets/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
 import _marko_component from "./template.component.js";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "VBJ9cK7S",
-      _marko_template = _t(__filename),
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("VBJ9cK7S", () => _marko_template),
       _marko_component2 = _marko_component;
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-separate-assets/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-separate-assets/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
 import _marko_component from "./template.component.js";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "VBJ9cK7S",
-      _marko_template = _t(__filename),
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("VBJ9cK7S", () => _marko_template),
       _marko_component2 = _marko_component;
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-template/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-template/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/html/helpers";
 
 const _hello_tag = _t(_hello);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "OYtT0PES",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("OYtT0PES", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _hello_tag({

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag-template/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag-template/snapshots/translated-vdom.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/vdom/helpers";
 
 const _hello_tag = _t(_hello);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "OYtT0PES",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("OYtT0PES", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _hello_tag({

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/html/helpers";
 
 const _testHello_tag = _t(_testHello);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "J6ObXtms",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("J6ObXtms", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _testHello_tag({

--- a/packages/babel-plugin-marko/test/fixtures/custom-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/custom-tag/snapshots/translated-vdom.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/vdom/helpers";
 
 const _testHello_tag = _t(_testHello);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "J6ObXtms",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("J6ObXtms", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   _testHello_tag({

--- a/packages/babel-plugin-marko/test/fixtures/data-marko-implicit-component/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/data-marko-implicit-component/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { x as _marko_escapeXml, a as _marko_attr } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "QHrSVmWi",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("QHrSVmWi", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div class="test"${_marko_attr("data-marko", {

--- a/packages/babel-plugin-marko/test/fixtures/data-marko-implicit-component/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/data-marko-implicit-component/snapshots/translated-vdom.expected.js
@@ -1,10 +1,10 @@
 import "marko/src/runtime/vdom/preserve-attrs";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "QHrSVmWi",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("QHrSVmWi", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {

--- a/packages/babel-plugin-marko/test/fixtures/declaration/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/declaration/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "wx7UfmNS",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("wx7UfmNS", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<?xml version=\"1.0\" encoding=\"utf-8\"?><contact-info><name>Hello World</name></contact-info>");

--- a/packages/babel-plugin-marko/test/fixtures/declaration/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/declaration/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "wx7UfmNS",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("wx7UfmNS", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("contact-info", null, "1", component, null, 0);

--- a/packages/babel-plugin-marko/test/fixtures/declaration/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/declaration/snapshots/translated-vdom.expected.js
@@ -6,8 +6,8 @@ const _marko_template = _t(__filename),
       _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
-  out.be("contact-info", null, "1", component, null, 0);
-  out.be("name", null, "0", component, null, 0);
+  out.be("contact-info", null, "0", component, null, 0);
+  out.be("name", null, "1", component, null, 0);
   out.t("Hello World");
   out.ee();
   out.ee();

--- a/packages/babel-plugin-marko/test/fixtures/doctype/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/doctype/snapshots/translated-html.expected.js
@@ -21,13 +21,13 @@ const _marko_template = _t2(__filename),
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<!DOCTYPE html><html><head><title>Title of the document</title></head><body>");
 
-  _componentGlobals_tag({}, out, "2");
+  _componentGlobals_tag({}, out, "4");
 
   out.w("The content of the document......");
 
-  _initComponents_tag({}, out, "3");
+  _initComponents_tag({}, out, "5");
 
-  _awaitReorderer_tag({}, out, "4");
+  _awaitReorderer_tag({}, out, "6");
 
   out.w("</body></html>");
 }, {

--- a/packages/babel-plugin-marko/test/fixtures/doctype/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/doctype/snapshots/translated-html.expected.js
@@ -11,12 +11,12 @@ import _awaitReorderer from "marko/src/core-tags/core/await/reorderer-renderer.j
 
 const _awaitReorderer_tag = _t(_awaitReorderer);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "Fr76d7a7",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("Fr76d7a7", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<!DOCTYPE html><html><head><title>Title of the document</title></head><body>");

--- a/packages/babel-plugin-marko/test/fixtures/doctype/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/doctype/snapshots/translated-vdom.expected.js
@@ -19,21 +19,21 @@ const _marko_template = _t2(__filename),
       _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
-  out.be("html", null, "6", component, null, 0);
+  out.be("html", null, "0", component, null, 0);
   out.be("head", null, "1", component, null, 0);
-  out.be("title", null, "0", component, null, 0);
+  out.be("title", null, "2", component, null, 0);
   out.t("Title of the document");
   out.ee();
   out.ee();
-  out.be("body", null, "5", component, null, 0);
+  out.be("body", null, "3", component, null, 0);
 
-  _componentGlobals_tag({}, out, "2");
+  _componentGlobals_tag({}, out, "4");
 
   out.t("The content of the document......");
 
-  _initComponents_tag({}, out, "3");
+  _initComponents_tag({}, out, "5");
 
-  _awaitReorderer_tag({}, out, "4");
+  _awaitReorderer_tag({}, out, "6");
 
   out.ee();
   out.ee();

--- a/packages/babel-plugin-marko/test/fixtures/doctype/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/doctype/snapshots/translated-vdom.expected.js
@@ -11,12 +11,12 @@ import _awaitReorderer from "marko/src/core-tags/core/await/reorderer-renderer.j
 
 const _awaitReorderer_tag = _t(_awaitReorderer);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "Fr76d7a7",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("Fr76d7a7", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("html", null, "6", component, null, 0);

--- a/packages/babel-plugin-marko/test/fixtures/entities/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/entities/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "OLzQeSa9",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("OLzQeSa9", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("Hello John &amp; Suzy Invalid Entity: &b ; Valid Numeric Entity: &#34; Valid Hexadecimal Entity: &#x00A2;");

--- a/packages/babel-plugin-marko/test/fixtures/entities/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/entities/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "OLzQeSa9",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("OLzQeSa9", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.t("Hello John &amp; Suzy Invalid Entity: &b ; Valid Numeric Entity: &#34; Valid Hexadecimal Entity: &#x00A2;");

--- a/packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/snapshots/translated-html-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/snapshots/translated-html-error.expected.txt
@@ -1,3 +1,3 @@
-packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point for custom tag.
+packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point for custom tag <thing>.
 > 1 | <thing/>
     |  ^^^^^

--- a/packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/snapshots/translated-html-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/snapshots/translated-html-error.expected.txt
@@ -1,3 +1,3 @@
-packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point tag.
+packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point for custom tag.
 > 1 | <thing/>
     |  ^^^^^

--- a/packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/snapshots/translated-vdom-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/snapshots/translated-vdom-error.expected.txt
@@ -1,3 +1,3 @@
-packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point for custom tag.
+packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point for custom tag <thing>.
 > 1 | <thing/>
     |  ^^^^^

--- a/packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/snapshots/translated-vdom-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/snapshots/translated-vdom-error.expected.txt
@@ -1,3 +1,3 @@
-packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point tag.
+packages/babel-plugin-marko/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point for custom tag.
 > 1 | <thing/>
     |  ^^^^^

--- a/packages/babel-plugin-marko/test/fixtures/error-missing-entry-marko-json/snapshots/translated-html-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/error-missing-entry-marko-json/snapshots/translated-html-error.expected.txt
@@ -1,3 +1,3 @@
-packages/babel-plugin-marko/test/fixtures/error-missing-entry-marko-json/template.marko(1,2): Could not find custom tag "some-tag".
+packages/babel-plugin-marko/test/fixtures/error-missing-entry-marko-json/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
 > 1 | <some-tag/>
     |  ^^^^^^^^

--- a/packages/babel-plugin-marko/test/fixtures/error-missing-entry-marko-json/snapshots/translated-vdom-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/error-missing-entry-marko-json/snapshots/translated-vdom-error.expected.txt
@@ -1,3 +1,3 @@
-packages/babel-plugin-marko/test/fixtures/error-missing-entry-marko-json/template.marko(1,2): Could not find custom tag "some-tag".
+packages/babel-plugin-marko/test/fixtures/error-missing-entry-marko-json/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
 > 1 | <some-tag/>
     |  ^^^^^^^^

--- a/packages/babel-plugin-marko/test/fixtures/error-unknown-tag/snapshots/translated-html-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/error-unknown-tag/snapshots/translated-html-error.expected.txt
@@ -1,3 +1,3 @@
-packages/babel-plugin-marko/test/fixtures/error-unknown-tag/template.marko(1,2): Could not find custom tag "some-tag".
+packages/babel-plugin-marko/test/fixtures/error-unknown-tag/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
 > 1 | <some-tag/>
     |  ^^^^^^^^

--- a/packages/babel-plugin-marko/test/fixtures/error-unknown-tag/snapshots/translated-vdom-error.expected.txt
+++ b/packages/babel-plugin-marko/test/fixtures/error-unknown-tag/snapshots/translated-vdom-error.expected.txt
@@ -1,3 +1,3 @@
-packages/babel-plugin-marko/test/fixtures/error-unknown-tag/template.marko(1,2): Could not find custom tag "some-tag".
+packages/babel-plugin-marko/test/fixtures/error-unknown-tag/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
 > 1 | <some-tag/>
     |  ^^^^^^^^

--- a/packages/babel-plugin-marko/test/fixtures/event-handlers/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/event-handlers/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ import _customTag from "./components/custom-tag.marko";
 
 const _customTag_tag = _t(_customTag);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "SSsZKEJG",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("SSsZKEJG", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div${_marko_attr("data-marko", {

--- a/packages/babel-plugin-marko/test/fixtures/event-handlers/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/event-handlers/snapshots/translated-vdom.expected.js
@@ -3,12 +3,12 @@ import { t as _t } from "marko/src/runtime/vdom/helpers";
 
 const _customTag_tag = _t(_customTag);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "SSsZKEJG",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("SSsZKEJG", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "0", component, 0, 0, {

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/generated.expected.marko
@@ -1,15 +1,51 @@
+<!-- without keys -->
 <for|val, i| of=arr>
   <div>
     ${i}: ${val}
   </div>
+  <div/>
+  <div/>
 </for>
 <for|key, val| in=obj>
   <div>
     ${key}: ${val}
   </div>
+  <div/>
+  <div/>
 </for>
 <for|i| from=0 to=10 step=2>
   <div>
     ${i}
   </div>
+  <div/>
+  <div/>
+</for>
+<!-- with keys -->
+<for|val, i| of=arr>
+  <div key=i>
+    ${i}: ${val}
+  </div>
+  <div/>
+  <div key=`other-${i}`/>
+</for>
+<for|key, val| in=obj>
+  <div key=key>
+    ${key}: ${val}
+  </div>
+  <div/>
+  <div key=`other-${key}`/>
+</for>
+<for|i| from=0 to=10 step=2>
+  <div key=i>
+    ${i}
+  </div>
+  <div/>
+  <div key=`other-${i}`/>
+  <for|i| from=0 to=10 step=2>
+    <div key=i>
+      ${i}
+    </div>
+    <div/>
+    <div key=`other-${i}`/>
+  </for>
 </for>

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-html.expected.js
@@ -28,24 +28,20 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   for (const val of arr) {
     let i = _i3++;
-    const _loopKey = `@${i}`;
     out.w(`<div>${_marko_escapeXml(i)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
   }
 
   for (const key in obj) {
     const val = obj[key];
-    const _loopKey2 = `@${key}`;
     out.w(`<div>${_marko_escapeXml(key)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
   }
 
   for (let _i5 = 0; _i5 <= 10; _i5 += 2) {
     const i = _i5;
-    const _loopKey3 = `@${i}`;
     out.w(`<div>${_marko_escapeXml(i)}</div><div></div><div></div>`);
 
     for (let _i4 = 0; _i4 <= 10; _i4 += 2) {
       const i = _i4;
-      const _loopKey4 = `@${i}`;
       out.w(`<div>${_marko_escapeXml(i)}</div><div></div><div></div>`);
     }
   }

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-html.expected.js
@@ -1,27 +1,53 @@
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "lqIjMHgX",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("lqIjMHgX", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   let _i = -1;
 
   for (const val of arr) {
     let i = _i++;
-    out.w(`<div>${_marko_escapeXml(i)}: ${_marko_escapeXml(val)}</div>`);
+    out.w(`<div>${_marko_escapeXml(i)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
   }
 
   for (const key in obj) {
     const val = obj[key];
-    out.w(`<div>${_marko_escapeXml(key)}: ${_marko_escapeXml(val)}</div>`);
+    out.w(`<div>${_marko_escapeXml(key)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
   }
 
   for (let _i2 = 0; _i2 <= 10; _i2 += 2) {
     const i = _i2;
-    out.w(`<div>${_marko_escapeXml(i)}</div>`);
+    out.w(`<div>${_marko_escapeXml(i)}</div><div></div><div></div>`);
+  }
+
+  let _i3 = -1;
+
+  for (const val of arr) {
+    let i = _i3++;
+    const _loopKey = `@${i}`;
+    out.w(`<div>${_marko_escapeXml(i)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
+  }
+
+  for (const key in obj) {
+    const val = obj[key];
+    const _loopKey2 = `@${key}`;
+    out.w(`<div>${_marko_escapeXml(key)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
+  }
+
+  for (let _i5 = 0; _i5 <= 10; _i5 += 2) {
+    const i = _i5;
+    const _loopKey3 = `@${i}`;
+    out.w(`<div>${_marko_escapeXml(i)}</div><div></div><div></div>`);
+
+    for (let _i4 = 0; _i4 <= 10; _i4 += 2) {
+      const i = _i4;
+      const _loopKey4 = `@${i}`;
+      out.w(`<div>${_marko_escapeXml(i)}</div><div></div><div></div>`);
+    }
   }
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-vdom.expected.js
@@ -10,38 +10,38 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   for (const val of arr) {
     let i = _i++;
-    out.be("div", null, "0", component, null, 0);
+    out.be("div", null, "1", component, null, 0);
     out.t(i);
     out.t(": ");
     out.t(val);
     out.ee();
-    out.be("div", null, "1", component, 0, 0);
-    out.ee();
     out.be("div", null, "2", component, 0, 0);
+    out.ee();
+    out.be("div", null, "3", component, 0, 0);
     out.ee();
   }
 
   for (const key in obj) {
     const val = obj[key];
-    out.be("div", null, "4", component, null, 0);
+    out.be("div", null, "5", component, null, 0);
     out.t(key);
     out.t(": ");
     out.t(val);
     out.ee();
-    out.be("div", null, "5", component, 0, 0);
-    out.ee();
     out.be("div", null, "6", component, 0, 0);
+    out.ee();
+    out.be("div", null, "7", component, 0, 0);
     out.ee();
   }
 
   for (let _i2 = 0; _i2 <= 10; _i2 += 2) {
     const i = _i2;
-    out.be("div", null, "8", component, null, 0);
+    out.be("div", null, "9", component, null, 0);
     out.t(i);
     out.ee();
-    out.be("div", null, "9", component, 0, 0);
-    out.ee();
     out.be("div", null, "10", component, 0, 0);
+    out.ee();
+    out.be("div", null, "11", component, 0, 0);
     out.ee();
   }
 
@@ -49,13 +49,12 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   for (const val of arr) {
     let i = _i3++;
-    const _loopKey = `@${i}`;
-    out.be("div", null, _loopKey, component, null, 0);
+    out.be("div", null, `@${i}`, component, null, 0);
     out.t(i);
     out.t(": ");
     out.t(val);
     out.ee();
-    out.be("div", null, `12[${_loopKey}]`, component, 0, 0);
+    out.be("div", null, "14", component, 0, 0);
     out.ee();
     out.be("div", null, `@other-${i}`, component, 0, 0);
     out.ee();
@@ -63,13 +62,12 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   for (const key in obj) {
     const val = obj[key];
-    const _loopKey2 = `@${key}`;
-    out.be("div", null, _loopKey2, component, null, 0);
+    out.be("div", null, `@${key}`, component, null, 0);
     out.t(key);
     out.t(": ");
     out.t(val);
     out.ee();
-    out.be("div", null, `14[${_loopKey2}]`, component, 0, 0);
+    out.be("div", null, "18", component, 0, 0);
     out.ee();
     out.be("div", null, `@other-${key}`, component, 0, 0);
     out.ee();
@@ -77,22 +75,20 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   for (let _i5 = 0; _i5 <= 10; _i5 += 2) {
     const i = _i5;
-    const _loopKey3 = `@${i}`;
-    out.be("div", null, _loopKey3, component, null, 0);
+    out.be("div", null, `@${i}`, component, null, 0);
     out.t(i);
     out.ee();
-    out.be("div", null, `16[${_loopKey3}]`, component, 0, 0);
+    out.be("div", null, "22", component, 0, 0);
     out.ee();
     out.be("div", null, `@other-${i}`, component, 0, 0);
     out.ee();
 
     for (let _i4 = 0; _i4 <= 10; _i4 += 2) {
       const i = _i4;
-      const _loopKey4 = `@${i}`;
-      out.be("div", null, _loopKey4, component, null, 0);
+      out.be("div", null, `@${i}`, component, null, 0);
       out.t(i);
       out.ee();
-      out.be("div", null, `17[${_loopKey3}][${_loopKey4}]`, component, 0, 0);
+      out.be("div", null, "26", component, 0, 0);
       out.ee();
       out.be("div", null, `@other-${i}`, component, 0, 0);
       out.ee();

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "lqIjMHgX",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("lqIjMHgX", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   let _i = -1;
@@ -15,22 +15,88 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     out.t(": ");
     out.t(val);
     out.ee();
+    out.be("div", null, "1", component, 0, 0);
+    out.ee();
+    out.be("div", null, "2", component, 0, 0);
+    out.ee();
   }
 
   for (const key in obj) {
     const val = obj[key];
-    out.be("div", null, "2", component, null, 0);
+    out.be("div", null, "4", component, null, 0);
     out.t(key);
     out.t(": ");
     out.t(val);
+    out.ee();
+    out.be("div", null, "5", component, 0, 0);
+    out.ee();
+    out.be("div", null, "6", component, 0, 0);
     out.ee();
   }
 
   for (let _i2 = 0; _i2 <= 10; _i2 += 2) {
     const i = _i2;
-    out.be("div", null, "4", component, null, 0);
+    out.be("div", null, "8", component, null, 0);
     out.t(i);
     out.ee();
+    out.be("div", null, "9", component, 0, 0);
+    out.ee();
+    out.be("div", null, "10", component, 0, 0);
+    out.ee();
+  }
+
+  let _i3 = -1;
+
+  for (const val of arr) {
+    let i = _i3++;
+    const _loopKey = `@${i}`;
+    out.be("div", null, _loopKey, component, null, 0);
+    out.t(i);
+    out.t(": ");
+    out.t(val);
+    out.ee();
+    out.be("div", null, `12[${_loopKey}]`, component, 0, 0);
+    out.ee();
+    out.be("div", null, `@other-${i}`, component, 0, 0);
+    out.ee();
+  }
+
+  for (const key in obj) {
+    const val = obj[key];
+    const _loopKey2 = `@${key}`;
+    out.be("div", null, _loopKey2, component, null, 0);
+    out.t(key);
+    out.t(": ");
+    out.t(val);
+    out.ee();
+    out.be("div", null, `14[${_loopKey2}]`, component, 0, 0);
+    out.ee();
+    out.be("div", null, `@other-${key}`, component, 0, 0);
+    out.ee();
+  }
+
+  for (let _i5 = 0; _i5 <= 10; _i5 += 2) {
+    const i = _i5;
+    const _loopKey3 = `@${i}`;
+    out.be("div", null, _loopKey3, component, null, 0);
+    out.t(i);
+    out.ee();
+    out.be("div", null, `16[${_loopKey3}]`, component, 0, 0);
+    out.ee();
+    out.be("div", null, `@other-${i}`, component, 0, 0);
+    out.ee();
+
+    for (let _i4 = 0; _i4 <= 10; _i4 += 2) {
+      const i = _i4;
+      const _loopKey4 = `@${i}`;
+      out.be("div", null, _loopKey4, component, null, 0);
+      out.t(i);
+      out.ee();
+      out.be("div", null, `17[${_loopKey3}][${_loopKey4}]`, component, 0, 0);
+      out.ee();
+      out.be("div", null, `@other-${i}`, component, 0, 0);
+      out.ee();
+    }
   }
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/template.marko
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/template.marko
@@ -1,11 +1,42 @@
+<!-- without keys -->
 <for|val, i| of=arr>
   <div>${i}: ${val}</div>
+  <div/>
+  <div/>
 </for>
 
 <for|key, val| in=obj>
   <div>${key}: ${val}</div>
+  <div/>
+  <div/>
 </for>
 
 <for|i| from=0 to=10 step=2>
   <div>${i}</div>
+  <div/>
+  <div/>
+</for>
+
+<!-- with keys -->
+<for|val, i| of=arr>
+  <div key=i>${i}: ${val}</div>
+  <div/>
+  <div key=`other-${i}`/>
+</for>
+
+<for|key, val| in=obj>
+  <div key=key>${key}: ${val}</div>
+  <div/>
+  <div key=`other-${key}`/>
+</for>
+
+<for|i| from=0 to=10 step=2>
+  <div key=i>${i}</div>
+  <div/>
+  <div key=`other-${i}`/>
+<for|i| from=0 to=10 step=2>
+  <div key=i>${i}</div>
+  <div/>
+  <div key=`other-${i}`/>
+</for>
 </for>

--- a/packages/babel-plugin-marko/test/fixtures/hello-dynamic/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/hello-dynamic/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "Lt7mJiby",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("Lt7mJiby", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`Hello ${_marko_escapeXml(input.name)}! Hello ${input.name}! Hello ${input.missing}!`);

--- a/packages/babel-plugin-marko/test/fixtures/hello-dynamic/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/hello-dynamic/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "Lt7mJiby",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("Lt7mJiby", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.t("Hello ");

--- a/packages/babel-plugin-marko/test/fixtures/html-comment/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/html-comment/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "Vfg6Efpl",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("Vfg6Efpl", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<!--test-->");

--- a/packages/babel-plugin-marko/test/fixtures/html-comment/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/html-comment/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "Vfg6Efpl",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("Vfg6Efpl", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/if-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/if-tag/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "lYKPsINJ",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("lYKPsINJ", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   if (a + b) {

--- a/packages/babel-plugin-marko/test/fixtures/if-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/if-tag/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "lYKPsINJ",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("lYKPsINJ", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   if (a + b) {

--- a/packages/babel-plugin-marko/test/fixtures/if-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/if-tag/snapshots/translated-vdom.expected.js
@@ -14,7 +14,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     out.t("World");
   }
 
-  out.be("div", null, "5", component, null, 0);
+  out.be("div", null, "2", component, null, 0);
 
   if (x) {
     out.t("A");

--- a/packages/babel-plugin-marko/test/fixtures/import-tag-conflict/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/import-tag-conflict/snapshots/translated-html.expected.js
@@ -1,11 +1,11 @@
 import { asset as test } from "./test1/asset";
 import { asset } from "./test2/asset";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "0kf6vBvn",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("0kf6vBvn", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/import-tag-conflict/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/import-tag-conflict/snapshots/translated-vdom.expected.js
@@ -1,11 +1,11 @@
 import { asset as test } from "./test1/asset";
 import { asset } from "./test2/asset";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "0kf6vBvn",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("0kf6vBvn", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/import-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/import-tag/snapshots/translated-html.expected.js
@@ -1,11 +1,11 @@
 import bar, { f as foo } from "./bar";
 import "./foo";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "bMwM8SrD",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("bMwM8SrD", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/import-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/import-tag/snapshots/translated-vdom.expected.js
@@ -1,11 +1,11 @@
 import bar, { f as foo } from "./bar";
 import "./foo";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "bMwM8SrD",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("bMwM8SrD", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-html.expected.js
@@ -17,7 +17,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
         out.w("<li>");
 
         _marko_dynamicTag(_renderTree, { ...child
-        }, out, _component, "0");
+        }, out, _component, "5");
 
         out.w("</li>");
       }

--- a/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { x as _marko_escapeXml, d as _marko_dynamicTag } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "9QKeN8cm",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("9QKeN8cm", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   function _renderTree(node, out) {

--- a/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-vdom.expected.js
@@ -1,10 +1,10 @@
 import { d as _marko_dynamicTag } from "marko/src/runtime/vdom/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "9QKeN8cm",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("9QKeN8cm", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   function _renderTree(node, out) {

--- a/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/macros/snapshots/translated-vdom.expected.js
@@ -13,13 +13,13 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     out.t(" Children: ");
 
     if (node.children) {
-      out.be("ul", null, "3", component, null, 0);
+      out.be("ul", null, "2", component, null, 0);
 
       for (const child of node.children) {
-        out.be("li", null, "1", component, null, 0);
+        out.be("li", null, "4", component, null, 0);
 
         _marko_dynamicTag(_renderTree, { ...child
-        }, out, _component, "0");
+        }, out, _component, "5");
 
         out.ee();
       }

--- a/packages/babel-plugin-marko/test/fixtures/no-update-directives/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-directives/snapshots/translated-html.expected.js
@@ -7,12 +7,12 @@ import _hello from "./components/hello/index.marko";
 
 const _hello_tag = _t(_hello);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "FaQWPoit",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("FaQWPoit", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   const _noUpdateKey = _component.___nextKey("0");

--- a/packages/babel-plugin-marko/test/fixtures/no-update-directives/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-directives/snapshots/translated-html.expected.js
@@ -1,11 +1,11 @@
-import _noUpdate from "marko/src/core-tags/components/preserve-tag.js";
+import _hello from "./components/hello/index.marko";
 import { t as _t } from "marko/src/runtime/html/helpers";
 
-const _noUpdate_tag = _t(_noUpdate);
-
-import _hello from "./components/hello/index.marko";
-
 const _hello_tag = _t(_hello);
+
+import _noUpdate from "marko/src/core-tags/components/preserve-tag.js";
+
+const _noUpdate_tag = _t(_noUpdate);
 
 import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
@@ -26,11 +26,11 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
           out.w("<div></div>");
         }
-      }, out, "3");
+      }, out, "0");
     }
   }, out, `#${_noUpdateKey}`);
 
-  const _noUpdateKey2 = _component.___nextKey("4");
+  const _noUpdateKey2 = _component.___nextKey("3");
 
   _noUpdate_tag({
     "cid": _noUpdateKey2,
@@ -38,23 +38,23 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "renderBody": out => {
       _hello_tag({
         "renderBody": out => {
-          const _noUpdateKey3 = _component.___nextKey("5");
+          const _noUpdateKey3 = _component.___nextKey("4");
 
           _noUpdate_tag({
             "cid": _noUpdateKey3,
             "if": (a, b),
             "renderBody": out => {
-              _hello_tag({}, out, "6");
+              _hello_tag({}, out, "4");
             }
           }, out, `#${_noUpdateKey3}`);
 
           out.w("<div></div>");
         }
-      }, out, "8");
+      }, out, "3");
     }
   }, out, `#${_noUpdateKey2}`);
 
-  const _noUpdateKey4 = _component.___nextKey("9");
+  const _noUpdateKey4 = _component.___nextKey("6");
 
   _noUpdate_tag({
     "cid": _noUpdateKey4,
@@ -62,15 +62,15 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "renderBody": out => {
       _hello_tag({
         "renderBody": out => {
-          _hello_tag({}, out, "10");
+          _hello_tag({}, out, "7");
 
           out.w("<div></div>");
         }
-      }, out, "12");
+      }, out, "6");
     }
   }, out, `#${_noUpdateKey4}`);
 
-  const _noUpdateKey5 = _component.___nextKey("13");
+  const _noUpdateKey5 = _component.___nextKey("9");
 
   _noUpdate_tag({
     "cid": _noUpdateKey5,
@@ -79,7 +79,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "renderBody": out => {
       _hello_tag({
         "renderBody": out => {
-          const _noUpdateKey6 = _component.___nextKey("14");
+          const _noUpdateKey6 = _component.___nextKey("10");
 
           _noUpdate_tag({
             "cid": _noUpdateKey6,
@@ -90,13 +90,13 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
                 "renderBody": out => {
                   out.w("Again");
                 }
-              }, out, "15");
+              }, out, "10");
             }
           }, out, `#${_noUpdateKey6}`);
 
           out.w("<div></div>");
         }
-      }, out, "17");
+      }, out, "9");
     }
   }, out, `#${_noUpdateKey5}`);
 }, {
@@ -106,6 +106,6 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 _marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);
 _marko_template.meta = {
   id: _marko_componentType,
-  tags: ["marko/src/core-tags/components/preserve-tag.js", "./components/hello/index.marko"]
+  tags: ["./components/hello/index.marko", "marko/src/core-tags/components/preserve-tag.js"]
 };
 export default _marko_template;

--- a/packages/babel-plugin-marko/test/fixtures/no-update-directives/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-directives/snapshots/translated-vdom.expected.js
@@ -1,11 +1,11 @@
-import _noUpdate from "marko/src/core-tags/components/preserve-tag.js";
+import _hello from "./components/hello/index.marko";
 import { t as _t } from "marko/src/runtime/vdom/helpers";
 
-const _noUpdate_tag = _t(_noUpdate);
-
-import _hello from "./components/hello/index.marko";
-
 const _hello_tag = _t(_hello);
+
+import _noUpdate from "marko/src/core-tags/components/preserve-tag.js";
+
+const _noUpdate_tag = _t(_noUpdate);
 
 import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
@@ -27,11 +27,11 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
           out.be("div", null, "2", component, 0, 0);
           out.ee();
         }
-      }, out, "3");
+      }, out, "0");
     }
   }, out, `#${_noUpdateKey}`);
 
-  const _noUpdateKey2 = _component.___nextKey("4");
+  const _noUpdateKey2 = _component.___nextKey("3");
 
   _noUpdate_tag({
     "cid": _noUpdateKey2,
@@ -39,24 +39,24 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "renderBody": out => {
       _hello_tag({
         "renderBody": out => {
-          const _noUpdateKey3 = _component.___nextKey("5");
+          const _noUpdateKey3 = _component.___nextKey("4");
 
           _noUpdate_tag({
             "cid": _noUpdateKey3,
             "if": (a, b),
             "renderBody": out => {
-              _hello_tag({}, out, "6");
+              _hello_tag({}, out, "4");
             }
           }, out, `#${_noUpdateKey3}`);
 
-          out.be("div", null, "7", component, 0, 0);
+          out.be("div", null, "5", component, 0, 0);
           out.ee();
         }
-      }, out, "8");
+      }, out, "3");
     }
   }, out, `#${_noUpdateKey2}`);
 
-  const _noUpdateKey4 = _component.___nextKey("9");
+  const _noUpdateKey4 = _component.___nextKey("6");
 
   _noUpdate_tag({
     "cid": _noUpdateKey4,
@@ -64,16 +64,16 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "renderBody": out => {
       _hello_tag({
         "renderBody": out => {
-          _hello_tag({}, out, "10");
+          _hello_tag({}, out, "7");
 
-          out.be("div", null, "11", component, 0, 0);
+          out.be("div", null, "8", component, 0, 0);
           out.ee();
         }
-      }, out, "12");
+      }, out, "6");
     }
   }, out, `#${_noUpdateKey4}`);
 
-  const _noUpdateKey5 = _component.___nextKey("13");
+  const _noUpdateKey5 = _component.___nextKey("9");
 
   _noUpdate_tag({
     "cid": _noUpdateKey5,
@@ -82,7 +82,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "renderBody": out => {
       _hello_tag({
         "renderBody": out => {
-          const _noUpdateKey6 = _component.___nextKey("14");
+          const _noUpdateKey6 = _component.___nextKey("10");
 
           _noUpdate_tag({
             "cid": _noUpdateKey6,
@@ -93,14 +93,14 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
                 "renderBody": out => {
                   out.t("Again");
                 }
-              }, out, "15");
+              }, out, "10");
             }
           }, out, `#${_noUpdateKey6}`);
 
-          out.be("div", null, "16", component, 0, 0);
+          out.be("div", null, "11", component, 0, 0);
           out.ee();
         }
-      }, out, "17");
+      }, out, "9");
     }
   }, out, `#${_noUpdateKey5}`);
 }, {
@@ -110,6 +110,6 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 _marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);
 _marko_template.meta = {
   id: _marko_componentType,
-  tags: ["marko/src/core-tags/components/preserve-tag.js", "./components/hello/index.marko"]
+  tags: ["./components/hello/index.marko", "marko/src/core-tags/components/preserve-tag.js"]
 };
 export default _marko_template;

--- a/packages/babel-plugin-marko/test/fixtures/no-update-directives/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-directives/snapshots/translated-vdom.expected.js
@@ -7,12 +7,12 @@ import _hello from "./components/hello/index.marko";
 
 const _hello_tag = _t(_hello);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "FaQWPoit",
-      _marko_template = _t2(__filename),
-      _marko_component = null;
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("FaQWPoit", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   const _noUpdateKey = _component.___nextKey("0");

--- a/packages/babel-plugin-marko/test/fixtures/no-update-modifier-multiple/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-modifier-multiple/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { a as _marko_attr } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "i58_DLy_",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("i58_DLy_", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div><input${_marko_attr("value", input.defaultValue)}${_marko_attr("data-marko", {

--- a/packages/babel-plugin-marko/test/fixtures/no-update-modifier-multiple/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-modifier-multiple/snapshots/translated-vdom.expected.js
@@ -1,10 +1,10 @@
 import "marko/src/runtime/vdom/preserve-attrs";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "i58_DLy_",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("i58_DLy_", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "2", component, null, 0);

--- a/packages/babel-plugin-marko/test/fixtures/no-update-modifier-multiple/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-modifier-multiple/snapshots/translated-vdom.expected.js
@@ -7,17 +7,17 @@ const _marko_template = _t(__filename),
       _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
-  out.be("div", null, "2", component, null, 0);
+  out.be("div", null, "0", component, null, 0);
   out.e("input", {
     "value": input.defaultValue
-  }, "0", component, 0, 0, {
+  }, "1", component, 0, 0, {
     noupdate: ["value"]
   });
   out.e("input", {
     "type": "checkbox",
     "value": input.defaultValue,
     "checked": input.checked
-  }, "1", component, 0, 0, {
+  }, "2", component, 0, 0, {
     noupdate: ["value", "checked"]
   });
   out.ee();

--- a/packages/babel-plugin-marko/test/fixtures/no-update-modifier/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-modifier/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { a as _marko_attr } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "AwMFg6kF",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("AwMFg6kF", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<input${_marko_attr("value", input.defaultValue)}${_marko_attr("data-marko", {

--- a/packages/babel-plugin-marko/test/fixtures/no-update-modifier/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/no-update-modifier/snapshots/translated-vdom.expected.js
@@ -1,10 +1,10 @@
 import "marko/src/runtime/vdom/preserve-attrs";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "AwMFg6kF",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("AwMFg6kF", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.e("input", {

--- a/packages/babel-plugin-marko/test/fixtures/prevent-override-component-def/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/prevent-override-component-def/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "yxFtiAwF",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("yxFtiAwF", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component2, component, state) {
   const _component = "test";

--- a/packages/babel-plugin-marko/test/fixtures/prevent-override-component-def/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/prevent-override-component-def/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "yxFtiAwF",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("yxFtiAwF", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component2, component, state) {
   const _component = "test";

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
@@ -62,7 +62,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   _marko_dynamicTag(_thing, {
     "x": 1
-  }, out, _component, "12");
+  }, out, _component, "13");
 
   _other_tag({
     "renderBody": (out, a) => {
@@ -92,7 +92,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "renderBody": (out, b) => {
       out.w("<div></div>");
     }
-  }, out, "20");
+  }, out, "16");
 
   out.w(`<div id="a" class="b c" a="[object Object]" c="${d}"${_marko_attrs(e)}${_marko_attrs(f())}>${_marko_escapeXml(a)}<!--abc--><div c="1"></div><div d="1"></div>`);
 

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
@@ -12,11 +12,11 @@ import _other from "./components/other/index.marko";
 
 const _other_tag = _t(_other);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/html";
 
-const _marko_componentType = "8f1lFGb_",
-      _marko_template = _t2(__filename),
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("8f1lFGb_", () => _marko_template),
       _marko_component = {
   onCreate() {
     this.stuff();

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
@@ -42,7 +42,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   function _thing(stuff, out) {
     out.be("div", {
       "x": stuff.x
-    }, "3", component, 0, 0);
+    }, "4", component, 0, 0);
     out.ee();
   }
 
@@ -51,14 +51,14 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   out.be("div", {
     "b": b,
     "c": c
-  }, "6", component, null, 0);
+  }, "5", component, null, 0);
   {
     var d = thing;
     let e = thing;
     out.be("div", {
       "d": d,
       "e": e
-    }, "5", component, 0, 0);
+    }, "6", component, 0, 0);
     out.ee();
   }
   out.ee();
@@ -86,18 +86,18 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   _marko_dynamicTag(a, {
     "renderBody": out => {
-      out.be("div", null, "11", component, 0, 0);
+      out.be("div", null, "12", component, 0, 0);
       out.ee();
     }
   }, out, _component, "@x");
 
   _marko_dynamicTag(_thing, {
     "x": 1
-  }, out, _component, "12");
+  }, out, _component, "13");
 
   _other_tag({
     "renderBody": (out, a) => {
-      out.be("div", null, "13", component, 0, 0);
+      out.be("div", null, "15", component, 0, 0);
       out.ee();
     }
   }, out, "14", ["click", "handleClick", false, [a, b, ...d]]);
@@ -114,20 +114,20 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
       "d": {
         "d": 1,
         "renderBody": out => {
-          out.be("div", null, "17", component, 0, 0);
+          out.be("div", null, "21", component, 0, 0);
           out.ee();
         }
       },
       "renderBody": out => {
-        out.be("div", null, "16", component, 0, 0);
+        out.be("div", null, "19", component, 0, 0);
         out.ee();
       }
     },
     "renderBody": (out, b) => {
-      out.be("div", null, "15", component, 0, 0);
+      out.be("div", null, "17", component, 0, 0);
       out.ee();
     }
-  }, out, "20");
+  }, out, "16");
 
   out.be("div", {
     "id": "a",
@@ -138,15 +138,15 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "c": "${d}",
     ...e,
     ...f()
-  }, "27", component, null, 0);
+  }, "22", component, null, 0);
   out.t(a);
   out.be("div", {
     "c": 1
-  }, "22", component, 0, 0);
+  }, "23", component, 0, 0);
   out.ee();
   out.be("div", {
     "d": 1
-  }, "23", component, 0, 0);
+  }, "24", component, 0, 0);
   out.ee();
 
   if (x === a) {
@@ -179,7 +179,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     const i = _i;
     out.be("div", {
       "c": 1
-    }, "32", component, 0, 0);
+    }, "33", component, 0, 0);
     out.ee();
   }
 
@@ -187,7 +187,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     const val = obj[key];
     out.be("div", {
       "c": 1
-    }, "34", component, 0, 0);
+    }, "35", component, 0, 0);
     out.ee();
   }
 

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
@@ -13,11 +13,11 @@ import _other from "./components/other/index.marko";
 
 const _other_tag = _t(_other);
 
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t2 } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "8f1lFGb_",
-      _marko_template = _t2(__filename),
+const _marko_template = _t2(__filename),
+      _marko_componentType = _marko_registerComponent("8f1lFGb_", () => _marko_template),
       _marko_component = {
   onCreate() {
     this.stuff();
@@ -28,7 +28,7 @@ const _marko_componentType = "8f1lFGb_",
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("style", {
     "id": "css"
-  }, "1", component, null, 4);
+  }, "1", component, null, 1);
   out.t("\n  div {\n    color: ");
   out.t(x);
   out.t(";\n  }\n");
@@ -68,7 +68,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   out.ee();
   out.be("div", {
     "id": _component.elId("1")
-  }, "8", component, 0, 4);
+  }, "8", component, 0, 1);
   out.ee();
   out.be("div", {
     "class": _marko_class_merge(["a", {
@@ -78,7 +78,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "style": _marko_style_merge({
       a: "b"
     })
-  }, "9", component, 0, 4);
+  }, "9", component, 0, 1);
   out.ee();
   out.e("input", {
     "type": "text"

--- a/packages/babel-plugin-marko/test/fixtures/scriptlet-line-block/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/scriptlet-line-block/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "C_B82F6C",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("C_B82F6C", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   var foo = 123;

--- a/packages/babel-plugin-marko/test/fixtures/scriptlet-line-block/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/scriptlet-line-block/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "C_B82F6C",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("C_B82F6C", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   var foo = 123;

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { cl as _marko_class_merge, a as _marko_attr } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "OQLZ1bnz",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("OQLZ1bnz", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div class="shorthand"></div><div class="shorthand1 shorthand2"></div><div class="shorthand1 shorthand2 inline"></div><div${_marko_attr("class", _marko_class_merge(["shorthand1 shorthand2", dynamic1]))}></div><div${_marko_attr("class", _marko_class_merge([dynamic1, "inline"]))}></div><div${_marko_attr("class", _marko_class_merge([dynamic1, "shorthand2", "inline"]))}></div><div${_marko_attr("class", _marko_class_merge([dynamic1, "shorthand2", dynamic2]))}></div><div${_marko_attr("class", _marko_class_merge([dynamic1, "shorthand2", dynamic2, dynamic3]))}></div><div${_marko_attr("class", _marko_class_merge(["shorthand", dynamic1, dynamic2]))}></div><div${_marko_attr("class", _marko_class_merge(["partially-" + dynamic1, "shorthand2", dynamic2]))}></div>`);

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-classname/snapshots/translated-vdom.expected.js
@@ -1,51 +1,51 @@
 import { cl as _marko_class_merge } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "OQLZ1bnz",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("OQLZ1bnz", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "class": "shorthand"
-  }, "0", component, 0, 4);
+  }, "0", component, 0, 1);
   out.ee();
   out.be("div", {
     "class": "shorthand1 shorthand2"
-  }, "1", component, 0, 4);
+  }, "1", component, 0, 1);
   out.ee();
   out.be("div", {
     "class": "shorthand1 shorthand2 inline"
-  }, "2", component, 0, 4);
+  }, "2", component, 0, 1);
   out.ee();
   out.be("div", {
     "class": _marko_class_merge(["shorthand1 shorthand2", dynamic1])
-  }, "3", component, 0, 4);
+  }, "3", component, 0, 1);
   out.ee();
   out.be("div", {
     "class": _marko_class_merge([dynamic1, "inline"])
-  }, "4", component, 0, 4);
+  }, "4", component, 0, 1);
   out.ee();
   out.be("div", {
     "class": _marko_class_merge([dynamic1, "shorthand2", "inline"])
-  }, "5", component, 0, 4);
+  }, "5", component, 0, 1);
   out.ee();
   out.be("div", {
     "class": _marko_class_merge([dynamic1, "shorthand2", dynamic2])
-  }, "6", component, 0, 4);
+  }, "6", component, 0, 1);
   out.ee();
   out.be("div", {
     "class": _marko_class_merge([dynamic1, "shorthand2", dynamic2, dynamic3])
-  }, "7", component, 0, 4);
+  }, "7", component, 0, 1);
   out.ee();
   out.be("div", {
     "class": _marko_class_merge(["shorthand", dynamic1, dynamic2])
-  }, "8", component, 0, 4);
+  }, "8", component, 0, 1);
   out.ee();
   out.be("div", {
     "class": _marko_class_merge(["partially-" + dynamic1, "shorthand2", dynamic2])
-  }, "9", component, 0, 4);
+  }, "9", component, 0, 1);
   out.ee();
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { a as _marko_attr } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "cFDIY1TL",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("cFDIY1TL", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div id="shorthand"></div><div${_marko_attr("id", dynamic)}></div><div${_marko_attr("id", "partial-" + dynamic)}></div>`);

--- a/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/shorthand-id/snapshots/translated-vdom.expected.js
@@ -1,22 +1,22 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "cFDIY1TL",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("cFDIY1TL", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "id": "shorthand"
-  }, "0", component, 0, 4);
+  }, "0", component, 0, 1);
   out.ee();
   out.be("div", {
     "id": dynamic
-  }, "1", component, 0, 4);
+  }, "1", component, 0, 1);
   out.ee();
   out.be("div", {
     "id": "partial-" + dynamic
-  }, "2", component, 0, 4);
+  }, "2", component, 0, 1);
   out.ee();
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/simple-attrs-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/simple-attrs-tag/snapshots/translated-html.expected.js
@@ -1,11 +1,11 @@
 import _marko_style_merge from "marko/src/runtime/vdom/helper-styleAttr";
 import { a as _marko_attr } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "G7Zu4cGH",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("G7Zu4cGH", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`<div class="b" id="a"${_marko_attr("style", _marko_style_merge({

--- a/packages/babel-plugin-marko/test/fixtures/simple-attrs-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/simple-attrs-tag/snapshots/translated-vdom.expected.js
@@ -1,11 +1,11 @@
 import _marko_style_merge from "marko/src/runtime/vdom/helper-styleAttr";
 import "marko/src/runtime/vdom/preserve-attrs";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "G7Zu4cGH",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("G7Zu4cGH", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
@@ -14,20 +14,20 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "style": _marko_style_merge({
       c: 1
     })
-  }, "0", component, 0, 4);
+  }, "0", component, 0, 1);
   out.ee();
   out.be("div", {
     "id": "a",
     "style": _marko_style_merge({
       c: 1
     })
-  }, "1", component, 0, 4);
+  }, "1", component, 0, 1);
   out.ee();
   out.be("div", {
     "style": _marko_style_merge({
       c: 1
     })
-  }, "2", component, 0, 4);
+  }, "2", component, 0, 1);
   out.ee();
   out.be("div", {
     "style": _marko_style_merge({

--- a/packages/babel-plugin-marko/test/fixtures/simple/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/simple/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "hXm4QTQF",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("hXm4QTQF", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w(`Hello ${_marko_escapeXml(input.name)}! `);

--- a/packages/babel-plugin-marko/test/fixtures/simple/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/simple/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "hXm4QTQF",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("hXm4QTQF", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.t("Hello ");

--- a/packages/babel-plugin-marko/test/fixtures/simple/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/simple/snapshots/translated-vdom.expected.js
@@ -11,17 +11,17 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   out.t("! ");
 
   if (input.colors.length) {
-    out.be("ul", null, "2", component, null, 0);
+    out.be("ul", null, "1", component, null, 0);
 
     for (const color of input.colors) {
-      out.be("li", null, "0", component, null, 0);
+      out.be("li", null, "3", component, null, 0);
       out.t(color);
       out.ee();
     }
 
     out.ee();
   } else {
-    out.be("div", null, "4", component, null, 0);
+    out.be("div", null, "5", component, null, 0);
     out.t("No colors!");
     out.ee();
   }

--- a/packages/babel-plugin-marko/test/fixtures/split-component-with-component/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/split-component-with-component/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
 import _marko_component from "./template.component.js";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "9b_ZSA-h",
-      _marko_template = _t(__filename),
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("9b_ZSA-h", () => _marko_template),
       _marko_component2 = _marko_component;
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {

--- a/packages/babel-plugin-marko/test/fixtures/split-component-with-component/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/split-component-with-component/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
 import _marko_component from "./template.component.js";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "9b_ZSA-h",
-      _marko_template = _t(__filename),
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("9b_ZSA-h", () => _marko_template),
       _marko_component2 = _marko_component;
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {

--- a/packages/babel-plugin-marko/test/fixtures/split-component/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/split-component/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "prO3cwdD",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("prO3cwdD", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div></div>");

--- a/packages/babel-plugin-marko/test/fixtures/split-component/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/split-component/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "prO3cwdD",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("prO3cwdD", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "0", component, 0, 0);

--- a/packages/babel-plugin-marko/test/fixtures/static-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/static-tag/snapshots/translated-html.expected.js
@@ -3,12 +3,12 @@ var foo = 123;
 function bar() {}
 
 var baz = 456;
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "POLyS7AN",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("POLyS7AN", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/static-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/static-tag/snapshots/translated-vdom.expected.js
@@ -3,12 +3,12 @@ var foo = 123;
 function bar() {}
 
 var baz = 456;
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "POLyS7AN",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("POLyS7AN", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {}, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/style-block-empty/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/style-block-empty/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "k7Oc1u-Y",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("k7Oc1u-Y", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div class=\"test\"></div>");

--- a/packages/babel-plugin-marko/test/fixtures/style-block-empty/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/style-block-empty/snapshots/translated-vdom.expected.js
@@ -1,14 +1,14 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "k7Oc1u-Y",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("k7Oc1u-Y", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "class": "test"
-  }, "1", component, 0, 4);
+  }, "1", component, 0, 1);
   out.ee();
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/style-block-with-styles/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/style-block-with-styles/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "bZPuqO3U",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("bZPuqO3U", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div class=\"test\"></div>");

--- a/packages/babel-plugin-marko/test/fixtures/style-block-with-styles/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/style-block-with-styles/snapshots/translated-vdom.expected.js
@@ -1,14 +1,14 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "bZPuqO3U",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("bZPuqO3U", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", {
     "class": "test"
-  }, "1", component, 0, 4);
+  }, "1", component, 0, 1);
   out.ee();
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/svg-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/svg-tag/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "Dw11N4il",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("Dw11N4il", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<svg height=\"100\" width=\"100\"><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\"><a></a><style>div { color: green }</style><script>alert(\"Hello\");</script><title>Test</title></svg><a></a>");

--- a/packages/babel-plugin-marko/test/fixtures/svg-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/svg-tag/snapshots/translated-vdom.expected.js
@@ -1,15 +1,15 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "Dw11N4il",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("Dw11N4il", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("svg", {
     "height": "100",
     "width": "100"
-  }, "5", component, null, 1);
+  }, "5", component, null, 0);
   out.e("circle", {
     "cx": "50",
     "cy": "50",
@@ -17,16 +17,16 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "stroke": "black",
     "stroke-width": "3",
     "fill": "red"
-  }, "0", component, 0, 1);
-  out.be("a", null, "1", component, 0, 1);
+  }, "0", component, 0, 0);
+  out.be("a", null, "1", component, 0, 0);
   out.ee();
-  out.be("style", null, "2", component, null, 1);
+  out.be("style", null, "2", component, null, 0);
   out.t("div { color: green }");
   out.ee();
-  out.be("script", null, "3", component, null, 1);
+  out.be("script", null, "3", component, null, 0);
   out.t("alert(\"Hello\");");
   out.ee();
-  out.be("title", null, "4", component, null, 1);
+  out.be("title", null, "4", component, null, 0);
   out.t("Test");
   out.ee();
   out.ee();

--- a/packages/babel-plugin-marko/test/fixtures/svg-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/svg-tag/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   out.be("svg", {
     "height": "100",
     "width": "100"
-  }, "5", component, null, 0);
+  }, "0", component, null, 0);
   out.e("circle", {
     "cx": "50",
     "cy": "50",
@@ -17,16 +17,16 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "stroke": "black",
     "stroke-width": "3",
     "fill": "red"
-  }, "0", component, 0, 0);
-  out.be("a", null, "1", component, 0, 0);
+  }, "1", component, 0, 0);
+  out.be("a", null, "2", component, 0, 0);
   out.ee();
-  out.be("style", null, "2", component, null, 0);
+  out.be("style", null, "3", component, null, 0);
   out.t("div { color: green }");
   out.ee();
-  out.be("script", null, "3", component, null, 0);
+  out.be("script", null, "4", component, null, 0);
   out.t("alert(\"Hello\");");
   out.ee();
-  out.be("title", null, "4", component, null, 0);
+  out.be("title", null, "5", component, null, 0);
   out.t("Test");
   out.ee();
   out.ee();

--- a/packages/babel-plugin-marko/test/fixtures/tag-block-scoping/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/tag-block-scoping/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { a as _marko_attr } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "HxdBTLNA",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("HxdBTLNA", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   var b = thing;

--- a/packages/babel-plugin-marko/test/fixtures/tag-block-scoping/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/tag-block-scoping/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "HxdBTLNA",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("HxdBTLNA", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   var b = thing;

--- a/packages/babel-plugin-marko/test/fixtures/tag-block-scoping/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/tag-block-scoping/snapshots/translated-vdom.expected.js
@@ -11,14 +11,14 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   out.be("div", {
     "b": b,
     "c": c
-  }, "1", component, null, 0);
+  }, "0", component, null, 0);
   {
     var d = thing;
     let e = thing;
     out.be("div", {
       "d": d,
       "e": e
-    }, "0", component, 0, 0);
+    }, "1", component, 0, 0);
     out.ee();
   }
   out.ee();

--- a/packages/babel-plugin-marko/test/fixtures/textarea-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/textarea-tag/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "oZK15ZeF",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("oZK15ZeF", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<textarea>\n  hello world\n</textarea>");

--- a/packages/babel-plugin-marko/test/fixtures/textarea-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/textarea-tag/snapshots/translated-vdom.expected.js
@@ -1,12 +1,12 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "oZK15ZeF",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("oZK15ZeF", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
-  out.be("textarea", null, "0", component, null, 2);
+  out.be("textarea", null, "0", component, null, 0);
   out.t("\n  hello world\n");
   out.ee();
 }, {

--- a/packages/babel-plugin-marko/test/fixtures/top-level-text/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/top-level-text/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "s1ePMl_H",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("s1ePMl_H", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("Hello John");

--- a/packages/babel-plugin-marko/test/fixtures/top-level-text/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/top-level-text/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "s1ePMl_H",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("s1ePMl_H", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.t("Hello John");

--- a/packages/babel-plugin-marko/test/fixtures/while-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/while-tag/snapshots/translated-html.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "7_cIMGIq",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("7_cIMGIq", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   let i = 0;

--- a/packages/babel-plugin-marko/test/fixtures/while-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/while-tag/snapshots/translated-vdom.expected.js
@@ -10,7 +10,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   while (i < 10) {
     i++;
-    out.be("div", null, "0", component, 0, 0);
+    out.be("div", null, "1", component, 0, 0);
     out.ee();
   }
 }, {

--- a/packages/babel-plugin-marko/test/fixtures/while-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/while-tag/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "7_cIMGIq",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("7_cIMGIq", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   let i = 0;

--- a/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-html.expected.js
@@ -1,10 +1,10 @@
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers";
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/html";
 
-const _marko_componentType = "f5PlznI-",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("f5PlznI-", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.w("<div><div>Hello <div> </div> World</div><div> Hello</div><pre>\n    This should  \n      be preserved\n  </pre><div><div>Hello </div></div></div><div>");

--- a/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-vdom.expected.js
@@ -1,9 +1,9 @@
-import { r as _marko_renderer, c as _marko_defineComponent } from "marko/src/runtime/components/helpers";
+import { r as _marko_renderer, c as _marko_defineComponent, rc as _marko_registerComponent } from "marko/src/runtime/components/helpers";
 import { t as _t } from "marko/src/runtime/vdom";
 
-const _marko_componentType = "f5PlznI-",
-      _marko_template = _t(__filename),
-      _marko_component = null;
+const _marko_template = _t(__filename),
+      _marko_componentType = _marko_registerComponent("f5PlznI-", () => _marko_template),
+      _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
   out.be("div", null, "6", component, null, 0);

--- a/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/white-space-test/snapshots/translated-vdom.expected.js
@@ -6,22 +6,22 @@ const _marko_template = _t(__filename),
       _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
-  out.be("div", null, "6", component, null, 0);
+  out.be("div", null, "0", component, null, 0);
   out.be("div", null, "1", component, null, 0);
   out.t("Hello ");
-  out.be("div", null, "0", component, null, 0);
+  out.be("div", null, "2", component, null, 0);
   out.t(" ");
   out.ee();
   out.t(" World");
   out.ee();
-  out.be("div", null, "2", component, null, 0);
+  out.be("div", null, "3", component, null, 0);
   out.t(" Hello");
   out.ee();
-  out.be("pre", null, "3", component, null, 0);
+  out.be("pre", null, "4", component, null, 0);
   out.t("\n    This should  \n      be preserved\n  ");
   out.ee();
   out.be("div", null, "5", component, null, 0);
-  out.be("div", null, "4", component, null, 0);
+  out.be("div", null, "6", component, null, 0);
   out.t("Hello ");
   out.ee();
   out.ee();


### PR DESCRIPTION
## Description

Adds enter and exit hooks to transformers and code-generators.
Sets up basic auto keying for loops.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
