### PR TITLE
For loop fixes

### DIFF
--- a/packages/babel-plugin-marko/src/taglib/core/translate-for.js
+++ b/packages/babel-plugin-marko/src/taglib/core/translate-for.js
@@ -44,9 +44,10 @@ export function exit(path) {
       block
     );
   } else if (ofAttr) {
+    let ofAttrValue = ofAttr.value;
     allowedAttributes.push("of");
 
-    const [valParam, keyParam] = node.params;
+    const [valParam, keyParam, loopParam] = node.params;
 
     if (!valParam) {
       throw namePath.buildCodeFrameError(
@@ -66,15 +67,34 @@ export function exit(path) {
 
       block.body.unshift(
         t.variableDeclaration("let", [
-          t.variableDeclarator(keyParam, t.updateExpression("++", indexName))
+          t.variableDeclarator(
+            keyParam,
+            t.updateExpression("++", indexName, true)
+          )
         ])
       );
+    }
+
+    if (loopParam) {
+      ofAttrValue = loopParam;
+      forNode.push(
+        t.variableDeclaration("const", [
+          t.variableDeclarator(loopParam, ofAttr.value)
+        ])
+      );
+
+      // forNode.push(
+      //   t.forOfStatement(
+      //     t.variableDeclaration("const", [loopParam]),
+      //     loopParam.value,
+      //   )
+      // );
     }
 
     forNode.push(
       t.forOfStatement(
         t.variableDeclaration("const", [t.variableDeclarator(valParam)]),
-        ofAttr.value,
+        ofAttrValue,
         block
       )
     );

--- a/packages/babel-plugin-marko/src/taglib/core/translate-for.js
+++ b/packages/babel-plugin-marko/src/taglib/core/translate-for.js
@@ -82,13 +82,6 @@ export function exit(path) {
           t.variableDeclarator(loopParam, ofAttr.value)
         ])
       );
-
-      // forNode.push(
-      //   t.forOfStatement(
-      //     t.variableDeclaration("const", [loopParam]),
-      //     loopParam.value,
-      //   )
-      // );
     }
 
     forNode.push(

--- a/packages/babel-plugin-marko/src/taglib/core/translate-for.js
+++ b/packages/babel-plugin-marko/src/taglib/core/translate-for.js
@@ -86,6 +86,7 @@ export function exit(path) {
     const indexName = path.scope.generateUidIdentifier(
       indexParam ? indexParam.name : "i"
     );
+    const operator = stepAttr.value.operator !== "-" ? "<=" : ">=";
 
     if (indexParam) {
       block.body.unshift(
@@ -99,7 +100,7 @@ export function exit(path) {
       t.variableDeclaration("let", [
         t.variableDeclarator(indexName, fromAttr.value)
       ]),
-      t.binaryExpression("<=", indexName, toAttr.value),
+      t.binaryExpression(operator, indexName, toAttr.value),
       stepAttr
         ? t.assignmentExpression("+=", indexName, stepAttr.value)
         : t.updateExpression("++", indexName),

--- a/packages/babel-plugin-marko/src/taglib/core/translate-for.js
+++ b/packages/babel-plugin-marko/src/taglib/core/translate-for.js
@@ -61,16 +61,13 @@ export function exit(path) {
       const indexName = path.scope.generateUidIdentifier(keyParam.name);
       forNode.push(
         t.variableDeclaration("let", [
-          t.variableDeclarator(indexName, t.numericLiteral(-1))
+          t.variableDeclarator(indexName, t.numericLiteral(0))
         ])
       );
 
       block.body.unshift(
         t.variableDeclaration("let", [
-          t.variableDeclarator(
-            keyParam,
-            t.updateExpression("++", indexName, true)
-          )
+          t.variableDeclarator(keyParam, t.updateExpression("++", indexName))
         ])
       );
     }

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/generated.expected.marko
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/generated.expected.marko
@@ -28,6 +28,11 @@
   <div/>
   <div key=`other-${i}`/>
 </for>
+<for|val, i, list| of=arr>
+  <div key=i>
+    ${list.length}: ${val}
+  </div>
+</for>
 <for|key, val| in=obj>
   <div key=key>
     ${key}: ${val}
@@ -48,4 +53,11 @@
     <div/>
     <div key=`other-${i}`/>
   </for>
+</for>
+<for|i| from=10 to=0 step=-2>
+  <div key=i>
+    ${i}
+  </div>
+  <div/>
+  <div key=`other-${i}`/>
 </for>

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-html.expected.js
@@ -10,7 +10,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   let _i = -1;
 
   for (const val of arr) {
-    let i = _i++;
+    let i = ++_i;
     out.w(`<div>${_marko_escapeXml(i)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
   }
 
@@ -27,8 +27,16 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   let _i3 = -1;
 
   for (const val of arr) {
-    let i = _i3++;
+    let i = ++_i3;
     out.w(`<div>${_marko_escapeXml(i)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
+  }
+
+  let _i4 = -1;
+  const list = arr;
+
+  for (const val of list) {
+    let i = ++_i4;
+    out.w(`<div>${_marko_escapeXml(list.length)}: ${_marko_escapeXml(val)}</div>`);
   }
 
   for (const key in obj) {
@@ -36,14 +44,19 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     out.w(`<div>${_marko_escapeXml(key)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
   }
 
-  for (let _i5 = 0; _i5 <= 10; _i5 += 2) {
-    const i = _i5;
+  for (let _i6 = 0; _i6 <= 10; _i6 += 2) {
+    const i = _i6;
     out.w(`<div>${_marko_escapeXml(i)}</div><div></div><div></div>`);
 
-    for (let _i4 = 0; _i4 <= 10; _i4 += 2) {
-      const i = _i4;
+    for (let _i5 = 0; _i5 <= 10; _i5 += 2) {
+      const i = _i5;
       out.w(`<div>${_marko_escapeXml(i)}</div><div></div><div></div>`);
     }
+  }
+
+  for (let _i7 = 10; _i7 >= 0; _i7 += -2) {
+    const i = _i7;
+    out.w(`<div>${_marko_escapeXml(i)}</div><div></div><div></div>`);
   }
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-html.expected.js
@@ -7,10 +7,10 @@ const _marko_template = _t(__filename),
       _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
-  let _i = -1;
+  let _i = 0;
 
   for (const val of arr) {
-    let i = ++_i;
+    let i = _i++;
     out.w(`<div>${_marko_escapeXml(i)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
   }
 
@@ -24,18 +24,18 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     out.w(`<div>${_marko_escapeXml(i)}</div><div></div><div></div>`);
   }
 
-  let _i3 = -1;
+  let _i3 = 0;
 
   for (const val of arr) {
-    let i = ++_i3;
+    let i = _i3++;
     out.w(`<div>${_marko_escapeXml(i)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
   }
 
-  let _i4 = -1;
+  let _i4 = 0;
   const list = arr;
 
   for (const val of list) {
-    let i = ++_i4;
+    let i = _i4++;
     out.w(`<div>${_marko_escapeXml(list.length)}: ${_marko_escapeXml(val)}</div>`);
   }
 

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-vdom.expected.js
@@ -9,7 +9,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   let _i = -1;
 
   for (const val of arr) {
-    let i = _i++;
+    let i = ++_i;
     out.be("div", null, "1", component, null, 0);
     out.t(i);
     out.t(": ");
@@ -48,7 +48,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   let _i3 = -1;
 
   for (const val of arr) {
-    let i = _i3++;
+    let i = ++_i3;
     out.be("div", null, `@${i}`, component, null, 0);
     out.t(i);
     out.t(": ");
@@ -60,6 +60,18 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     out.ee();
   }
 
+  let _i4 = -1;
+  const list = arr;
+
+  for (const val of list) {
+    let i = ++_i4;
+    out.be("div", null, `@${i}`, component, null, 0);
+    out.t(list.length);
+    out.t(": ");
+    out.t(val);
+    out.ee();
+  }
+
   for (const key in obj) {
     const val = obj[key];
     out.be("div", null, `@${key}`, component, null, 0);
@@ -67,32 +79,43 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     out.t(": ");
     out.t(val);
     out.ee();
-    out.be("div", null, "18", component, 0, 0);
+    out.be("div", null, "20", component, 0, 0);
     out.ee();
     out.be("div", null, `@other-${key}`, component, 0, 0);
     out.ee();
   }
 
-  for (let _i5 = 0; _i5 <= 10; _i5 += 2) {
-    const i = _i5;
+  for (let _i6 = 0; _i6 <= 10; _i6 += 2) {
+    const i = _i6;
     out.be("div", null, `@${i}`, component, null, 0);
     out.t(i);
     out.ee();
-    out.be("div", null, "22", component, 0, 0);
+    out.be("div", null, "24", component, 0, 0);
     out.ee();
     out.be("div", null, `@other-${i}`, component, 0, 0);
     out.ee();
 
-    for (let _i4 = 0; _i4 <= 10; _i4 += 2) {
-      const i = _i4;
+    for (let _i5 = 0; _i5 <= 10; _i5 += 2) {
+      const i = _i5;
       out.be("div", null, `@${i}`, component, null, 0);
       out.t(i);
       out.ee();
-      out.be("div", null, "26", component, 0, 0);
+      out.be("div", null, "28", component, 0, 0);
       out.ee();
       out.be("div", null, `@other-${i}`, component, 0, 0);
       out.ee();
     }
+  }
+
+  for (let _i7 = 10; _i7 >= 0; _i7 += -2) {
+    const i = _i7;
+    out.be("div", null, `@${i}`, component, null, 0);
+    out.t(i);
+    out.ee();
+    out.be("div", null, "32", component, 0, 0);
+    out.ee();
+    out.be("div", null, `@other-${i}`, component, 0, 0);
+    out.ee();
   }
 }, {
   ___type: _marko_componentType,

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/snapshots/translated-vdom.expected.js
@@ -6,10 +6,10 @@ const _marko_template = _t(__filename),
       _marko_component = {};
 
 _marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
-  let _i = -1;
+  let _i = 0;
 
   for (const val of arr) {
-    let i = ++_i;
+    let i = _i++;
     out.be("div", null, "1", component, null, 0);
     out.t(i);
     out.t(": ");
@@ -45,10 +45,10 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     out.ee();
   }
 
-  let _i3 = -1;
+  let _i3 = 0;
 
   for (const val of arr) {
-    let i = ++_i3;
+    let i = _i3++;
     out.be("div", null, `@${i}`, component, null, 0);
     out.t(i);
     out.t(": ");
@@ -60,11 +60,11 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     out.ee();
   }
 
-  let _i4 = -1;
+  let _i4 = 0;
   const list = arr;
 
   for (const val of list) {
-    let i = ++_i4;
+    let i = _i4++;
     out.be("div", null, `@${i}`, component, null, 0);
     out.t(list.length);
     out.t(": ");

--- a/packages/babel-plugin-marko/test/fixtures/for-tag/template.marko
+++ b/packages/babel-plugin-marko/test/fixtures/for-tag/template.marko
@@ -24,6 +24,10 @@
   <div key=`other-${i}`/>
 </for>
 
+<for|val, i, list| of=arr>
+  <div key=i>${list.length}: ${val}</div>
+</for>
+
 <for|key, val| in=obj>
   <div key=key>${key}: ${val}</div>
   <div/>
@@ -39,4 +43,10 @@
   <div/>
   <div key=`other-${i}`/>
 </for>
+</for>
+
+<for|i| from=10 to=0 step=-2>
+  <div key=i>${i}</div>
+  <div/>
+  <div key=`other-${i}`/>
 </for>

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
@@ -119,7 +119,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   let _i2 = -1;
 
   for (const val of arr) {
-    let i = _i2++;
+    let i = ++_i2;
     i;
     out.w("<div c=\"1\"></div>");
 

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-html.expected.js
@@ -116,10 +116,10 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     out.w("<div c=\"1\"></div>");
   }
 
-  let _i2 = -1;
+  let _i2 = 0;
 
   for (const val of arr) {
-    let i = ++_i2;
+    let i = _i2++;
     i;
     out.w("<div c=\"1\"></div>");
 

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
@@ -194,10 +194,10 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     out.ee();
   }
 
-  let _i2 = -1;
+  let _i2 = 0;
 
   for (const val of arr) {
-    let i = ++_i2;
+    let i = _i2++;
     i;
     out.be("div", {
       "c": 1

--- a/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
+++ b/packages/babel-plugin-marko/test/fixtures/sanity-check/snapshots/translated-vdom.expected.js
@@ -197,7 +197,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   let _i2 = -1;
 
   for (const val of arr) {
-    let i = _i2++;
+    let i = ++_i2;
     i;
     out.be("div", {
       "c": 1


### PR DESCRIPTION
## Description
Fixed the following tests:
- [ ] Third parameter for <for> (the array) is not available
    - [ ] for-attr-separator
    - [ ] for-attr-separator-html
    - [ ] for-attr-separator-status-var
    - [ ] for-attr-status-var-string
    - [ ] for-tag-separator
    - [ ] for-tag-separator-status-var
    - [ ] for-tag-status-var
- [ ] _loopIndex should be incremented with ++_loopIndex
    - [ ] for-props-status-var
- [ ] For descending
    - [ ] for-range-descending-step
    - [ ] for-range-step-neg2

## Motivation and Context
- Added a check for operator if the step is negative or positive sign, so we can loop backwards or forwards.
- Added a loopParam variable which when present will be used in the loop and accessible. 

## Screenshots (if appropriate):

## Checklist:
- [X] I have updated/added documentation affected by my changes.
- [X] I have added tests to cover my changes.
