### PR TITLE
Fixed html comments and attribute tags

### DIFF
--- a/packages/translator-default/src/tag/util.js
+++ b/packages/translator-default/src/tag/util.js
@@ -2,6 +2,15 @@ import { types as t } from "@marko/babel-types";
 import { escapeXmlAttr } from "marko/src/runtime/html/escape";
 import { getTagDef } from "@marko/babel-utils";
 
+function getPropertyKey(name, noCamel, tagDefAttributes) {
+  const currentTagDef = tagDefAttributes[name] || {};
+  let currentKey = name;
+  if (currentTagDef.targetProperty) {
+    currentKey = currentTagDef.targetProperty;
+  }
+  return noCamel ? currentKey : camelCase(currentKey);
+}
+
 export function getAttrs(path, noCamel, skipRenderBody) {
   const { node } = path;
   const {
@@ -28,7 +37,7 @@ export function getAttrs(path, noCamel, skipRenderBody) {
     foundProperties[name] = true;
     properties[i] = name
       ? t.objectProperty(
-          t.stringLiteral(noCamel ? name : camelCase(name)),
+          t.stringLiteral(getPropertyKey(name, noCamel, tagDefAttributes)),
           value
         )
       : t.spreadElement(value);

--- a/packages/translator-default/src/taglib/core/marko.json
+++ b/packages/translator-default/src/taglib/core/marko.json
@@ -81,7 +81,7 @@
   "<html-comment>": {
     "code-generator": "./translate-html-comment.js",
     "parse-options": {
-      "state": "static-text"
+      "state": "parsed-text"
     }
   },
   "<fragment>": {


### PR DESCRIPTION
## Description
Fixed the following tests
* html-comment-tag-dynamic
* custom-tag-target-property
* default-attributes
* scanned-tags (target properties)

## Motivation and Context
- For the html comments, change marko.json definition to do `parsed-text`
- For the attributes, changed it so that it will keep track of all properties set. Then it iterates through all taglib attributes and adds default value
- Also changed the key to use target-property. Moved code to a generic function to make it easier to extend later if needed (and moved camelcase too)

## Checklist:

- [X] I have updated/added documentation affected by my changes.
- [X] I have added tests to cover my changes.
