### PR TITLE
Fragment fix

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -19,45 +19,45 @@
     {
       "name": "*",
       "individual": {
-        "min": 11532,
-        "gzip": 5076,
-        "brotli": 4633
+        "min": 11661,
+        "gzip": 5150,
+        "brotli": 4713
       }
     },
     {
       "name": "register",
       "individual": {
         "min": 277,
-        "gzip": 224,
-        "brotli": 182
+        "gzip": 222,
+        "brotli": 184
       },
       "cumulative": {
         "min": 277,
-        "gzip": 224,
-        "brotli": 182
+        "gzip": 222,
+        "brotli": 184
       },
       "increment": {
         "min": 277,
-        "gzip": 224,
-        "brotli": 182
+        "gzip": 222,
+        "brotli": 184
       }
     },
     {
       "name": "init",
       "individual": {
         "min": 837,
-        "gzip": 535,
-        "brotli": 456
+        "gzip": 534,
+        "brotli": 455
       },
       "cumulative": {
         "min": 886,
-        "gzip": 556,
-        "brotli": 474
+        "gzip": 553,
+        "brotli": 470
       },
       "increment": {
         "min": 609,
-        "gzip": 332,
-        "brotli": 292
+        "gzip": 331,
+        "brotli": 286
       }
     },
     {
@@ -69,13 +69,13 @@
       },
       "cumulative": {
         "min": 1121,
-        "gzip": 664,
-        "brotli": 578
+        "gzip": 662,
+        "brotli": 572
       },
       "increment": {
         "min": 235,
-        "gzip": 108,
-        "brotli": 104
+        "gzip": 109,
+        "brotli": 102
       }
     },
     {
@@ -83,35 +83,35 @@
       "individual": {
         "min": 1270,
         "gzip": 681,
-        "brotli": 621
+        "brotli": 620
       },
       "cumulative": {
         "min": 1968,
-        "gzip": 1041,
-        "brotli": 940
+        "gzip": 1040,
+        "brotli": 946
       },
       "increment": {
         "min": 847,
-        "gzip": 377,
-        "brotli": 362
+        "gzip": 378,
+        "brotli": 374
       }
     },
     {
       "name": "effect",
       "individual": {
         "min": 1315,
-        "gzip": 698,
+        "gzip": 697,
         "brotli": 632
       },
       "cumulative": {
         "min": 2026,
-        "gzip": 1066,
-        "brotli": 964
+        "gzip": 1064,
+        "brotli": 966
       },
       "increment": {
         "min": 58,
-        "gzip": 25,
-        "brotli": 24
+        "gzip": 24,
+        "brotli": 20
       }
     },
     {
@@ -119,125 +119,125 @@
       "individual": {
         "min": 317,
         "gzip": 241,
-        "brotli": 198
+        "brotli": 199
       },
       "cumulative": {
         "min": 2075,
-        "gzip": 1085,
-        "brotli": 982
+        "gzip": 1082,
+        "brotli": 985
       },
       "increment": {
         "min": 49,
-        "gzip": 19,
-        "brotli": 18
+        "gzip": 18,
+        "brotli": 19
       }
     },
     {
       "name": "set",
       "individual": {
         "min": 1701,
-        "gzip": 929,
-        "brotli": 838
+        "gzip": 928,
+        "brotli": 842
       },
       "cumulative": {
         "min": 3396,
-        "gzip": 1685,
-        "brotli": 1519
+        "gzip": 1680,
+        "brotli": 1524
       },
       "increment": {
         "min": 1321,
-        "gzip": 600,
-        "brotli": 537
+        "gzip": 598,
+        "brotli": 539
       }
     },
     {
       "name": "on",
       "individual": {
         "min": 577,
-        "gzip": 390,
+        "gzip": 391,
         "brotli": 326
       },
       "cumulative": {
         "min": 3737,
-        "gzip": 1839,
-        "brotli": 1660
+        "gzip": 1837,
+        "brotli": 1658
       },
       "increment": {
         "min": 341,
-        "gzip": 154,
-        "brotli": 141
+        "gzip": 157,
+        "brotli": 134
       }
     },
     {
       "name": "attr",
       "individual": {
         "min": 1536,
-        "gzip": 816,
-        "brotli": 738
+        "gzip": 815,
+        "brotli": 736
       },
       "cumulative": {
         "min": 3970,
-        "gzip": 1937,
-        "brotli": 1751
+        "gzip": 1934,
+        "brotli": 1748
       },
       "increment": {
         "min": 233,
-        "gzip": 98,
-        "brotli": 91
+        "gzip": 97,
+        "brotli": 90
       }
     },
     {
       "name": "text",
       "individual": {
-        "min": 2034,
-        "gzip": 1016,
-        "brotli": 917
+        "min": 2010,
+        "gzip": 1007,
+        "brotli": 915
       },
       "cumulative": {
-        "min": 4747,
-        "gzip": 2249,
-        "brotli": 2037
+        "min": 4723,
+        "gzip": 2236,
+        "brotli": 2026
       },
       "increment": {
-        "min": 777,
-        "gzip": 312,
-        "brotli": 286
+        "min": 753,
+        "gzip": 302,
+        "brotli": 278
       }
     },
     {
       "name": "conditional",
       "individual": {
-        "min": 2885,
-        "gzip": 1378,
-        "brotli": 1266
+        "min": 3022,
+        "gzip": 1440,
+        "brotli": 1309
       },
       "cumulative": {
-        "min": 5783,
-        "gzip": 2673,
-        "brotli": 2444
+        "min": 5940,
+        "gzip": 2725,
+        "brotli": 2505
       },
       "increment": {
-        "min": 1036,
-        "gzip": 424,
-        "brotli": 407
+        "min": 1217,
+        "gzip": 489,
+        "brotli": 479
       }
     },
     {
       "name": "loopOf",
       "individual": {
-        "min": 5273,
-        "gzip": 2494,
-        "brotli": 2295
+        "min": 5417,
+        "gzip": 2560,
+        "brotli": 2363
       },
       "cumulative": {
-        "min": 8058,
-        "gzip": 3738,
-        "brotli": 3429
+        "min": 8189,
+        "gzip": 3803,
+        "brotli": 3514
       },
       "increment": {
-        "min": 2275,
-        "gzip": 1065,
-        "brotli": 985
+        "min": 2249,
+        "gzip": 1078,
+        "brotli": 1009
       }
     }
   ]

--- a/.sizes.json
+++ b/.sizes.json
@@ -19,27 +19,27 @@
     {
       "name": "*",
       "individual": {
-        "min": 11661,
-        "gzip": 5150,
-        "brotli": 4713
+        "min": 11586,
+        "gzip": 5103,
+        "brotli": 4675
       }
     },
     {
       "name": "register",
       "individual": {
         "min": 277,
-        "gzip": 222,
-        "brotli": 184
+        "gzip": 224,
+        "brotli": 183
       },
       "cumulative": {
         "min": 277,
-        "gzip": 222,
-        "brotli": 184
+        "gzip": 224,
+        "brotli": 183
       },
       "increment": {
         "min": 277,
-        "gzip": 222,
-        "brotli": 184
+        "gzip": 224,
+        "brotli": 183
       }
     },
     {
@@ -47,143 +47,143 @@
       "individual": {
         "min": 837,
         "gzip": 534,
-        "brotli": 455
+        "brotli": 456
       },
       "cumulative": {
         "min": 886,
-        "gzip": 553,
-        "brotli": 470
+        "gzip": 554,
+        "brotli": 474
       },
       "increment": {
         "min": 609,
-        "gzip": 331,
-        "brotli": 286
+        "gzip": 330,
+        "brotli": 291
       }
     },
     {
       "name": "source",
       "individual": {
         "min": 475,
-        "gzip": 320,
-        "brotli": 255
+        "gzip": 319,
+        "brotli": 265
       },
       "cumulative": {
         "min": 1121,
         "gzip": 662,
-        "brotli": 572
+        "brotli": 571
       },
       "increment": {
         "min": 235,
-        "gzip": 109,
-        "brotli": 102
+        "gzip": 108,
+        "brotli": 97
       }
     },
     {
       "name": "compute",
       "individual": {
         "min": 1270,
-        "gzip": 681,
-        "brotli": 620
+        "gzip": 680,
+        "brotli": 617
       },
       "cumulative": {
         "min": 1968,
-        "gzip": 1040,
-        "brotli": 946
+        "gzip": 1041,
+        "brotli": 938
       },
       "increment": {
         "min": 847,
-        "gzip": 378,
-        "brotli": 374
+        "gzip": 379,
+        "brotli": 367
       }
     },
     {
       "name": "effect",
       "individual": {
         "min": 1315,
-        "gzip": 697,
-        "brotli": 632
+        "gzip": 698,
+        "brotli": 629
       },
       "cumulative": {
         "min": 2026,
-        "gzip": 1064,
-        "brotli": 966
+        "gzip": 1065,
+        "brotli": 962
       },
       "increment": {
         "min": 58,
         "gzip": 24,
-        "brotli": 20
+        "brotli": 24
       }
     },
     {
       "name": "get",
       "individual": {
         "min": 317,
-        "gzip": 241,
-        "brotli": 199
+        "gzip": 242,
+        "brotli": 200
       },
       "cumulative": {
         "min": 2075,
-        "gzip": 1082,
-        "brotli": 985
+        "gzip": 1084,
+        "brotli": 980
       },
       "increment": {
         "min": 49,
-        "gzip": 18,
-        "brotli": 19
+        "gzip": 19,
+        "brotli": 18
       }
     },
     {
       "name": "set",
       "individual": {
         "min": 1701,
-        "gzip": 928,
-        "brotli": 842
+        "gzip": 927,
+        "brotli": 838
       },
       "cumulative": {
         "min": 3396,
-        "gzip": 1680,
-        "brotli": 1524
+        "gzip": 1681,
+        "brotli": 1525
       },
       "increment": {
         "min": 1321,
-        "gzip": 598,
-        "brotli": 539
+        "gzip": 597,
+        "brotli": 545
       }
     },
     {
       "name": "on",
       "individual": {
         "min": 577,
-        "gzip": 391,
-        "brotli": 326
+        "gzip": 392,
+        "brotli": 327
       },
       "cumulative": {
         "min": 3737,
         "gzip": 1837,
-        "brotli": 1658
+        "brotli": 1662
       },
       "increment": {
         "min": 341,
-        "gzip": 157,
-        "brotli": 134
+        "gzip": 156,
+        "brotli": 137
       }
     },
     {
       "name": "attr",
       "individual": {
         "min": 1536,
-        "gzip": 815,
-        "brotli": 736
+        "gzip": 816,
+        "brotli": 740
       },
       "cumulative": {
         "min": 3970,
         "gzip": 1934,
-        "brotli": 1748
+        "brotli": 1749
       },
       "increment": {
         "min": 233,
         "gzip": 97,
-        "brotli": 90
+        "brotli": 87
       }
     },
     {
@@ -191,17 +191,17 @@
       "individual": {
         "min": 2010,
         "gzip": 1007,
-        "brotli": 915
+        "brotli": 910
       },
       "cumulative": {
         "min": 4723,
-        "gzip": 2236,
-        "brotli": 2026
+        "gzip": 2237,
+        "brotli": 2029
       },
       "increment": {
         "min": 753,
-        "gzip": 302,
-        "brotli": 278
+        "gzip": 303,
+        "brotli": 280
       }
     },
     {
@@ -214,30 +214,30 @@
       "cumulative": {
         "min": 5940,
         "gzip": 2725,
-        "brotli": 2505
+        "brotli": 2500
       },
       "increment": {
         "min": 1217,
-        "gzip": 489,
-        "brotli": 479
+        "gzip": 488,
+        "brotli": 471
       }
     },
     {
       "name": "loopOf",
       "individual": {
-        "min": 5417,
-        "gzip": 2560,
-        "brotli": 2363
+        "min": 5342,
+        "gzip": 2512,
+        "brotli": 2314
       },
       "cumulative": {
-        "min": 8189,
-        "gzip": 3803,
-        "brotli": 3514
+        "min": 8114,
+        "gzip": 3756,
+        "brotli": 3454
       },
       "increment": {
-        "min": 2249,
-        "gzip": 1078,
-        "brotli": 1009
+        "min": 2174,
+        "gzip": 1031,
+        "brotli": 954
       }
     }
   ]

--- a/.sizes.json
+++ b/.sizes.json
@@ -19,9 +19,9 @@
     {
       "name": "*",
       "individual": {
-        "min": 11586,
-        "gzip": 5103,
-        "brotli": 4675
+        "min": 11603,
+        "gzip": 5114,
+        "brotli": 4709
       }
     },
     {
@@ -207,19 +207,19 @@
     {
       "name": "conditional",
       "individual": {
-        "min": 3022,
-        "gzip": 1440,
-        "brotli": 1309
+        "min": 3039,
+        "gzip": 1449,
+        "brotli": 1324
       },
       "cumulative": {
-        "min": 5940,
-        "gzip": 2725,
-        "brotli": 2500
+        "min": 5957,
+        "gzip": 2735,
+        "brotli": 2507
       },
       "increment": {
-        "min": 1217,
-        "gzip": 488,
-        "brotli": 471
+        "min": 1234,
+        "gzip": 498,
+        "brotli": 478
       }
     },
     {
@@ -230,14 +230,14 @@
         "brotli": 2314
       },
       "cumulative": {
-        "min": 8114,
-        "gzip": 3756,
-        "brotli": 3454
+        "min": 8131,
+        "gzip": 3765,
+        "brotli": 3466
       },
       "increment": {
         "min": 2174,
-        "gzip": 1031,
-        "brotli": 954
+        "gzip": 1030,
+        "brotli": 959
       }
     }
   ]

--- a/.sizes.json
+++ b/.sizes.json
@@ -19,9 +19,9 @@
     {
       "name": "*",
       "individual": {
-        "min": 11603,
-        "gzip": 5114,
-        "brotli": 4709
+        "min": 11619,
+        "gzip": 5119,
+        "brotli": 4693
       }
     },
     {
@@ -225,19 +225,19 @@
     {
       "name": "loopOf",
       "individual": {
-        "min": 5342,
-        "gzip": 2512,
-        "brotli": 2314
+        "min": 5358,
+        "gzip": 2518,
+        "brotli": 2321
       },
       "cumulative": {
-        "min": 8131,
-        "gzip": 3765,
-        "brotli": 3466
+        "min": 8147,
+        "gzip": 3769,
+        "brotli": 3471
       },
       "increment": {
-        "min": 2174,
-        "gzip": 1030,
-        "brotli": 959
+        "min": 2190,
+        "gzip": 1034,
+        "brotli": 964
       }
     }
   ]

--- a/packages/runtime/src/dom/control-flow.ts
+++ b/packages/runtime/src/dom/control-flow.ts
@@ -12,14 +12,14 @@ import {
 import {
   Fragment,
   createFragment,
+  createFragmentFromRenderer,
   currentFragment,
-  insertFragmentBefore,
-  removeFragment
+  replaceFragment
 } from "./fragments";
 import { Context, setContext } from "../common/context";
 import { reconcile } from "./reconcile";
 import { render, Renderer } from "./dom";
-import { walk, walkAndGetText } from "./walker";
+import { walk } from "./walker";
 
 type ForIterationFragment<T> = Fragment & {
   ___itemSignal: Source<T>;
@@ -41,67 +41,72 @@ export function loopOf<T>(
 ) {
   if (isSignal(array)) {
     const ctx = Context;
-    const marker = !onlyChild ? walkAndGetText() : null;
-    const parent = onlyChild
-      ? (walk() as Node & ParentNode)
-      : marker!.parentNode!;
-    const rootFragment = currentFragment;
-    let oldNodes: Map<string, Fragment> = new Map();
+    const EMPTY_KEY = "_MARKO_EMPTY_KEY_";
+    const rootFragment = currentFragment!;
+    const emptyNodes: Map<string, Fragment> = new Map();
+    let oldNodes: Map<string, Fragment> = emptyNodes;
     let oldKeys: string[] = [];
+    let emptyMarker: Node;
+    let emptyFragment: Fragment;
+    let parent: Node & ParentNode;
+    let trackFragmentFlags: number;
 
-    if (currentFragment!.___firstChild === marker) {
-      setRefGetter(
-        currentFragment!.___firstRef,
-        "___firstChild",
-        () => oldNodes!.get(oldKeys[0])!.___firstRef.___firstChild
-      );
-    }
-    if (currentFragment!.___lastChild === marker) {
-      setRefGetter(
-        currentFragment!.___lastRef,
-        "___lastChild",
-        () =>
-          oldNodes!.get(oldKeys[oldKeys.length - 1])!.___lastRef.___lastChild
-      );
+    if (onlyChild) {
+      parent = walk() as Node & ParentNode;
+      trackFragmentFlags = 0;
+    } else {
+      emptyMarker = walk();
+      emptyFragment = createFragment(emptyMarker, rootFragment);
+      trackFragmentFlags = trackFragmentChildren(rootFragment, emptyMarker!);
+      oldNodes.set(EMPTY_KEY, emptyFragment);
+      oldKeys.push(EMPTY_KEY);
     }
 
     const newNodes = createComputation(
       _array => {
-        const _newNodes: Map<string, Fragment> & {
+        let _newNodes: Map<string, Fragment> & {
           skipReconcile?: boolean;
-        } = new Map();
+        };
         let newItems = 0;
         let moved = false;
+        const len = _array.length;
 
-        setContext(ctx);
-        for (let index = 0, len = _array.length; index < len; index++) {
-          const item = _array[index];
-          const key = getKey ? getKey(item, index) : "" + index;
-          const previousChildFragment = oldNodes.get(
-            key
-          ) as ForIterationFragment<typeof item>;
-          moved = moved || key !== oldKeys[index];
-          if (!previousChildFragment) {
-            newItems++;
-            const itemSignal = createSource(item);
-            const indexSignal = hasIndex && createSource(index);
-            const childFragment = createFragment(
-              renderer,
-              rootFragment,
-              itemSignal,
-              indexSignal,
-              array
-            ) as ForIterationFragment<T>;
-            childFragment.___itemSignal = itemSignal;
-            childFragment.___indexSignal = indexSignal;
-            _newNodes.set(key, childFragment);
-          } else {
-            setSignalValue(previousChildFragment.___itemSignal, item);
-            previousChildFragment.___indexSignal &&
-              setSignalValue(previousChildFragment.___indexSignal, index);
-            _newNodes.set(key, previousChildFragment);
+        if (len === 0) {
+          _newNodes = emptyNodes;
+        } else {
+          _newNodes = new Map();
+          setContext(ctx);
+          for (let index = 0; index < len; index++) {
+            const item = _array[index];
+            const key = getKey ? getKey(item, index) : "" + index;
+            const previousChildFragment = oldNodes.get(
+              key
+            ) as ForIterationFragment<typeof item>;
+            moved = moved || key !== oldKeys[index];
+            if (!previousChildFragment) {
+              newItems++;
+              const itemSignal = createSource(item);
+              const indexSignal = hasIndex && createSource(index);
+              const childFragment = createFragmentFromRenderer(
+                renderer,
+                rootFragment,
+                itemSignal,
+                indexSignal,
+                array
+              ) as ForIterationFragment<T>;
+              childFragment.___itemSignal = itemSignal;
+              childFragment.___indexSignal = indexSignal;
+              _newNodes.set(key, childFragment);
+            } else {
+              setSignalValue(previousChildFragment.___itemSignal, item);
+              previousChildFragment.___indexSignal &&
+                setSignalValue(previousChildFragment.___indexSignal, index);
+              _newNodes.set(key, previousChildFragment);
+            }
+            setContext(null);
           }
         }
+
         const removals = _newNodes.size - oldNodes.size - newItems < 0;
         if (removals) {
           for (const k of oldNodes.keys()) {
@@ -110,7 +115,7 @@ export function loopOf<T>(
         }
         _newNodes.skipReconcile = !newItems && !removals && !moved;
 
-        setContext(null);
+        
         return _newNodes;
       },
       array,
@@ -121,10 +126,29 @@ export function loopOf<T>(
       _newNodes => {
         if (_newNodes.skipReconcile) return;
         const newKeys = Array.from(_newNodes.keys());
-        reconcile(parent, oldKeys, oldNodes, newKeys, _newNodes, marker);
+        const oldLastChild = oldNodes.get(oldKeys[oldKeys.length - 1]);
+        const afterReference = oldLastChild
+          ? oldLastChild.___lastChild.nextSibling
+          : null;
+        reconcile(
+          parent,
+          oldKeys,
+          oldNodes,
+          newKeys,
+          _newNodes,
+          afterReference
+        );
 
-        // TODO: we should be able to remove the marker if the loop was not empty
-        // But we'll need to track the last fragment and ensure the marker is added if the loop becomes empty
+        if (trackFragmentFlags) {
+          const newFirstChild = _newNodes.get(newKeys[0]);
+          const newLastChild = _newNodes.get(newKeys[newKeys.length - 1]);
+          updateFragmentChildren(
+            rootFragment,
+            trackFragmentFlags,
+            newFirstChild!,
+            newLastChild!
+          );
+        }
 
         oldKeys = newKeys;
         oldNodes = _newNodes;
@@ -207,12 +231,12 @@ export function conditional(
   ...input: UpstreamSignalOrValue[]
 ) {
   if (isSignal(renderer)) {
-    let previousFragment: Fragment | undefined;
-    const marker = walkAndGetText();
     const rootFragment = currentFragment!;
-    const trackFirstRef = rootFragment.___firstRef.___firstChild === marker;
-    const trackLastRef = rootFragment.___lastRef.___lastChild === marker;
     const ctx = Context;
+    const emptyMarker = walk();
+    const trackFragmentFlags = trackFragmentChildren(rootFragment, emptyMarker);
+    const emptyFragment = createFragment(emptyMarker, rootFragment);
+    let previousFragment = emptyFragment;
 
     const fragmentSignal = createComputation(
       // TODO: hoist out this function and compare benchmarks
@@ -220,8 +244,9 @@ export function conditional(
         setContext(ctx);
         if (!_renderer && previousFragment)
           markFragmentDestroyed(previousFragment);
-        const result =
-          _renderer && createFragment(_renderer, rootFragment, ...input);
+        const result = _renderer
+          ? createFragmentFromRenderer(_renderer, rootFragment, ...input)
+          : emptyFragment;
         setContext(null);
         return result;
       },
@@ -231,24 +256,14 @@ export function conditional(
 
     createEffect(
       nextFragment => {
-        if (nextFragment) {
-          insertFragmentBefore(null, nextFragment, marker);
-          if (trackFirstRef) {
-            nextFragment.___firstRef = rootFragment.___firstRef;
-            nextFragment.___firstRef.___firstChild = nextFragment.___firstChild;
-          }
-
-          if (trackLastRef) {
-            nextFragment.___lastRef = rootFragment.___lastRef;
-            nextFragment.___lastRef.___lastChild = nextFragment.___lastChild;
-          }
-        }
-
-        if (previousFragment) {
-          removeFragment(previousFragment);
-        }
-
+        replaceFragment(previousFragment, nextFragment);
         previousFragment = nextFragment;
+        updateFragmentChildren(
+          rootFragment,
+          trackFragmentFlags,
+          nextFragment,
+          nextFragment
+        );
       },
       fragmentSignal,
       1
@@ -263,16 +278,50 @@ function firstArgAsKey(key: unknown) {
   return key + "";
 }
 
-function setRefGetter(object, key, getter) {
-  Object.defineProperty(object, key, {
-    get: getter,
-    set(value) {
-      Object.defineProperty(object, key, {
-        value,
-        writable: true,
-        configurable: true
-      });
-    },
-    configurable: true
-  });
+const TRACK_FIRST = 1;
+const TRACK_LAST = 2;
+
+function trackFragmentChildren(rootFragment: Fragment, marker: Node) {
+  let flags = 0;
+  if (rootFragment.___firstChild === marker) flags |= TRACK_FIRST;
+  if (rootFragment.___lastChild === marker) flags |= TRACK_LAST;
+  return flags;
+}
+
+function updateFragmentChildren(
+  rootFragment: Fragment,
+  flags: number,
+  firstChildFragment: Fragment | undefined,
+  lastChildFragment: Fragment | undefined
+) {
+  if (flags & TRACK_FIRST) {
+    updateFragmentChild(
+      rootFragment,
+      firstChildFragment!,
+      "___firstRef",
+      "___firstChild"
+    );
+  }
+  if (flags & TRACK_LAST) {
+    updateFragmentChild(
+      rootFragment,
+      lastChildFragment!,
+      "___lastRef",
+      "___lastChild"
+    );
+  }
+}
+
+function updateFragmentChild(
+  fragment: Fragment,
+  child: Fragment,
+  refKey: "___firstRef" | "___lastRef",
+  childKey: "___firstChild" | "___lastChild",
+  parent = fragment.___parentFragment
+) {
+  fragment[refKey] = child;
+  fragment[childKey] = child[childKey];
+  if (parent && parent[refKey] === fragment) {
+    updateFragmentChild(parent, fragment, refKey, childKey);
+  }
 }

--- a/packages/runtime/src/dom/control-flow.ts
+++ b/packages/runtime/src/dom/control-flow.ts
@@ -125,8 +125,9 @@ export function loopOf<T>(
         const afterReference = oldLastChild
           ? oldLastChild.___lastChild.nextSibling
           : null;
+        const parentNode = parent || oldLastChild!.___lastChild.parentNode;
         reconcile(
-          parent,
+          parentNode,
           oldKeys,
           oldNodes,
           newKeys,

--- a/packages/runtime/src/dom/control-flow.ts
+++ b/packages/runtime/src/dom/control-flow.ts
@@ -111,7 +111,7 @@ export function loopOf<T>(
         } else if (!newItems && !moved) {
           return oldNodes;
         }
-        
+
         return _newNodes;
       },
       array,

--- a/packages/runtime/src/dom/dom.ts
+++ b/packages/runtime/src/dom/dom.ts
@@ -10,7 +10,7 @@ import {
   dynamicKeys,
   runInBatch
 } from "./signals";
-import { createFragment, removeFragment } from "./fragments";
+import { createFragmentFromRenderer, removeFragment } from "./fragments";
 import { conditional } from "./control-flow";
 import {
   walker,
@@ -63,7 +63,11 @@ export function createRenderFn<H extends HydrateFunction>(
     (input: Input) =>
       runInBatch(() => {
         const inputSource = createSource(input);
-        const fragment = createFragment(renderer, undefined, inputSource);
+        const fragment = createFragmentFromRenderer(
+          renderer,
+          undefined,
+          inputSource
+        );
         const container = fragment.___dom as ComponentFragment<Input>;
 
         container.rerender = (newInput: Input) =>
@@ -126,7 +130,11 @@ function parse(template: string, ensureFragment?: boolean) {
   parser.innerHTML = template;
   const content = parser.content;
 
-  if (ensureFragment || (node = content.firstChild) !== content.lastChild) {
+  if (
+    ensureFragment ||
+    (node = content.firstChild) !== content.lastChild ||
+    (node && node.nodeType === NodeType.Comment)
+  ) {
     node = doc.createDocumentFragment();
     node.appendChild(content);
   } else if (!node) {

--- a/packages/runtime/src/dom/fragments.ts
+++ b/packages/runtime/src/dom/fragments.ts
@@ -88,8 +88,10 @@ export function insertFragmentBefore(
 }
 
 export function replaceFragment(current: Fragment, replacement: Fragment) {
-  insertFragmentBefore(null, replacement, referenceStart(current));
-  removeFragment(current);
+  if (current !== replacement) {
+    insertFragmentBefore(null, replacement, referenceStart(current));
+    removeFragment(current);
+  }
 }
 
 export function removeFragment(fragment: Fragment) {

--- a/packages/runtime/src/dom/fragments.ts
+++ b/packages/runtime/src/dom/fragments.ts
@@ -3,8 +3,8 @@ import { detachedWalk } from "./walker";
 import { Renderer, isDocumentFragment } from "./dom";
 
 export interface Fragment {
-  ___firstRef: Fragment & { ___firstChild: Node };
-  ___lastRef: Fragment & { ___lastChild: Node };
+  ___firstRef?: Fragment;
+  ___lastRef?: Fragment;
   ___nextNode?: Node;
   ___firstChild: Node;
   ___lastChild: Node;
@@ -19,25 +19,31 @@ export interface Fragment {
 export let currentFragment: Fragment | undefined;
 
 export function createFragment(
-  renderer: Renderer,
-  parentFragment = currentFragment,
-  ...input: UpstreamSignalOrValue[]
+  node: Node,
+  parentFragment = currentFragment
 ): Fragment {
-  const clone = renderer.___clone();
-  const isFragment = isDocumentFragment(clone);
-  const cachedFragment = currentFragment;
-  const fragment = ({
+  const isFragment = isDocumentFragment(node);
+  return {
     ___firstRef: undefined,
     ___lastRef: undefined,
     ___nextNode: undefined,
-    ___firstChild: isFragment ? clone.firstChild! : clone,
-    ___lastChild: isFragment ? clone.lastChild! : clone,
+    ___firstChild: isFragment ? node.firstChild! : node,
+    ___lastChild: isFragment ? node.lastChild! : node,
     ___parentFragment: parentFragment,
-    ___dom: clone,
+    ___dom: node,
     ___tracked: new Set(),
     ___cleanup: cleanup
-  } as any) as Fragment;
-  fragment.___firstRef = fragment.___lastRef = fragment;
+  };
+}
+
+export function createFragmentFromRenderer(
+  renderer: Renderer,
+  parentFragment = currentFragment,
+  ...input: UpstreamSignalOrValue[]
+) {
+  const clone = renderer.___clone();
+  const fragment = createFragment(clone, parentFragment);
+  const cachedFragment = currentFragment;
 
   currentFragment = fragment;
   detachedWalk(fragment.___firstChild, renderer, ...input);
@@ -73,8 +79,8 @@ export function insertFragmentBefore(
   const domParent = parent || nextSibling!.parentNode!;
   withChildren(
     domParent,
-    fragment.___firstRef.___firstChild,
-    fragment.___lastRef.___lastChild,
+    fragment.___firstChild,
+    fragment.___lastChild,
     nextSibling,
     domParent.insertBefore
   );
@@ -90,8 +96,8 @@ export function removeFragment(fragment: Fragment) {
   const domParent = referenceStart(fragment).parentNode!;
   withChildren(
     domParent,
-    fragment.___firstRef.___firstChild,
-    fragment.___lastRef.___lastChild!,
+    fragment.___firstChild,
+    fragment.___lastChild,
     null,
     domParent.removeChild
   );
@@ -99,11 +105,11 @@ export function removeFragment(fragment: Fragment) {
 }
 
 export function referenceStart(fragment: Fragment) {
-  return fragment.___firstRef.___firstChild;
+  return fragment.___firstChild;
 }
 
 export function referenceAfter(fragment: Fragment) {
-  return fragment.___lastChild!.nextSibling;
+  return fragment.___lastChild.nextSibling;
 }
 
 export function withChildren(

--- a/packages/runtime/test/dom/fixtures/batched-updates-cleanup/index.ts
+++ b/packages/runtime/test/dom/fixtures/batched-updates-cleanup/index.ts
@@ -19,8 +19,8 @@ const click = (container: Element) => {
 
 export const inputs = [{}, click] as const;
 
-export const template = `<button></button>`;
-export const walks = get + after + over(1);
+export const template = `<button></button><!>`;
+export const walks = get + over(1) + get + over(1);
 export const hydrate = register(__dirname.split("/").pop()!, () => {
   const show = source(true);
   const message = source("hi");

--- a/packages/runtime/test/dom/fixtures/batched-updates-cleanup/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/batched-updates-cleanup/snapshot.expected.md
@@ -8,7 +8,7 @@
 
 # Mutations
 ```
-inserted button0, span1, #text2
+inserted button0, span1
 ```
 
 
@@ -17,9 +17,11 @@ container.querySelector("button").click();
 
 ```html
 <button />
+<!---->
 ```
 
 # Mutations
 ```
-removed span after button0
+inserted #comment1
+removed span after #comment1
 ```

--- a/packages/runtime/test/dom/fixtures/create-and-clear-rows-loop-from/index.ts
+++ b/packages/runtime/test/dom/fixtures/create-and-clear-rows-loop-from/index.ts
@@ -26,7 +26,7 @@ export const inputs = [
 ];
 
 export const template = `<div></div>`;
-export const walks = inside + over(1);
+export const walks = get + over(1);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: typeof inputs[0]) => {
@@ -34,7 +34,8 @@ export const hydrate = register(
       input.from,
       input.to,
       input.step,
-      createRenderer(loop_template, loop_walks, undefined, i => text(i))
+      createRenderer(loop_template, loop_walks, undefined, i => text(i)),
+      true
     );
   }
 );

--- a/packages/runtime/test/dom/fixtures/create-and-clear-rows-loop-from/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/create-and-clear-rows-loop-from/snapshot.expected.md
@@ -18,10 +18,7 @@ inserted div0
 
 # Mutations
 ```
-removed #text before 
-removed #text before 
-removed #text before 
-removed #text before div0/#text0
+removed #text, #text, #text, #text in div0
 ```
 
 

--- a/packages/runtime/test/dom/fixtures/create-and-clear-rows-loop-in/index.ts
+++ b/packages/runtime/test/dom/fixtures/create-and-clear-rows-loop-in/index.ts
@@ -28,7 +28,7 @@ export const inputs = [
 ];
 
 export const template = `<div></div>`;
-export const walks = inside + over(1);
+export const walks = get + over(1);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: { children: { [x: string]: string } }) => {
@@ -36,7 +36,8 @@ export const hydrate = register(
       input.children,
       createRenderer(loop_template, loop_walks, undefined, (_, value) => {
         text(value);
-      })
+      }),
+      true
     );
   }
 );

--- a/packages/runtime/test/dom/fixtures/create-and-clear-rows-loop-in/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/create-and-clear-rows-loop-in/snapshot.expected.md
@@ -18,9 +18,7 @@ inserted div0
 
 # Mutations
 ```
-removed #text before 
-removed #text before 
-removed #text before div0/#text0
+removed #text, #text, #text in div0
 ```
 
 

--- a/packages/runtime/test/dom/fixtures/create-and-clear-rows/index.ts
+++ b/packages/runtime/test/dom/fixtures/create-and-clear-rows/index.ts
@@ -47,7 +47,7 @@ export const inputs = [
 ];
 
 export const template = `<div></div>`;
-export const walks = inside + over(1);
+export const walks = get + over(1);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: { children: Array<{ id: number; text: string }> }) => {
@@ -56,7 +56,9 @@ export const hydrate = register(
       createRenderer(loop_template, loop_walks, undefined, item => {
         text(computeProperty("text", item));
       }),
-      i => "" + i.id
+      i => "" + i.id,
+      false,
+      true
     );
   }
 );

--- a/packages/runtime/test/dom/fixtures/create-and-clear-rows/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/create-and-clear-rows/snapshot.expected.md
@@ -18,9 +18,7 @@ inserted div0
 
 # Mutations
 ```
-removed #text before 
-removed #text before 
-removed #text before div0/#text0
+removed #text, #text, #text in div0
 ```
 
 

--- a/packages/runtime/test/dom/fixtures/dynamic-tag/index.ts
+++ b/packages/runtime/test/dom/fixtures/dynamic-tag/index.ts
@@ -38,7 +38,7 @@ export const inputs = [
 ];
 
 export const template = `<!>`;
-export const walks = replace + over(1);
+export const walks = get + over(1);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: typeof inputs[number]) => {

--- a/packages/runtime/test/dom/fixtures/dynamic-tag/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/dynamic-tag/snapshot.expected.md
@@ -9,7 +9,7 @@
 
 # Mutations
 ```
-inserted span0, #text1
+inserted span0
 ```
 
 
@@ -21,7 +21,7 @@ Hello
 # Mutations
 ```
 inserted #text0
-removed span before #text0
+removed span after #text0
 ```
 
 
@@ -37,7 +37,7 @@ removed span before #text0
 # Mutations
 ```
 inserted span0
-removed #text before span0
+removed #text after span0
 span0: attr(a) null => "1"
 ```
 
@@ -54,7 +54,7 @@ span0: attr(a) null => "1"
 # Mutations
 ```
 inserted a0
-removed span before a0
+removed span after a0
 a0: attr(a) null => "1"
 ```
 
@@ -71,6 +71,6 @@ a0: attr(a) null => "1"
 # Mutations
 ```
 inserted div0
-removed a before div0
+removed a after div0
 div0: attr(a) null => "1"
 ```

--- a/packages/runtime/test/dom/fixtures/move-and-clear-children/index.ts
+++ b/packages/runtime/test/dom/fixtures/move-and-clear-children/index.ts
@@ -6,7 +6,7 @@ import {
   createRenderer,
   createRenderFn
 } from "../../../../src/dom/index";
-import { get, over, inside } from "../../utils/walks";
+import { get, over } from "../../utils/walks";
 
 export const inputs = [
   {
@@ -47,7 +47,7 @@ export const inputs = [
 ];
 
 export const template = `<div></div>`;
-export const walks = inside + over(1);
+export const walks = get + over(1);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: { children: Array<{ id: number; text: string }> }) => {
@@ -56,7 +56,9 @@ export const hydrate = register(
       createRenderer(loop_template, loop_walks, undefined, item => {
         text(computeProperty("text", item));
       }),
-      i => "" + i.id
+      i => "" + i.id,
+      false,
+      true
     );
   }
 );

--- a/packages/runtime/test/dom/fixtures/move-and-clear-children/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/move-and-clear-children/snapshot.expected.md
@@ -32,7 +32,5 @@ inserted div0/#text2
 
 # Mutations
 ```
-removed #text before 
-removed #text before 
-removed #text before div0/#text0
+removed #text, #text, #text in div0
 ```

--- a/packages/runtime/test/dom/fixtures/move-and-clear-top-level/index.ts
+++ b/packages/runtime/test/dom/fixtures/move-and-clear-top-level/index.ts
@@ -1,0 +1,67 @@
+import {
+  loopOf,
+  text,
+  computeProperty,
+  register,
+  createRenderer,
+  createRenderFn
+} from "../../../../src/dom/index";
+import { over, inside, get } from "../../utils/walks";
+
+export const inputs = [
+  {
+    children: [
+      {
+        id: 1,
+        text: "a"
+      },
+      {
+        id: 2,
+        text: "b"
+      },
+      {
+        id: 3,
+        text: "c"
+      }
+    ]
+  },
+  {
+    children: []
+  },
+  {
+    children: [
+      {
+        id: 1,
+        text: "a"
+      },
+      {
+        id: 2,
+        text: "b"
+      },
+      {
+        id: 3,
+        text: "c"
+      }
+    ]
+  }
+];
+
+export const template = `<!>`;
+export const walks = get + over(1);
+export const hydrate = register(
+  __dirname.split("/").pop()!,
+  (input: { children: Array<{ id: number; text: string }> }) => {
+    loopOf(
+      input.children,
+      createRenderer(loop_template, loop_walks, undefined, item => {
+        text(computeProperty("text", item));
+      }),
+      i => "" + i.id
+    );
+  }
+);
+
+const loop_template = " ";
+const loop_walks = get + over(1);
+
+export default createRenderFn(template, walks, ["children"], hydrate);

--- a/packages/runtime/test/dom/fixtures/move-and-clear-top-level/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/move-and-clear-top-level/snapshot.expected.md
@@ -1,0 +1,40 @@
+# Render {"children":[{"id":1,"text":"a"},{"id":2,"text":"b"},{"id":3,"text":"c"}]}
+```html
+abc
+```
+
+# Mutations
+```
+inserted #text0, #text1, #text2
+```
+
+
+# Render {"children":[]}
+```html
+<!---->
+```
+
+# Mutations
+```
+inserted #comment0
+removed #text before 
+removed #text before 
+removed #text before #comment0
+```
+
+
+# Render {"children":[{"id":1,"text":"a"},{"id":2,"text":"b"},{"id":3,"text":"c"}]}
+```html
+abc
+```
+
+# Mutations
+```
+inserted #text0
+inserted #text1
+inserted #text2
+removed #comment before #text0
+#text0: " " => "a"
+#text1: " " => "b"
+#text2: " " => "c"
+```

--- a/packages/runtime/test/dom/fixtures/remove-and-add-rows/index.ts
+++ b/packages/runtime/test/dom/fixtures/remove-and-add-rows/index.ts
@@ -6,7 +6,7 @@ import {
   createRenderer,
   createRenderFn
 } from "../../../../src/dom/index";
-import { get, over, inside } from "../../utils/walks";
+import { get, over } from "../../utils/walks";
 
 export const inputs = [
   {
@@ -52,7 +52,7 @@ export const inputs = [
 ];
 
 export const template = `<div></div>`;
-export const walks = inside + over(1);
+export const walks = get + over(1);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: { children: Array<{ id: number; text: string }> }) => {
@@ -61,7 +61,9 @@ export const hydrate = register(
       createRenderer(loop_template, loop_walks, undefined, item => {
         text(computeProperty("text", item));
       }),
-      i => "" + i.id
+      i => "" + i.id,
+      false,
+      true
     );
   }
 );

--- a/packages/runtime/test/dom/fixtures/switch-adjacent-only-children/index.ts
+++ b/packages/runtime/test/dom/fixtures/switch-adjacent-only-children/index.ts
@@ -48,7 +48,7 @@ export const inputs = [
 ];
 
 export const template = `<div></div>`;
-export const walks = inside + over(1);
+export const walks = get + over(1);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: { children: Array<{ id: number; text: string }> }) => {
@@ -57,7 +57,9 @@ export const hydrate = register(
       createRenderer(loop_template, loop_walks, undefined, item => {
         text(computeProperty("text", item));
       }),
-      i => "" + i.id
+      i => "" + i.id,
+      false,
+      true
     );
   }
 );

--- a/packages/runtime/test/dom/fixtures/toggle-context/index.ts
+++ b/packages/runtime/test/dom/fixtures/toggle-context/index.ts
@@ -12,7 +12,7 @@ import {
   createRenderFn,
   walk
 } from "../../../../src/dom/index";
-import { get, inside, over } from "../../utils/walks";
+import { get, next, over } from "../../utils/walks";
 
 export const inputs = [
   {
@@ -29,8 +29,8 @@ export const inputs = [
   }
 ];
 
-export const template = `<div></div>`;
-export const walks = inside + over(1);
+export const template = `<div><!></div>`;
+export const walks = next(1) + get + over(1);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: { value: { name: string } | undefined; visible: boolean }) => {

--- a/packages/runtime/test/dom/fixtures/toggle-context/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/toggle-context/snapshot.expected.md
@@ -1,6 +1,8 @@
 # Render {"visible":false,"value":"Hi"}
 ```html
-<div />
+<div>
+  <!---->
+</div>
 ```
 
 # Mutations
@@ -21,6 +23,7 @@ inserted div0
 # Mutations
 ```
 inserted div0/span0
+removed #comment after div0/span0
 inserted div0/span0/#text0
 ```
 

--- a/packages/runtime/test/dom/fixtures/toggle-detached-state/index.ts
+++ b/packages/runtime/test/dom/fixtures/toggle-detached-state/index.ts
@@ -7,7 +7,7 @@ import {
   createRenderFn,
   walk
 } from "../../../../src/dom/index";
-import { get, inside, over } from "../../utils/walks";
+import { next, get, over } from "../../utils/walks";
 
 export const inputs = [
   {
@@ -24,8 +24,8 @@ export const inputs = [
   }
 ];
 
-export const template = `<div></div>`;
-export const walks = inside + over(1);
+export const template = `<div><!></div>`;
+export const walks = next(1) + get + over(1);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: { value: { name: string } | undefined; visible: boolean }) => {

--- a/packages/runtime/test/dom/fixtures/toggle-detached-state/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/toggle-detached-state/snapshot.expected.md
@@ -15,12 +15,15 @@ inserted div0
 
 # Render {"visible":false}
 ```html
-<div />
+<div>
+  <!---->
+</div>
 ```
 
 # Mutations
 ```
-removed span before div0/#text0
+inserted div0/#comment0
+removed span after div0/#comment0
 ```
 
 
@@ -36,5 +39,6 @@ removed span before div0/#text0
 # Mutations
 ```
 inserted div0/span0
+removed #comment after div0/span0
 inserted div0/span0/#text0
 ```

--- a/packages/runtime/test/dom/fixtures/toggle-first-child/index.ts
+++ b/packages/runtime/test/dom/fixtures/toggle-first-child/index.ts
@@ -7,7 +7,7 @@ import {
   createRenderer,
   createRenderFn
 } from "../../../../src/dom/index";
-import { next, over, before, get } from "../../utils/walks";
+import { next, over, get } from "../../utils/walks";
 
 export const inputs = [
   {
@@ -24,8 +24,8 @@ export const inputs = [
   }
 ];
 
-export const template = `<div><span></span><span></span></div>`;
-export const walks = next(1) + before;
+export const template = `<div><!><span></span><span></span></div>`;
+export const walks = next(1) + get + over(3);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: { value: string | undefined }) => {

--- a/packages/runtime/test/dom/fixtures/toggle-first-child/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/toggle-first-child/snapshot.expected.md
@@ -18,6 +18,7 @@ inserted div0
 # Render {"value":false}
 ```html
 <div>
+  <!---->
   <span />
   <span />
 </div>
@@ -25,7 +26,8 @@ inserted div0
 
 # Mutations
 ```
-removed span before div0/#text0
+inserted div0/#comment0
+removed span after div0/#comment0
 ```
 
 
@@ -43,6 +45,7 @@ removed span before div0/#text0
 # Mutations
 ```
 inserted div0/span0
+removed #comment after div0/span0
 inserted div0/span0/#text0
 ```
 

--- a/packages/runtime/test/dom/fixtures/toggle-last-child/index.ts
+++ b/packages/runtime/test/dom/fixtures/toggle-last-child/index.ts
@@ -7,7 +7,7 @@ import {
   createRenderer,
   createRenderFn
 } from "../../../../src/dom/index";
-import { next, over, after, get } from "../../utils/walks";
+import { next, over, get } from "../../utils/walks";
 
 export const inputs = [
   {
@@ -24,8 +24,8 @@ export const inputs = [
   }
 ];
 
-export const template = `<div><span></span><span></span></div>`;
-export const walks = next(2) + after;
+export const template = `<div><span></span><span></span><!></div>`;
+export const walks = next(3) + get + over(1);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: { value: string | undefined }) => {

--- a/packages/runtime/test/dom/fixtures/toggle-last-child/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/toggle-last-child/snapshot.expected.md
@@ -20,12 +20,14 @@ inserted div0
 <div>
   <span />
   <span />
+  <!---->
 </div>
 ```
 
 # Mutations
 ```
-removed span after div0/span1
+inserted div0/#comment2
+removed span after div0/#comment2
 ```
 
 
@@ -43,6 +45,7 @@ removed span after div0/span1
 # Mutations
 ```
 inserted div0/span2
+removed #comment after div0/span2
 inserted div0/span2/#text0
 ```
 

--- a/packages/runtime/test/dom/fixtures/toggle-middle-child/index.ts
+++ b/packages/runtime/test/dom/fixtures/toggle-middle-child/index.ts
@@ -7,7 +7,7 @@ import {
   createRenderer,
   createRenderFn
 } from "../../../../src/dom/index";
-import { next, over, before, get } from "../../utils/walks";
+import { next, over, get } from "../../utils/walks";
 
 export const inputs = [
   {
@@ -24,8 +24,8 @@ export const inputs = [
   }
 ];
 
-export const template = `<div><span></span><span></span></div>`;
-export const walks = next(2) + before;
+export const template = `<div><span></span><!><span></span></div>`;
+export const walks = next(2) + get + over(2);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: { value: string | undefined }) => {

--- a/packages/runtime/test/dom/fixtures/toggle-middle-child/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/toggle-middle-child/snapshot.expected.md
@@ -19,13 +19,15 @@ inserted div0
 ```html
 <div>
   <span />
+  <!---->
   <span />
 </div>
 ```
 
 # Mutations
 ```
-removed span after div0/span0
+inserted div0/#comment1
+removed span after div0/#comment1
 ```
 
 
@@ -43,6 +45,7 @@ removed span after div0/span0
 # Mutations
 ```
 inserted div0/span1
+removed #comment after div0/span1
 inserted div0/span1/#text0
 ```
 

--- a/packages/runtime/test/dom/fixtures/toggle-nested/index.ts
+++ b/packages/runtime/test/dom/fixtures/toggle-nested/index.ts
@@ -1,0 +1,98 @@
+import {
+  compute,
+  walk,
+  textContent,
+  conditional,
+  register,
+  createRenderer,
+  createRenderFn
+} from "../../../../src/dom/index";
+import { next, over, get } from "../../utils/walks";
+
+export const inputs = [
+  {
+    show: false,
+    value1: "Hello",
+    value2: "World"
+  },
+  {
+    show: true,
+    value1: "Hello",
+    value2: "World"
+  },
+  {
+    show: true,
+    value1: false,
+    value2: "World"
+  },
+  {
+    show: true,
+    value1: "Goodbye",
+    value2: "World"
+  },
+  {
+    show: false,
+    value1: "Goodbye",
+    value2: "World"
+  }
+];
+
+export const template = `<div><!></div>`;
+export const walks = next(1) + get + over(1);
+export const hydrate = register(
+  __dirname.split("/").pop()!,
+  (input: {
+    show: boolean;
+    value1: string | undefined;
+    value2: string | undefined;
+  }) => {
+    const branch0 = createRenderer(
+      branch0_template,
+      branch0_walks,
+      undefined,
+      () => {
+        const branch1 = createRenderer(
+          branch1_template,
+          branch1_walks,
+          undefined,
+          () => {
+            walk();
+            textContent(input.value1);
+          }
+        );
+        const branch2 = createRenderer(
+          branch2_template,
+          branch2_walks,
+          undefined,
+          () => {
+            walk();
+            textContent(input.value2);
+          }
+        );
+        conditional(
+          compute(value1 => (value1 ? branch1 : undefined), input.value1, 1)
+        );
+        conditional(
+          compute(value2 => (value2 ? branch2 : undefined), input.value2, 1)
+        );
+      }
+    );
+    conditional(compute(show => (show ? branch0 : undefined), input.show, 1));
+  }
+);
+
+const branch0_template = "<!><!>";
+const branch0_walks = get + over(1) + get + over(1);
+
+const branch1_template = "<span></span>";
+const branch1_walks = get + over(1);
+
+const branch2_template = "<span></span>";
+const branch2_walks = get + over(1);
+
+export default createRenderFn(
+  template,
+  walks,
+  ["show", "value1", "value2"],
+  hydrate
+);

--- a/packages/runtime/test/dom/fixtures/toggle-nested/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/toggle-nested/snapshot.expected.md
@@ -1,0 +1,89 @@
+# Render {"show":false,"value1":"Hello","value2":"World"}
+```html
+<div>
+  <!---->
+</div>
+```
+
+# Mutations
+```
+inserted div0
+```
+
+
+# Render {"show":true,"value1":"Hello","value2":"World"}
+```html
+<div>
+  <span>
+    Hello
+  </span>
+  <span>
+    World
+  </span>
+</div>
+```
+
+# Mutations
+```
+inserted 
+inserted 
+removed #comment after 
+inserted div0/span0
+removed #comment after div0/span0
+inserted div0/span1
+removed #comment after div0/span1
+inserted div0/span0/#text0
+inserted div0/span1/#text0
+```
+
+
+# Render {"show":true,"value1":false,"value2":"World"}
+```html
+<div>
+  <!---->
+  <span>
+    World
+  </span>
+</div>
+```
+
+# Mutations
+```
+inserted div0/#comment0
+removed span after div0/#comment0
+```
+
+
+# Render {"show":true,"value1":"Goodbye","value2":"World"}
+```html
+<div>
+  <span>
+    Goodbye
+  </span>
+  <span>
+    World
+  </span>
+</div>
+```
+
+# Mutations
+```
+inserted div0/span0
+removed #comment after div0/span0
+inserted div0/span0/#text0
+```
+
+
+# Render {"show":false,"value1":"Goodbye","value2":"World"}
+```html
+<div>
+  <!---->
+</div>
+```
+
+# Mutations
+```
+inserted div0/#comment0
+removed span after div0/#comment0
+removed span after div0/#comment0
+```

--- a/packages/runtime/test/dom/fixtures/toggle-only-child/index.ts
+++ b/packages/runtime/test/dom/fixtures/toggle-only-child/index.ts
@@ -7,7 +7,7 @@ import {
   createRenderFn,
   walk
 } from "../../../../src/dom/index";
-import { get, inside, over } from "../../utils/walks";
+import { get, next, over } from "../../utils/walks";
 
 export const inputs = [
   {
@@ -24,8 +24,8 @@ export const inputs = [
   }
 ];
 
-export const template = `<div></div>`;
-export const walks = inside + over(1);
+export const template = `<div><!></div>`;
+export const walks = next(1) + get + over(1);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: { value: string | undefined }) => {

--- a/packages/runtime/test/dom/fixtures/toggle-only-child/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/toggle-only-child/snapshot.expected.md
@@ -15,12 +15,15 @@ inserted div0
 
 # Render {"value":false}
 ```html
-<div />
+<div>
+  <!---->
+</div>
 ```
 
 # Mutations
 ```
-removed span before div0/#text0
+inserted div0/#comment0
+removed span after div0/#comment0
 ```
 
 
@@ -36,6 +39,7 @@ removed span before div0/#text0
 # Mutations
 ```
 inserted div0/span0
+removed #comment after div0/span0
 inserted div0/span0/#text0
 ```
 

--- a/packages/runtime/test/dom/fixtures/update-html/index.ts
+++ b/packages/runtime/test/dom/fixtures/update-html/index.ts
@@ -1,5 +1,5 @@
 import { html, register, createRenderFn } from "../../../../src/dom/index";
-import { over, after } from "../../utils/walks";
+import { over, get } from "../../utils/walks";
 
 export const inputs = [
   {
@@ -16,8 +16,8 @@ export const inputs = [
 export const FAILS_HYDRATE = true;
 
 // <em>Testing</em> $!{input.value}
-export const template = "<em>Testing</em> ";
-export const walks = over(1) + after + over(1);
+export const template = "<em>Testing</em> <!>";
+export const walks = over(2) + get + over(1);
 export const hydrate = register(
   __dirname.split("/").pop()!,
   (input: typeof inputs[number]) => {

--- a/packages/runtime/test/dom/fixtures/update-html/snapshot.expected.md
+++ b/packages/runtime/test/dom/fixtures/update-html/snapshot.expected.md
@@ -11,7 +11,7 @@ Hello
 
 # Mutations
 ```
-inserted em0, #text1, #text2, strong3, #text4
+inserted em0, #text1, #text2, strong3
 ```
 
 
@@ -26,8 +26,8 @@ Some content
 # Mutations
 ```
 inserted #text2
-removed #text after #text1
-removed strong after #text1
+removed #text after #text2
+removed strong after #text2
 ```
 
 
@@ -42,5 +42,5 @@ removed strong after #text1
 # Mutations
 ```
 inserted div2
-removed #text after #text1
+removed #text after div2
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixes issues related to empty fragments, specifically when nested.
- Fragments now use a comment as a marker rather than an empty text node
- The marker node is no longer always in the DOM, it is only there when empty

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
