### PR TITLE
refactor: scope as object per section, passed as arguments

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -6,27 +6,27 @@
     {
       "name": "*",
       "total": {
-        "min": 11267,
-        "gzip": 4998,
-        "brotli": 4523
+        "min": 10491,
+        "gzip": 4693,
+        "brotli": 4212
       }
     },
     {
       "name": "counter",
       "user": {
-        "min": 336,
-        "gzip": 256,
-        "brotli": 218
+        "min": 370,
+        "gzip": 266,
+        "brotli": 233
       },
       "runtime": {
-        "min": 4502,
-        "gzip": 2125,
-        "brotli": 1892
+        "min": 4110,
+        "gzip": 1985,
+        "brotli": 1757
       },
       "total": {
-        "min": 4838,
-        "gzip": 2381,
-        "brotli": 2110
+        "min": 4480,
+        "gzip": 2251,
+        "brotli": 1990
       }
     }
   ]

--- a/packages/runtime/src/__tests__/fixtures/basic-counter/__snapshots__/ssr-hydrate.expected.md
+++ b/packages/runtime/src/__tests__/fixtures/basic-counter/__snapshots__/ssr-hydrate.expected.md
@@ -1,5 +1,5 @@
 # Write
-  <!M^0><body><!M#2 0 2><button><!M#1 0 3>0</button></body><!M/0><script>(M$h=[]).push((b,s)=>({"0":[,,,,0]}),["counter",2,0,])</script>
+  <!M^0><body><!M#0 0 0><button><!M#1 0 1>0</button></body><!M/0><script>(M$h=[]).push((b,s)=>({"0":[,,0]}),["counter",0,])</script>
 
 
 # Render "End"
@@ -8,13 +8,13 @@
 <html>
   <head />
   <body>
-    <!--M#2 0 2-->
+    <!--M#0 0 0-->
     <button>
-      <!--M#1 0 3-->
+      <!--M#1 0 1-->
       0
     </button>
     <script>
-      (M$h=[]).push((b,s)=&gt;({"0":[,,,,0]}),["counter",2,0,])
+      (M$h=[]).push((b,s)=&gt;({"0":[,,0]}),["counter",0,])
     </script>
   </body>
   <!--M/0-->
@@ -43,13 +43,13 @@ inserted #document/html1/body1/script2/#text0
 <html>
   <head />
   <body>
-    <!--M#2 0 2-->
+    <!--M#0 0 0-->
     <button>
-      <!--M#1 0 3-->
+      <!--M#1 0 1-->
       0
     </button>
     <script>
-      (M$h=[]).push((b,s)=&gt;({"0":[,,,,0]}),["counter",2,0,])
+      (M$h=[]).push((b,s)=&gt;({"0":[,,0]}),["counter",0,])
     </script>
   </body>
   <!--M/0-->
@@ -70,13 +70,13 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M#2 0 2-->
+    <!--M#0 0 0-->
     <button>
-      <!--M#1 0 3-->
+      <!--M#1 0 1-->
       1
     </button>
     <script>
-      (M$h=[]).push((b,s)=&gt;({"0":[,,,,0]}),["counter",2,0,])
+      (M$h=[]).push((b,s)=&gt;({"0":[,,0]}),["counter",0,])
     </script>
   </body>
   <!--M/0-->
@@ -97,13 +97,13 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M#2 0 2-->
+    <!--M#0 0 0-->
     <button>
-      <!--M#1 0 3-->
+      <!--M#1 0 1-->
       2
     </button>
     <script>
-      (M$h=[]).push((b,s)=&gt;({"0":[,,,,0]}),["counter",2,0,])
+      (M$h=[]).push((b,s)=&gt;({"0":[,,0]}),["counter",0,])
     </script>
   </body>
   <!--M/0-->
@@ -124,13 +124,13 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M#2 0 2-->
+    <!--M#0 0 0-->
     <button>
-      <!--M#1 0 3-->
+      <!--M#1 0 1-->
       3
     </button>
     <script>
-      (M$h=[]).push((b,s)=&gt;({"0":[,,,,0]}),["counter",2,0,])
+      (M$h=[]).push((b,s)=&gt;({"0":[,,0]}),["counter",0,])
     </script>
   </body>
   <!--M/0-->

--- a/packages/runtime/src/__tests__/fixtures/basic-counter/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/basic-counter/browser.ts
@@ -2,10 +2,10 @@ import {
   data,
   createRenderFn,
   on,
-  read,
   queue,
   write,
   bind,
+  Scope,
 } from "../../../dom/index";
 import { get, next, open, close } from "../../utils/walks";
 
@@ -15,37 +15,41 @@ const enum Index {
   CLICK_COUNT = 2,
 }
 
-type scope = {
+type ComponentScope = Scope<{
   [Index.BUTTON]: HTMLButtonElement;
   [Index.BUTTON_TEXT]: Text;
   [Index.CLICK_COUNT]: number;
-};
+}>;
 
 // <let/clickCount = 0/>
 // <button onclick() { clickCount++ }>${clickCount}</button>
 
 export const template = `<button> </button>`;
 export const walks = open(3) + get + next(1) + get + next(1) + close;
-export const render = () => {
-  renderClickCount(0);
-  hydrate();
+export const render = (scope: ComponentScope) => {
+  renderClickCount(scope, 0);
+  hydrate(scope);
 };
 
-export const hydrate = () => {
-  on(Index.BUTTON, "click", bind(clickHandler));
+export const hydrate = (scope: ComponentScope) => {
+  on(scope, Index.BUTTON, "click", bind(scope, clickHandler));
 };
 
-const renderClickCount = (value: scope[Index.CLICK_COUNT]) => {
-  if (write(Index.CLICK_COUNT, value)) {
-    data(Index.BUTTON_TEXT, value);
+const renderClickCount = (
+  scope: ComponentScope,
+  value: ComponentScope[Index.CLICK_COUNT]
+) => {
+  if (write(scope, Index.CLICK_COUNT, value)) {
+    data(scope, Index.BUTTON_TEXT, value);
   }
 };
 
-const clickHandler = () => {
+const clickHandler = (scope: ComponentScope) => {
   queue(
+    scope,
     renderClickCount,
     Index.CLICK_COUNT,
-    read<scope, Index.CLICK_COUNT>(Index.CLICK_COUNT) + 1
+    scope[Index.CLICK_COUNT] + 1
   );
 };
 

--- a/packages/runtime/src/__tests__/fixtures/basic-counter/server.ts
+++ b/packages/runtime/src/__tests__/fixtures/basic-counter/server.ts
@@ -1,30 +1,22 @@
 import type { Scope } from "../../../common/types";
 import { write, markScopeOffset, writeScope, writeCall } from "../../../html";
 
-export default (
-  _input: unknown,
-  currentScope: Scope,
-  currentOffset: number
-) => {
+export default (_input: unknown, currentScope: Scope) => {
   write("<body>");
-  counter(_input, currentScope, currentOffset);
+  counter(_input, currentScope);
   write("</body>");
 };
 
-const counter = (
-  _input: unknown,
-  currentScope: Scope,
-  currentOffset: number
-) => {
+const counter = (_input: unknown, currentScope: Scope) => {
   const count = 0;
 
-  currentScope[currentOffset + 2] = count;
+  currentScope[2] = count;
   write(
-    `${markScopeOffset(currentOffset, currentScope)}<button>${markScopeOffset(
-      currentOffset + 1,
+    `${markScopeOffset(0, currentScope)}<button>${markScopeOffset(
+      1,
       currentScope
     )}${count}</button>`
   );
   writeScope(currentScope);
-  writeCall("counter", currentOffset, currentScope.___id);
+  writeCall("counter", currentScope.___id);
 };

--- a/packages/runtime/src/__tests__/fixtures/create-and-clear-rows-loop-from/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/create-and-clear-rows-loop-from/browser.ts
@@ -4,7 +4,7 @@ import {
   createRenderer,
   createRenderFn,
   write,
-  read,
+  Scope,
 } from "../../../dom/index";
 import { over, get, next, open, close } from "../../utils/walks";
 
@@ -36,13 +36,13 @@ const enum Index {
   INPUT_STEP = 6,
 }
 
-type scope = {
+type ComponentScope = Scope<{
   [Index.DIV]: HTMLDivElement;
   [Index.LOOP]: HTMLDivElement;
   [Index.INPUT_FROM]: Input["from"];
   [Index.INPUT_TO]: Input["to"];
   [Index.INPUT_STEP]: Input["step"];
-};
+}>;
 
 // <div>
 //   <for|child| from=input.from to=input.to step=input.step>
@@ -53,22 +53,23 @@ type scope = {
 export const template = `<div></div>`;
 export const walks = open(7) + get + over(1) + close;
 
-export const execInputFromToStep = () => {
+export const execInputFromToStep = (scope: ComponentScope) => {
   setLoopFromTo(
+    scope,
     Index.LOOP,
-    read<scope, Index.INPUT_FROM>(Index.INPUT_FROM),
-    read<scope, Index.INPUT_TO>(Index.INPUT_TO),
-    read<scope, Index.INPUT_STEP>(Index.INPUT_STEP),
+    scope[Index.INPUT_FROM] as number,
+    scope[Index.INPUT_TO] as number,
+    scope[Index.INPUT_STEP] as number,
     iter0,
     iter0_execItem
   );
 };
 
-export const execDynamicInput = (input: Input) => {
-  write(Index.INPUT_FROM, input.from);
-  write(Index.INPUT_TO, input.to);
-  write(Index.INPUT_STEP, input.step);
-  execInputFromToStep();
+export const execDynamicInput = (scope: ComponentScope, input: Input) => {
+  write(scope, Index.INPUT_FROM, input.from);
+  write(scope, Index.INPUT_TO, input.to);
+  write(scope, Index.INPUT_STEP, input.step);
+  execInputFromToStep(scope);
 };
 
 export default createRenderFn(template, walks, undefined, 0, execDynamicInput);
@@ -78,10 +79,11 @@ const enum Iter0Index {
   ITEM = 1,
 }
 
-// type iterScope = {
-//   [Iter0Index.TEXT]: Text;
-//   [Iter0Index.ITEM]: number;
-// };
+type IterScope = Scope<{
+  _: ComponentScope;
+  [Iter0Index.TEXT]: Text;
+  [Iter0Index.ITEM]: number;
+}>;
 
 const iter0 = createRenderer(
   " ",
@@ -90,8 +92,8 @@ const iter0 = createRenderer(
   0
 );
 
-const iter0_execItem = (item: number) => {
-  if (write(Iter0Index.ITEM, item)) {
-    data(Iter0Index.TEXT, item);
+const iter0_execItem = (scope: IterScope, item: number) => {
+  if (write(scope, Iter0Index.ITEM, item)) {
+    data(scope, Iter0Index.TEXT, item);
   }
 };

--- a/packages/runtime/src/__tests__/fixtures/event-handlers/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/event-handlers/browser.ts
@@ -2,10 +2,10 @@ import {
   data,
   createRenderFn,
   on,
-  read,
   queue,
   write,
   bind,
+  Scope,
 } from "../../../dom/index";
 import { get, next, open, close } from "../../utils/walks";
 
@@ -22,49 +22,47 @@ const enum Index {
   EVENT_HANDLER = 3,
 }
 
-type scope = {
+type ComponentScope = Scope<{
   [Index.BUTTON]: HTMLButtonElement;
   [Index.BUTTON_TEXT]: Text;
   [Index.CLICK_COUNT]: number;
   [Index.EVENT_HANDLER]: false | (() => void);
-};
+}>;
 
 // <let/clickCount = 0/>
 // <button onclick=(clickCount < 1 ? (() => clickCount++) : false)>${clickCount}</button>
 
 export const template = `<button> </button>`;
 export const walks = open(3) + get + next(1) + get + next(1) + close;
-export const render = () => {
-  execClickCount(0);
+export const render = (scope: ComponentScope) => {
+  execClickCount(scope, 0);
 };
 
-const execClickCount = (value: scope[Index.CLICK_COUNT]) => {
-  if (write(Index.CLICK_COUNT, value)) {
-    data(Index.BUTTON_TEXT, value);
-    execClickHandler(value <= 1 ? bind(clickHandler) : false);
+const execClickCount = (
+  scope: ComponentScope,
+  value: ComponentScope[Index.CLICK_COUNT]
+) => {
+  if (write(scope, Index.CLICK_COUNT, value)) {
+    data(scope, Index.BUTTON_TEXT, value);
+    execClickHandler(scope, value <= 1 ? bind(scope, clickHandler) : false);
   }
 };
 
-const execClickHandler = (value: scope[Index.EVENT_HANDLER]) => {
-  if (write(Index.EVENT_HANDLER, value)) {
-    attachEventHandler();
+const execClickHandler = (
+  scope: ComponentScope,
+  value: ComponentScope[Index.EVENT_HANDLER]
+) => {
+  if (write(scope, Index.EVENT_HANDLER, value)) {
+    attachEventHandler(scope);
   }
 };
 
-export const attachEventHandler = () => {
-  on(
-    Index.BUTTON,
-    "click",
-    read<scope, Index.EVENT_HANDLER>(Index.EVENT_HANDLER)
-  );
+export const attachEventHandler = (scope: ComponentScope) => {
+  on(scope, Index.BUTTON, "click", scope[Index.EVENT_HANDLER] as () => void);
 };
 
-const clickHandler = () => {
-  queue(
-    execClickCount as any,
-    Index.CLICK_COUNT,
-    read<scope, Index.CLICK_COUNT>(Index.CLICK_COUNT) + 1
-  );
+const clickHandler = (scope: ComponentScope) => {
+  queue(scope, execClickCount, Index.CLICK_COUNT, scope[Index.CLICK_COUNT] + 1);
 };
 
 export default createRenderFn(template, walks, render, 0);

--- a/packages/runtime/src/__tests__/fixtures/move-and-clear-children/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/move-and-clear-children/browser.ts
@@ -1,10 +1,10 @@
 import {
   data,
-  read,
   write,
   setLoopOf,
   createRenderer,
   createRenderFn,
+  Scope,
 } from "../../../dom/index";
 import { open, close, get, next, over } from "../../utils/walks";
 
@@ -54,11 +54,11 @@ const enum Index {
   INPUT_CHILDREN = 4,
 }
 
-type scope = {
+type ComponentScope = Scope<{
   [Index.DIV]: HTMLDivElement;
   [Index.LOOP]: HTMLDivElement;
   [Index.INPUT_CHILDREN]: Input["children"];
-};
+}>;
 
 // <div>
 //   <for|child| of=input.children by(c) { return c.id }>
@@ -69,19 +69,20 @@ type scope = {
 export const template = `<div></div>`;
 export const walks = open(5) + get + over(1) + close;
 
-export const execInputChildren = () => {
+export const execInputChildren = (scope: ComponentScope) => {
   setLoopOf(
+    scope,
     Index.LOOP,
-    read<scope, Index.INPUT_CHILDREN>(Index.INPUT_CHILDREN),
+    scope[Index.INPUT_CHILDREN] as Input["children"],
     iter0,
     (i) => "" + (i as Input["children"][number]).id,
     iter0_execItem
   );
 };
 
-export const execDynamicInput = (input: Input) => {
-  if (write(Index.INPUT_CHILDREN, input.children)) {
-    execInputChildren();
+export const execDynamicInput = (scope: ComponentScope, input: Input) => {
+  if (write(scope, Index.INPUT_CHILDREN, input.children)) {
+    execInputChildren(scope);
   }
 };
 
@@ -92,7 +93,11 @@ const enum Iter0Index {
   ITEM = 1,
 }
 
-// type iterScope = [Text, Input["children"][number]];
+type IterScope = Scope<{
+  _: ComponentScope;
+  [Iter0Index.TEXT]: Text;
+  [Iter0Index.ITEM]: Input["children"][number];
+}>;
 
 const iter0 = createRenderer(
   " ",
@@ -101,8 +106,8 @@ const iter0 = createRenderer(
   0
 );
 
-const iter0_execItem = (item: Input["children"][number]) => {
-  if (write(Iter0Index.ITEM, item)) {
-    data(Iter0Index.TEXT, item.text);
+const iter0_execItem = (scope: IterScope, item: Input["children"][number]) => {
+  if (write(scope, Iter0Index.ITEM, item)) {
+    data(scope, Iter0Index.TEXT, item.text);
   }
 };

--- a/packages/runtime/src/__tests__/fixtures/move-and-clear-top-level/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/move-and-clear-top-level/browser.ts
@@ -1,10 +1,10 @@
 import {
   data,
-  read,
   write,
   setLoopOf,
   createRenderer,
   createRenderFn,
+  Scope,
 } from "../../../dom/index";
 import { open, close, next, over, get } from "../../utils/walks";
 
@@ -54,11 +54,11 @@ const enum Index {
   INPUT_CHILDREN = 4,
 }
 
-type scope = {
+type ComponentScope = Scope<{
   [Index.COMMENT]: Comment;
   [Index.LOOP]: Comment;
   [Index.INPUT_CHILDREN]: Input["children"];
-};
+}>;
 
 // <for|child| of=input.children by(c) { return c.id }>
 //   ${child.text}
@@ -67,19 +67,20 @@ type scope = {
 export const template = `<!>`;
 export const walks = open(5) + get + over(1) + close;
 
-export const execInputChildren = () => {
+export const execInputChildren = (scope: ComponentScope) => {
   setLoopOf(
+    scope,
     Index.LOOP,
-    read<scope, Index.INPUT_CHILDREN>(Index.INPUT_CHILDREN),
+    scope[Index.INPUT_CHILDREN] as Input["children"],
     iter0,
     (i) => "" + (i as Input["children"][number]).id,
     iter0_execItem
   );
 };
 
-export const execDynamicInput = (input: Input) => {
-  if (write(Index.INPUT_CHILDREN, input.children)) {
-    execInputChildren();
+export const execDynamicInput = (scope: ComponentScope, input: Input) => {
+  if (write(scope, Index.INPUT_CHILDREN, input.children)) {
+    execInputChildren(scope);
   }
 };
 
@@ -90,7 +91,11 @@ const enum Iter0Index {
   ITEM = 1,
 }
 
-// type iterScope = [Text, Input["children"][number]];
+type IterScope = Scope<{
+  _: ComponentScope;
+  [Iter0Index.TEXT]: Text;
+  [Iter0Index.ITEM]: Input["children"][number];
+}>;
 
 const iter0 = createRenderer(
   " ",
@@ -99,8 +104,8 @@ const iter0 = createRenderer(
   0
 );
 
-const iter0_execItem = (item: Input["children"][number]) => {
-  if (write(Iter0Index.ITEM, item)) {
-    data(Iter0Index.TEXT, item.text);
+const iter0_execItem = (scope: IterScope, item: Input["children"][number]) => {
+  if (write(scope, Iter0Index.ITEM, item)) {
+    data(scope, Iter0Index.TEXT, item.text);
   }
 };

--- a/packages/runtime/src/__tests__/fixtures/switch-adjacent-only-children/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/switch-adjacent-only-children/browser.ts
@@ -1,10 +1,10 @@
 import {
   data,
-  read,
   write,
   setLoopOf,
   createRenderer,
   createRenderFn,
+  Scope,
 } from "../../../dom/index";
 import { get, next, open, close } from "../../utils/walks";
 
@@ -55,11 +55,11 @@ const enum Index {
   INPUT_CHILDREN = 4,
 }
 
-type scope = {
+type ComponentScope = Scope<{
   [Index.DIV]: HTMLDivElement;
   [Index.LOOP]: HTMLDivElement;
   [Index.INPUT_CHILDREN]: Input["children"];
-};
+}>;
 
 // <div>
 //   <for|child| of=input.children by(c) { return c.id }>
@@ -70,19 +70,20 @@ type scope = {
 export const template = `<div></div>`;
 export const walks = open(5) + get + next(1) + close;
 
-export const execInputChildren = () => {
+export const execInputChildren = (scope: ComponentScope) => {
   setLoopOf(
+    scope,
     Index.LOOP,
-    read<scope, Index.INPUT_CHILDREN>(Index.INPUT_CHILDREN),
+    scope[Index.INPUT_CHILDREN] as Input["children"],
     iter0,
     (i) => "" + (i as Input["children"][number]).id,
     iter0_execItem
   );
 };
 
-export const execDynamicInput = (input: Input) => {
-  if (write(Index.INPUT_CHILDREN, input.children)) {
-    execInputChildren();
+export const execDynamicInput = (scope: ComponentScope, input: Input) => {
+  if (write(scope, Index.INPUT_CHILDREN, input.children)) {
+    execInputChildren(scope);
   }
 };
 
@@ -93,7 +94,11 @@ const enum Iter0Index {
   ITEM = 1,
 }
 
-// type iterScope = [Text, Input["children"][number]];
+type IterScope = Scope<{
+  _: ComponentScope;
+  [Iter0Index.TEXT]: Text;
+  [Iter0Index.ITEM]: Input["children"][number];
+}>;
 
 const iter0 = createRenderer(
   " ",
@@ -102,8 +107,8 @@ const iter0 = createRenderer(
   0
 );
 
-const iter0_execItem = (item: Input["children"][number]) => {
-  if (write(Iter0Index.ITEM, item)) {
-    data(Iter0Index.TEXT, item.text);
+const iter0_execItem = (scope: IterScope, item: Input["children"][number]) => {
+  if (write(scope, Iter0Index.ITEM, item)) {
+    data(scope, Iter0Index.TEXT, item.text);
   }
 };

--- a/packages/runtime/src/__tests__/fixtures/toggle-first-child/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/toggle-first-child/browser.ts
@@ -2,11 +2,10 @@ import {
   data,
   setConditionalRenderer,
   write,
-  read,
   createRenderer,
   createRenderFn,
-  readInOwner,
   queueInBranch,
+  Scope,
 } from "../../../dom/index";
 import { next, over, get, open, close } from "../../utils/walks";
 
@@ -36,11 +35,11 @@ const enum PRIORITY {
   closure_value = 1,
 }
 
-type SCOPE = {
+type ComponentScope = Scope<{
   [INDEX.comment]: Comment;
   [INDEX.conditional]: Comment;
   [INDEX.value]: typeof inputs[number]["value"];
-};
+}>;
 
 // <attrs/{ value }/>
 // <div>
@@ -54,12 +53,14 @@ type SCOPE = {
 export const template = `<div><!><span></span><span></span></div>`;
 export const walks = open(5) + next(1) + get + over(3) + close;
 
-export const _apply_value = () => {
+export const _apply_value = (scope: ComponentScope) => {
   setConditionalRenderer(
+    scope,
     INDEX.conditional,
-    read(INDEX.value) ? branch0 : undefined
+    scope[INDEX.value] ? branch0 : undefined
   );
   queueInBranch(
+    scope,
     INDEX.conditional,
     branch0,
     _apply_value2,
@@ -68,13 +69,16 @@ export const _apply_value = () => {
   );
 };
 
-function _apply_value2() {
-  data(INDEX_BRANCH0.text, readInOwner<SCOPE, INDEX.value>(INDEX.value));
+function _apply_value2(scope: Branch0Scope) {
+  data(scope, INDEX_BRANCH0.text, scope._[INDEX.value]);
 }
 
-export const _applyAttrs = (input: typeof inputs[number]) => {
-  if (write(INDEX.value, input.value)) {
-    _apply_value();
+export const _applyAttrs = (
+  scope: ComponentScope,
+  input: typeof inputs[number]
+) => {
+  if (write(scope, INDEX.value, input.value)) {
+    _apply_value(scope);
   }
 };
 
@@ -88,9 +92,10 @@ const enum PRIORITY_BRANCH0 {
   value = 0,
 }
 
-// type Branch0Scope = {
-//   [Branch0Index.TEXT]: Text
-// };
+type Branch0Scope = Scope<{
+  _: ComponentScope;
+  [INDEX_BRANCH0.text]: Text;
+}>;
 
 const branch0 = createRenderer(
   "<span> </span>",

--- a/packages/runtime/src/__tests__/fixtures/toggle-last-child/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/toggle-last-child/browser.ts
@@ -1,12 +1,11 @@
 import {
   data,
   setConditionalRenderer,
-  read,
   write,
   createRenderer,
   createRenderFn,
-  readInOwner,
   queueInBranch,
+  Scope,
 } from "../../../dom/index";
 import { next, over, get, open, close } from "../../utils/walks";
 
@@ -36,11 +35,11 @@ const enum PRIORITY {
   closure_value = 1,
 }
 
-type SCOPE = {
+type ComponentScope = Scope<{
   [INDEX.comment]: Comment;
   [INDEX.conditional]: Comment;
   [INDEX.value]: typeof inputs[number]["value"];
-};
+}>;
 
 // <attrs/{ value }/>
 // <div>
@@ -54,12 +53,14 @@ type SCOPE = {
 export const template = `<div><span></span><span></span><!></div>`;
 export const walks = open(5) + next(3) + get + over(1) + close;
 
-export const _apply_value = () => {
+export const _apply_value = (scope: ComponentScope) => {
   setConditionalRenderer(
+    scope,
     INDEX.conditional,
-    read(INDEX.value) ? branch0 : undefined
+    scope[INDEX.value] ? branch0 : undefined
   );
   queueInBranch(
+    scope,
     INDEX.conditional,
     branch0,
     _apply_value2,
@@ -68,13 +69,16 @@ export const _apply_value = () => {
   );
 };
 
-function _apply_value2() {
-  data(INDEX_BRANCH0.text, readInOwner<SCOPE, INDEX.value>(INDEX.value));
+function _apply_value2(scope: Branch0Scope) {
+  data(scope, INDEX_BRANCH0.text, scope._[INDEX.value]);
 }
 
-export const _applyAttrs = (input: typeof inputs[number]) => {
-  if (write(INDEX.value, input.value)) {
-    _apply_value();
+export const _applyAttrs = (
+  scope: ComponentScope,
+  input: typeof inputs[number]
+) => {
+  if (write(scope, INDEX.value, input.value)) {
+    _apply_value(scope);
   }
 };
 
@@ -88,9 +92,10 @@ const enum PRIORITY_BRANCH0 {
   value = 0,
 }
 
-// type Branch0Scope = {
-//   [Branch0Index.TEXT]: Text
-// };
+type Branch0Scope = Scope<{
+  _: ComponentScope;
+  [INDEX_BRANCH0.text]: Text;
+}>;
 
 const branch0 = createRenderer(
   "<span> </span>",

--- a/packages/runtime/src/__tests__/fixtures/toggle-nested/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/toggle-nested/browser.ts
@@ -5,10 +5,9 @@ import {
   createRenderFn,
   dynamicFragment,
   write,
-  read,
   queue,
-  readInOwner,
   queueInBranch,
+  Scope,
 } from "../../../dom/index";
 import { next, over, get, open, close, skip } from "../../utils/walks";
 
@@ -58,13 +57,13 @@ const enum PRIORITY {
   closure_value2 = 4,
 }
 
-type SCOPE = {
+type ComponentScope = Scope<{
   [INDEX.comment]: Comment;
   [INDEX.conditional]: Comment;
   [INDEX.show]: Input["show"];
   [INDEX.value1]: Input["value1"];
   [INDEX.value2]: Input["value2"];
-};
+}>;
 
 // <attrs/{show, value1, value2}/>
 // <div>
@@ -77,16 +76,18 @@ type SCOPE = {
 export const template = `<div><!></div>`;
 export const walks = open(7) + next(1) + get + over(1) + close;
 
-export const _apply_show = () => {
+export const _apply_show = (scope: ComponentScope) => {
   setConditionalRenderer(
+    scope,
     INDEX.conditional,
-    read<SCOPE, INDEX.show>(INDEX.show) ? branch0 : undefined,
+    scope[INDEX.show] ? branch0 : undefined,
     dynamicFragment
   );
 };
 
-export const _apply_value1 = () => {
+export const _apply_value1 = (scope: ComponentScope) => {
   queueInBranch(
+    scope,
     INDEX.conditional,
     branch0,
     execInputValue1Branch0,
@@ -95,12 +96,14 @@ export const _apply_value1 = () => {
   );
 };
 
-export const execInputValue1Branch0 = () => {
+export const execInputValue1Branch0 = (scope: Branch0Scope) => {
   setConditionalRenderer(
+    scope,
     INDEX_BRANCH0.conditional1,
-    readInOwner<SCOPE, INDEX.value1>(INDEX.value1) ? branch0_0 : undefined
+    scope._[INDEX.value1] ? branch0_0 : undefined
   );
   queueInBranch(
+    scope,
     INDEX_BRANCH0.conditional1,
     branch0_0,
     execInputValue1Branch0_0,
@@ -109,8 +112,9 @@ export const execInputValue1Branch0 = () => {
   );
 };
 
-export const execInputValue2 = () => {
+export const execInputValue2 = (scope: ComponentScope) => {
   queueInBranch(
+    scope,
     INDEX.conditional,
     branch0,
     execInputValue2Branch0,
@@ -119,12 +123,14 @@ export const execInputValue2 = () => {
   );
 };
 
-export const execInputValue2Branch0 = () => {
+export const execInputValue2Branch0 = (scope: Branch0Scope) => {
   setConditionalRenderer(
+    scope,
     INDEX_BRANCH0.conditional2,
-    readInOwner<SCOPE, INDEX.value2>(INDEX.value2) ? branch0_1 : undefined
+    scope._[INDEX.value2] ? branch0_1 : undefined
   );
   queueInBranch(
+    scope,
     INDEX_BRANCH0.conditional2,
     branch0_1,
     execInputValue2Branch0_1,
@@ -133,18 +139,18 @@ export const execInputValue2Branch0 = () => {
   );
 };
 
-const execInputValue1Branch0_0 = () => {
-  data(INDEX_BRANCH0_0.text, readInOwner<SCOPE, INDEX.value1>(INDEX.value1, 2));
+const execInputValue1Branch0_0 = (scope: Branch0_0Scope) => {
+  data(scope, INDEX_BRANCH0_0.text, scope._._[INDEX.value1]);
 };
 
-const execInputValue2Branch0_1 = () => {
-  data(INDEX_BRANCH0_1.text, readInOwner<SCOPE, INDEX.value2>(INDEX.value2, 2));
+const execInputValue2Branch0_1 = (scope: Branch0_1Scope) => {
+  data(scope, INDEX_BRANCH0_1.text, scope._._[INDEX.value2]);
 };
 
-export const execDynamicInput = (input: Input) => {
-  write(INDEX.show, input.show) && _apply_show();
-  write(INDEX.value1, input.value1) && _apply_value1();
-  write(INDEX.value2, input.value2) && execInputValue2();
+export const execDynamicInput = (scope: ComponentScope, input: Input) => {
+  write(scope, INDEX.show, input.show) && _apply_show(scope);
+  write(scope, INDEX.value1, input.value1) && _apply_value1(scope);
+  write(scope, INDEX.value2, input.value2) && execInputValue2(scope);
 };
 
 export default createRenderFn(template, walks, undefined, 0, execDynamicInput);
@@ -163,19 +169,20 @@ const enum PRIORITY_BRANCH0 {
   closure_value2 = 3,
 }
 
-// type Branch0Scope = {
-//   [Branch0Index.COMMENT1]: Comment;
-//   [Branch0Index.CONDITIONAL1]: Comment;
-//   [Branch0Index.COMMENT2]: Comment;
-//   [Branch0Index.CONDITIONAL2]: Comment;
-// };
+type Branch0Scope = Scope<{
+  _: ComponentScope;
+  [INDEX_BRANCH0.comment1]: Comment;
+  [INDEX_BRANCH0.conditional1]: Comment;
+  [INDEX_BRANCH0.comment2]: Comment;
+  [INDEX_BRANCH0.conditional2]: Comment;
+}>;
 
 const branch0 = createRenderer(
   "<!><!>",
   open(8) + get + over(1) + skip(3) + get + over(1) + close,
-  () => {
-    queue(execInputValue1Branch0, PRIORITY_BRANCH0.value1);
-    queue(execInputValue2Branch0, PRIORITY_BRANCH0.value2);
+  (scope: Branch0Scope) => {
+    queue(scope, execInputValue1Branch0, PRIORITY_BRANCH0.value1);
+    queue(scope, execInputValue2Branch0, PRIORITY_BRANCH0.value2);
   },
   0,
   0,
@@ -191,9 +198,10 @@ const enum PRIORITY_BRANCH0_0 {
   value1 = 0,
 }
 
-// type Branch0_0Scope = {
-//   [Branch0_0Index.TEXT]: Text;
-// };
+type Branch0_0Scope = Scope<{
+  _: Branch0Scope;
+  [INDEX_BRANCH0_0.text]: Text;
+}>;
 
 const branch0_0 = createRenderer(
   "<span> </span>",
@@ -210,9 +218,10 @@ const enum PRIORITY_BRANCH0_1 {
   value2 = 1,
 }
 
-// type Branch0_1Scope = {
-//   [Branch0_1Index.TEXT]: Text;
-// };
+type Branch0_1Scope = Scope<{
+  _: Branch0Scope;
+  [INDEX_BRANCH0_1.text]: Text;
+}>;
 
 // OPTIMIZATION: these two branches have the same renderer arguments
 // so they could share the same renderer instance

--- a/packages/runtime/src/__tests__/fixtures/toggle-only-child/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/toggle-only-child/browser.ts
@@ -3,10 +3,9 @@ import {
   setConditionalRendererOnlyChild,
   createRenderer,
   createRenderFn,
-  read,
   write,
-  readInOwner,
   queueInBranch,
+  Scope,
 } from "../../../dom/index";
 import { get, next, over, open, close } from "../../utils/walks";
 
@@ -36,11 +35,11 @@ const enum PRIORITY {
   closure_value = 1,
 }
 
-type SCOPE = {
+type ComponentScope = Scope<{
   [INDEX.comment]: Comment;
   [INDEX.conditional]: Comment;
   [INDEX.value]: typeof inputs[number]["value"];
-};
+}>;
 
 // <attrs/{ value }/>
 // <div>
@@ -52,12 +51,14 @@ type SCOPE = {
 export const template = `<div></div>`;
 export const walks = open(5) + get + over(1) + close;
 
-export const _apply_value = () => {
+export const _apply_value = (scope: ComponentScope) => {
   setConditionalRendererOnlyChild(
+    scope,
     INDEX.conditional,
-    read(INDEX.value) ? branch0 : undefined
+    scope[INDEX.value] ? branch0 : undefined
   );
   queueInBranch(
+    scope,
     INDEX.conditional,
     branch0,
     _apply_value2,
@@ -66,13 +67,16 @@ export const _apply_value = () => {
   );
 };
 
-function _apply_value2() {
-  data(INDEX_BRANCH0.text, readInOwner<SCOPE, INDEX.value>(INDEX.value));
+function _apply_value2(scope: Branch0Scope) {
+  data(scope, INDEX_BRANCH0.text, scope._[INDEX.value]);
 }
 
-export const _applyAttrs = (input: typeof inputs[number]) => {
-  if (write(INDEX.value, input.value)) {
-    _apply_value();
+export const _applyAttrs = (
+  scope: ComponentScope,
+  input: typeof inputs[number]
+) => {
+  if (write(scope, INDEX.value, input.value)) {
+    _apply_value(scope);
   }
 };
 
@@ -86,9 +90,10 @@ const enum PRIORITY_BRANCH0 {
   value = 0,
 }
 
-// type Branch0Scope = {
-//   [Branch0Index.TEXT]: Text
-// };
+type Branch0Scope = Scope<{
+  _: ComponentScope;
+  [INDEX_BRANCH0.text]: Text;
+}>;
 
 const branch0 = createRenderer(
   "<span> </span>",

--- a/packages/runtime/src/__tests__/fixtures/update-attr/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/update-attr/browser.ts
@@ -1,4 +1,4 @@
-import { attr, createRenderFn, write, read } from "../../../dom/index";
+import { attr, createRenderFn, write, Scope } from "../../../dom/index";
 import { get, over, open, close } from "../../utils/walks";
 
 export const inputs = [
@@ -27,22 +27,25 @@ const enum Index {
   INPUT_VALUE = 1,
 }
 
-type scope = {
+type ComponentScope = Scope<{
   [Index.DIV]: HTMLDivElement;
   [Index.INPUT_VALUE]: typeof inputs[number]["value"];
-};
+}>;
 
 // <div a=0 b=input.value/>
 export const template = `<div a=0></div>`;
 export const walks = open(2) + get + over(1) + close;
 
-export const execInputValue = () => {
-  attr(Index.DIV, "b", read<scope, Index.INPUT_VALUE>(Index.INPUT_VALUE));
+export const execInputValue = (scope: ComponentScope) => {
+  attr(scope, Index.DIV, "b", scope[Index.INPUT_VALUE]);
 };
 
-export const execDynamicInput = (input: typeof inputs[number]) => {
-  if (write(Index.INPUT_VALUE, input.value)) {
-    execInputValue();
+export const execDynamicInput = (
+  scope: ComponentScope,
+  input: typeof inputs[number]
+) => {
+  if (write(scope, Index.INPUT_VALUE, input.value)) {
+    execInputValue(scope);
   }
 };
 

--- a/packages/runtime/src/__tests__/fixtures/update-dynamic-attrs/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/update-dynamic-attrs/browser.ts
@@ -1,4 +1,4 @@
-import { attrs, createRenderFn, write } from "../../../dom/index";
+import { attrs, createRenderFn, write, Scope } from "../../../dom/index";
 import { get, over, open, close } from "../../utils/walks";
 
 export const inputs = [
@@ -24,22 +24,25 @@ const enum Index {
   INPUT_VALUE = 1,
 }
 
-// type scope = {
-//   [Index.DIV]: HTMLDivElement;
-//   [Index.INPUT_VALUE]: typeof inputs[number]["value"];
-// };
+type ComponentScope = Scope<{
+  [Index.DIV]: HTMLDivElement;
+  [Index.INPUT_VALUE]: typeof inputs[number]["value"];
+}>;
 
 // <div ...input.value/>
 export const template = `<div></div>`;
 export const walks = open(2) + get + over(1) + close;
 
-export const execInputValue = () => {
-  attrs(Index.DIV, Index.INPUT_VALUE);
+export const execInputValue = (scope: ComponentScope) => {
+  attrs(scope, Index.DIV, Index.INPUT_VALUE);
 };
 
-export const execDynamicInput = (input: typeof inputs[number]) => {
-  if (write(Index.INPUT_VALUE, input.value)) {
-    execInputValue();
+export const execDynamicInput = (
+  scope: ComponentScope,
+  input: typeof inputs[number]
+) => {
+  if (write(scope, Index.INPUT_VALUE, input.value)) {
+    execInputValue(scope);
   }
 };
 

--- a/packages/runtime/src/__tests__/fixtures/update-html/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/update-html/browser.ts
@@ -1,4 +1,4 @@
-import { html, read, write, createRenderFn } from "../../../dom/index";
+import { html, write, createRenderFn, Scope } from "../../../dom/index";
 import { over, get, open, close } from "../../utils/walks";
 
 export const inputs = [
@@ -20,22 +20,25 @@ const enum Index {
   INPUT_VALUE = 2,
 }
 
-type scope = {
+type ComponentScope = Scope<{
   [Index.HTML]: Node & ChildNode;
   [Index.INPUT_VALUE]: typeof inputs[number]["value"];
-};
+}>;
 
 // <em>Testing</em> $!{input.value}
 export const template = "<em>Testing</em> <!>";
 export const walks = open(2) + over(2) + get + over(1) + close;
 
-export const execInputValue = () => {
-  html(read<scope, Index.INPUT_VALUE>(Index.INPUT_VALUE), Index.HTML);
+export const execInputValue = (scope: ComponentScope) => {
+  html(scope, scope[Index.INPUT_VALUE] as string, Index.HTML);
 };
 
-export const execDynamicInput = (input: typeof inputs[number]) => {
-  if (write(Index.INPUT_VALUE, input.value)) {
-    execInputValue();
+export const execDynamicInput = (
+  scope: ComponentScope,
+  input: typeof inputs[number]
+) => {
+  if (write(scope, Index.INPUT_VALUE, input.value)) {
+    execInputValue(scope);
   }
 };
 

--- a/packages/runtime/src/__tests__/fixtures/update-text/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/update-text/browser.ts
@@ -1,4 +1,4 @@
-import { data, read, write, createRenderFn } from "../../../dom/index";
+import { data, write, createRenderFn, Scope } from "../../../dom/index";
 import { after, over, open, close } from "../../utils/walks";
 
 const enum Index {
@@ -6,22 +6,25 @@ const enum Index {
   INPUT_VALUE = 1,
 }
 
-type scope = {
+type ComponentScope = Scope<{
   [Index.TEXT]: Text;
   [Index.INPUT_VALUE]: string;
-};
+}>;
 
 // Static ${input.value}
 export const template = "Static ";
 export const walks = open(2) + after + over(1) + close;
 
-export const execInputValue = () => {
-  data(Index.TEXT, read<scope, Index.INPUT_VALUE>(Index.INPUT_VALUE));
+export const execInputValue = (scope: ComponentScope) => {
+  data(scope, Index.TEXT, scope[Index.INPUT_VALUE]);
 };
 
-export const execDynamicInput = (input: { value: string }) => {
-  if (write(Index.INPUT_VALUE, input.value)) {
-    execInputValue();
+export const execDynamicInput = (
+  scope: ComponentScope,
+  input: { value: string }
+) => {
+  if (write(scope, Index.INPUT_VALUE, input.value)) {
+    execInputValue(scope);
   }
 };
 

--- a/packages/runtime/src/__tests__/fixtures/user-effect-cleanup/browser.ts
+++ b/packages/runtime/src/__tests__/fixtures/user-effect-cleanup/browser.ts
@@ -3,9 +3,9 @@ import {
   createRenderFn,
   userEffect,
   queue,
-  read,
   write,
   bind,
+  Scope,
 } from "../../../dom/index";
 import { wait } from "../../utils/resolve";
 import { get, next, open, close } from "../../utils/walks";
@@ -21,14 +21,14 @@ const enum Index {
   EFFECT_CLEANUP = 5,
 }
 
-type scope = {
+type ComponentScope = Scope<{
   [Index.DIV_TEXT]: Text;
   [Index.INPUT_VALUE]: typeof inputs[0 | 2]["value"];
   [Index.A]: number;
   [Index.B]: number;
   [Index.CONCAT_AB]: string;
   [Index.EFFECT_CLEANUP]: () => void;
-};
+}>;
 
 // <let/a = 0/>
 // <let/b = 0/>
@@ -39,48 +39,54 @@ type scope = {
 // }/>
 export const template = `<div> </div>`;
 export const walks = open(5) + next(1) + get + next(1) + close;
-export const render = () => {
-  execA(0);
-  execB(0);
+export const render = (scope: ComponentScope) => {
+  execA(scope, 0);
+  execB(scope, 0);
 };
 
-function execA(value: scope[Index.A]) {
-  if (write(Index.A, value)) {
-    queue(execAB, Index.CONCAT_AB);
+function execA(scope: ComponentScope, value: ComponentScope[Index.A]) {
+  if (write(scope, Index.A, value)) {
+    queue(scope, execAB, Index.CONCAT_AB);
   }
 }
 
-function execB(value: scope[Index.B]) {
-  if (write(Index.B, value)) {
-    queue(execAB, Index.CONCAT_AB);
+function execB(scope: ComponentScope, value: ComponentScope[Index.B]) {
+  if (write(scope, Index.B, value)) {
+    queue(scope, execAB, Index.CONCAT_AB);
   }
 }
 
-function execAB() {
-  execConcatAB("" + read(Index.A) + read(Index.B));
+function execAB(scope: ComponentScope) {
+  execConcatAB(scope, "" + scope[Index.A] + scope[Index.B]);
 }
 
-function execConcatAB(value: scope[Index.CONCAT_AB]) {
-  if (write(Index.CONCAT_AB, value)) {
-    data(Index.DIV_TEXT, value);
+function execConcatAB(
+  scope: ComponentScope,
+  value: ComponentScope[Index.CONCAT_AB]
+) {
+  if (write(scope, Index.CONCAT_AB, value)) {
+    data(scope, Index.DIV_TEXT, value);
   }
 }
 
-export const hydrateInputValue = () => {
-  userEffect(Index.EFFECT_CLEANUP, effectFn);
+export const hydrateInputValue = (scope: ComponentScope) => {
+  userEffect(scope, Index.EFFECT_CLEANUP, effectFn);
 };
 
-const effectFn = () => {
-  const previousValue = read<scope, Index.INPUT_VALUE>(Index.INPUT_VALUE) + 1;
-  queue(execA, Index.A, previousValue);
-  return bind(() => {
-    queue(execB, Index.B, previousValue);
+const effectFn = (scope: ComponentScope) => {
+  const previousValue = scope[Index.INPUT_VALUE] + 1;
+  queue(scope, execA, Index.A, previousValue);
+  return bind(scope, () => {
+    queue(scope, execB, Index.B, previousValue);
   });
 };
 
-export const execDynamicInput = (input: typeof inputs[0]) => {
-  if (write(Index.INPUT_VALUE, input.value)) {
-    hydrateInputValue();
+export const execDynamicInput = (
+  scope: ComponentScope,
+  input: typeof inputs[0]
+) => {
+  if (write(scope, Index.INPUT_VALUE, input.value)) {
+    hydrateInputValue(scope);
   }
 };
 

--- a/packages/runtime/src/common/types.ts
+++ b/packages/runtime/src/common/types.ts
@@ -8,22 +8,15 @@ export type HydrateInstance = [
   number // offset
 ];
 
-export type Scope = [
-  Scope | undefined, // OWNER_SCOPE
-  number | undefined, // OWNER_OFFSET
-  ...unknown[]
-] & {
+export type Scope<
+  T extends { [x: number]: unknown } = { [x: number]: unknown }
+> = [...unknown[]] & {
   ___id: number;
   ___startNode: (Node & ChildNode) | number | undefined;
   ___endNode: (Node & ChildNode) | number | undefined;
   ___cleanup: Set<number | Scope> | undefined;
-};
-
-export const enum ScopeOffsets {
-  OWNER_SCOPE = 0,
-  OWNER_OFFSET = 1,
-  BEGIN_DATA = 2,
-}
+  _: Scope | undefined;
+} & T;
 
 export const enum HydrateSymbols {
   SCOPE_START = "^",

--- a/packages/runtime/src/dom/event.ts
+++ b/packages/runtime/src/dom/event.ts
@@ -1,5 +1,4 @@
-import { read } from "./scope";
-
+import type { Scope } from "../common/types";
 type Unset = false | null | undefined;
 type EventNames = keyof GlobalEventHandlersEventMap;
 
@@ -18,8 +17,8 @@ export function on<
   H extends
     | Unset
     | ((ev: GlobalEventHandlersEventMap[T], target: Element) => void)
->(elIndex: number, type: T, handler: H) {
-  const el = read(elIndex) as Element;
+>(scope: Scope, elIndex: number, type: T, handler: H) {
+  const el = scope[elIndex] as Element;
   const delegated = delegatedByType.get(type);
 
   if (delegated) {

--- a/packages/runtime/src/dom/fragment.ts
+++ b/packages/runtime/src/dom/fragment.ts
@@ -1,4 +1,4 @@
-import { Scope, ScopeOffsets } from "../common/types";
+import type { Scope } from "../common/types";
 import { ConditionalIndex, LoopIndex, emptyMarkerArray } from "./control-flow";
 
 export type DOMFragment = {
@@ -85,14 +85,10 @@ function getFirstNode(
   }
 
   return typeof indexOrNode === "number"
-    ? !(scopeOrScopes = currentScope[
-        indexOrNode + ConditionalIndex.SCOPE + ScopeOffsets.BEGIN_DATA
-      ] as Scope | Scope[]) || scopeOrScopes === emptyMarkerArray
-      ? (currentScope[
-          indexOrNode +
-            ConditionalIndex.REFERENCE_NODE +
-            ScopeOffsets.BEGIN_DATA
-        ] as Comment)
+    ? !(scopeOrScopes = currentScope[indexOrNode + ConditionalIndex.SCOPE] as
+        | Scope
+        | Scope[]) || scopeOrScopes === emptyMarkerArray
+      ? (currentScope[indexOrNode + ConditionalIndex.REFERENCE_NODE] as Comment)
       : (last ? getLastNode : getFirstNode)(
           (scopeOrScopes as Scope).___id
             ? (scopeOrScopes as Scope)

--- a/packages/runtime/src/dom/index.ts
+++ b/packages/runtime/src/dom/index.ts
@@ -29,17 +29,9 @@ export { init, register } from "./hydrate";
 
 export { pushContext, popContext, getInContext } from "../common/context";
 
-export { queue, queueInOwner, run } from "./queue";
+export { queue, run } from "./queue";
 
-export {
-  read,
-  write,
-  readInOwner,
-  writeInOwner,
-  bind,
-  runWithScope,
-  runInChild,
-} from "./scope";
+export { write, bind } from "./scope";
 
 export type { Scope } from "../common/types";
 

--- a/packages/runtime/src/dom/queue.ts
+++ b/packages/runtime/src/dom/queue.ts
@@ -1,1 +1,1 @@
-export { queue, queueInOwner, withQueueNext, run } from "./queue-heap";
+export { queue, withQueueNext, run } from "./queue-heap";

--- a/packages/runtime/src/html/writer.ts
+++ b/packages/runtime/src/html/writer.ts
@@ -1,6 +1,6 @@
 import type { Writable } from "stream";
 import { Context, setContext } from "../common/context";
-import { Renderer, Scope, ScopeOffsets, HydrateSymbols } from "../common/types";
+import { Renderer, Scope, HydrateSymbols } from "../common/types";
 import reorderRuntime from "./reorder-runtime";
 import { Serializer } from "./serializer";
 
@@ -47,7 +47,7 @@ export function createRenderer(renderer: Renderer, hydrateRoot?: boolean) {
           ? (Object.assign([], { ___id: 0 }) as any as Scope)
           : nullScope;
         hydrateRoot && write(markScopeStart(scope));
-        renderer(input, scope, ScopeOffsets.BEGIN_DATA);
+        renderer(input, scope);
         hydrateRoot && write(markScopeEnd(scope));
       } finally {
         renderedPromises = $_promises;
@@ -70,8 +70,8 @@ export function write(data: string) {
   $_buffer!.content += data;
 }
 
-export function writeCall(fnId: string, offset: number, scopeId: number) {
-  $_buffer!.calls += `"${fnId}",${offset},${scopeId},`;
+export function writeCall(fnId: string, scopeId: number) {
+  $_buffer!.calls += `"${fnId}",${scopeId},`;
 }
 
 export function writeScope(scope: Scope) {

--- a/packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/dom.expected.js
@@ -1,13 +1,13 @@
 let _thing;
 
-import { write as _write, setConditionalRenderer as _setConditionalRenderer, readInOwner as _readInOwner, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { write as _write, setConditionalRenderer as _setConditionalRenderer, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { apply as _customTag, template as _customTag_template, walks as _customTag_walks } from "./components/custom-tag/index.marko";
 
-function _apply_x(x = _readInOwner(0)) {
-  _setConditionalRenderer(0, x ? _if : null);
+function _apply_x(_scope, x = _scope._[0]) {
+  _setConditionalRenderer(_scope, 0, x ? _if : null);
 }
 
-function _apply() {
+function _apply(_scope) {
   _customTag();
 }
 

--- a/packages/translator/src/__tests__/fixtures/at-tags-dynamic-and-static/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags-dynamic-and-static/__snapshots__/dom.expected.js
@@ -1,6 +1,6 @@
 import { apply as _hello, template as _hello_template, walks as _hello_walks } from "./components/hello/index.marko";
 
-function _apply() {
+function _apply(_scope) {
   _hello();
 }
 

--- a/packages/translator/src/__tests__/fixtures/at-tags-dynamic-tag-parent/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags-dynamic-tag-parent/__snapshots__/dom.expected.js
@@ -1,4 +1,4 @@
-_dynamicTag(x, {
+_dynamicTag(_scope, x, {
   header: {
     class: "my-header",
 

--- a/packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected.js
@@ -1,17 +1,17 @@
 let _item;
 
-import { data as _data, write as _write, setConditionalRenderer as _setConditionalRenderer, readInOwner as _readInOwner, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { data as _data, write as _write, setConditionalRenderer as _setConditionalRenderer, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { apply as _hello, template as _hello_template, walks as _hello_walks } from "./components/hello/index.marko";
 
-function _apply() {
-  _data(0, y);
+function _apply(_scope) {
+  _data(_scope, 0, y);
 }
 
-function _apply_x(x = _readInOwner(0)) {
-  _setConditionalRenderer(0, x ? _if : null);
+function _apply_x(_scope, x = _scope._[0]) {
+  _setConditionalRenderer(_scope, 0, x ? _if : null);
 }
 
-function _apply2() {
+function _apply2(_scope) {
   _hello();
 }
 

--- a/packages/translator/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/dom.expected.js
@@ -15,7 +15,7 @@ _col.push({
 import { write as _write, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { apply as _hello, template as _hello_template, walks as _hello_walks } from "./components/hello/index.marko";
 
-function _apply() {
+function _apply(_scope) {
   _hello();
 }
 

--- a/packages/translator/src/__tests__/fixtures/at-tags/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags/__snapshots__/dom.expected.js
@@ -1,7 +1,7 @@
 import { write as _write, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { apply as _hello, template as _hello_template, walks as _hello_walks } from "./components/hello/index.marko";
 
-function _apply() {
+function _apply(_scope) {
   _hello();
 }
 

--- a/packages/translator/src/__tests__/fixtures/attr-escape/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/attr-escape/__snapshots__/dom.expected.js
@@ -1,11 +1,11 @@
 import { classAttr as _classAttr, attr as _attr, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply() {
+function _apply(_scope) {
   _classAttr(0, input.className);
 
-  _attr(0, "foo", 'a' + input.foo + 'b');
+  _attr(_scope, 0, "foo", 'a' + input.foo + 'b');
 
-  _attr(0, "bar", `a ${input.foo} b`);
+  _attr(_scope, 0, "bar", `a ${input.foo} b`);
 }
 
 export const template = "<div></div>";

--- a/packages/translator/src/__tests__/fixtures/attr-template-literal-escape/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/attr-template-literal-escape/__snapshots__/dom.expected.js
@@ -1,7 +1,7 @@
 import { attr as _attr, write as _write, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_name(name) {
-  if (_write(1, name)) _attr(0, "foo", `Hello ${name}`);
+function _apply_name(_scope, name) {
+  if (_write(_scope, 1, name)) _attr(_scope, 0, "foo", `Hello ${name}`);
 }
 
 export const template = "<div></div>";

--- a/packages/translator/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected.js
@@ -1,6 +1,6 @@
 import { apply as _counter, template as _counter_template, walks as _counter_walks } from "./components/counter.marko";
 
-function _apply() {
+function _apply(_scope) {
   _counter();
 }
 

--- a/packages/translator/src/__tests__/fixtures/basic-component/test.ts
+++ b/packages/translator/src/__tests__/fixtures/basic-component/test.ts
@@ -1,3 +1,5 @@
+export const skip_csr = true;
+export const skip_ssr = true;
 export const steps = [{}, click];
 
 function click(container: Element) {

--- a/packages/translator/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected.js
@@ -1,27 +1,27 @@
-import { queue as _queue, write as _write, read as _read, on as _on, data as _data, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queue as _queue, write as _write, on as _on, data as _data, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _hydrate_clickCount(clickCount = _read(2)) {
-  _on(0, "click", _read(3));
+function _hydrate_clickCount(_scope, clickCount = _scope[2]) {
+  _on(_scope, 0, "click", _scope[3]);
 }
 
-const _onclick = function () {
-  const clickCount = _read(2);
+const _onclick = function (_scope) {
+  const clickCount = _scope[2];
 
-  _queue(_apply_clickCount, 0, clickCount + 1);
+  _queue(_scope, _apply_clickCount, 0, clickCount + 1);
 };
 
-function _apply_clickCount(clickCount) {
-  if (_write(2, clickCount)) {
-    _write(3, _bind(_onclick));
+function _apply_clickCount(_scope, clickCount) {
+  if (_write(_scope, 2, clickCount)) {
+    _write(_scope, 3, _bind(_scope, _onclick));
 
-    _data(1, clickCount);
+    _data(_scope, 1, clickCount);
 
-    _hydrate_clickCount();
+    _hydrate_clickCount(_scope);
   }
 }
 
-function _apply() {
-  _apply_clickCount(0);
+function _apply(_scope) {
+  _apply_clickCount(_scope, 0);
 }
 
 export const template = "<div><button><!></button></div>";

--- a/packages/translator/src/__tests__/fixtures/basic-counter/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-counter/__snapshots__/html.expected.js
@@ -1,4 +1,4 @@
-import { markScopeOffset as _markScopeOffset, write as _write, read as _read, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markScopeOffset as _markScopeOffset, write as _write, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
 const _renderer = _register("packages/translator/src/__tests__/fixtures/basic-counter/template.marko", input => {
   const clickCount = 0;

--- a/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected.js
@@ -1,41 +1,41 @@
-import { queue as _queue, write as _write, read as _read, on as _on, data as _data, setConditionalRenderer as _setConditionalRenderer, readInOwner as _readInOwner, queueInBranch as _queueInBranch, bind as _bind, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queue as _queue, write as _write, on as _on, data as _data, setConditionalRenderer as _setConditionalRenderer, queueInBranch as _queueInBranch, bind as _bind, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_message2(message = _readInOwner(5)) {
-  _data(0, message.text);
+function _apply_message2(_scope, message = _scope._[5]) {
+  _data(_scope, 0, message.text);
 }
 
-function _apply2() {
-  _queue(_apply_message2, 0);
+function _apply2(_scope) {
+  _queue(_scope, _apply_message2, 0);
 }
 
-function _hydrate() {
-  _on(0, "click", _read(7));
+function _hydrate(_scope) {
+  _on(_scope, 0, "click", _scope[7]);
 }
 
-function _apply_show(show) {
-  if (_write(6, show)) _setConditionalRenderer(1, show ? _if : null);
+function _apply_show(_scope, show) {
+  if (_write(_scope, 6, show)) _setConditionalRenderer(_scope, 1, show ? _if : null);
 }
 
-function _apply_message(message) {
-  if (_write(5, message)) _queueInBranch(1, _if, _apply_message2, 0, 1);
+function _apply_message(_scope, message) {
+  if (_write(_scope, 5, message)) _queueInBranch(_scope, 1, _if, _apply_message2, 0, 1);
 }
 
-const _temp2 = function () {
-  _queue(_apply_message, 0, null);
+const _temp2 = function (_scope) {
+  _queue(_scope, _apply_message, 0, null);
 
-  _queue(_apply_show, 1, false);
+  _queue(_scope, _apply_show, 1, false);
 };
 
-function _apply() {
-  _apply_message({
+function _apply(_scope) {
+  _apply_message(_scope, {
     text: "hi"
   });
 
-  _apply_show(true);
+  _apply_show(_scope, true);
 
-  _write(7, _bind(_temp2));
+  _write(_scope, 7, _bind(_scope, _temp2));
 
-  _hydrate();
+  _hydrate(_scope);
 }
 
 const _if = _createRenderer("<!>", "%", _apply2);

--- a/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/html.expected.js
@@ -1,4 +1,4 @@
-import { markScopeOffset as _markScopeOffset, write as _write, read as _read, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markScopeOffset as _markScopeOffset, write as _write, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
 const _renderer = _register("packages/translator/src/__tests__/fixtures/basic-execution-order/template.marko", input => {
   const message = {

--- a/packages/translator/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected.js
@@ -1,29 +1,28 @@
-import { queue as _queue, write as _write, read as _read, on as _on, data as _data, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queue as _queue, write as _write, on as _on, data as _data, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _hydrate_count(count = _read(2)) {
-  _on(0, "click", _read(3));
+function _hydrate_count(_scope, count = _scope[2]) {
+  _on(_scope, 0, "click", _scope[3]);
 }
 
-const _onclick = function () {
-  const count = _read(2);
-
+const _onclick = function (_scope) {
+  const count = _scope[2];
   {
-    _queue(_apply_count, 0, count + 1);
+    _queue(_scope, _apply_count, 0, count + 1);
   }
 };
 
-function _apply_count(count) {
-  if (_write(2, count)) {
-    _write(3, _bind(_onclick));
+function _apply_count(_scope, count) {
+  if (_write(_scope, 2, count)) {
+    _write(_scope, 3, _bind(_scope, _onclick));
 
-    _data(1, count);
+    _data(_scope, 1, count);
 
-    _hydrate_count();
+    _hydrate_count(_scope);
   }
 }
 
-function _apply() {
-  _apply_count(0);
+function _apply(_scope) {
+  _apply_count(_scope, 0);
 }
 
 export const template = "<button><!></button>";

--- a/packages/translator/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/html.expected.js
@@ -1,4 +1,4 @@
-import { markScopeOffset as _markScopeOffset, write as _write, read as _read, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markScopeOffset as _markScopeOffset, write as _write, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
 const _renderer = _register("packages/translator/src/__tests__/fixtures/basic-fn-with-block/template.marko", input => {
   const count = 0;

--- a/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected.js
@@ -1,43 +1,42 @@
-import { queue as _queue, write as _write, read as _read, on as _on, data as _data, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queue as _queue, write as _write, on as _on, data as _data, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _hydrateWith_a_b(a = _read(2), b = _read(3)) {
-  _on(0, "click", _read(4));
+function _hydrateWith_a_b(_scope, a = _scope[2], b = _scope[3]) {
+  _on(_scope, 0, "click", _scope[4]);
 }
 
-const _onclick = a => {
-  const b = _read(3);
-
+const _onclick = (_scope, a) => {
+  const b = _scope[3];
   return b;
 };
 
-const _onclick2 = function () {
-  const a = _read(2);
+const _onclick2 = function (_scope) {
+  const a = _scope[2];
 
-  _queue(_apply_a, 0, a.map(_bind(_onclick)));
+  _queue(_scope, _apply_a, 0, a.map(_bind(_scope, _onclick)));
 };
 
-function _applyWith_a_b(a = _read(2), b = _read(3)) {
-  _write(4, _bind(_onclick2));
+function _applyWith_a_b(_scope, a = _scope[2], b = _scope[3]) {
+  _write(_scope, 4, _bind(_scope, _onclick2));
 
-  _hydrateWith_a_b();
+  _hydrateWith_a_b(_scope);
 }
 
-function _apply_b(b) {
-  if (_write(3, b)) _queue(_applyWith_a_b, 2);
+function _apply_b(_scope, b) {
+  if (_write(_scope, 3, b)) _queue(_scope, _applyWith_a_b, 2);
 }
 
-function _apply_a(a) {
-  if (_write(2, a)) {
-    _data(1, a.join(""));
+function _apply_a(_scope, a) {
+  if (_write(_scope, 2, a)) {
+    _data(_scope, 1, a.join(""));
 
-    _queue(_applyWith_a_b, 2);
+    _queue(_scope, _applyWith_a_b, 2);
   }
 }
 
-function _apply() {
-  _apply_a([0]);
+function _apply(_scope) {
+  _apply_a(_scope, [0]);
 
-  _apply_b(1);
+  _apply_b(_scope, 1);
 }
 
 export const template = "<button><!></button>";

--- a/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/html.expected.js
@@ -1,4 +1,4 @@
-import { markScopeOffset as _markScopeOffset, write as _write, read as _read, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markScopeOffset as _markScopeOffset, write as _write, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
 const _renderer = _register("packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/template.marko", input => {
   const a = [0];

--- a/packages/translator/src/__tests__/fixtures/basic-handler-refless/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-refless/__snapshots__/dom.expected.js
@@ -1,23 +1,23 @@
-import { queue as _queue, write as _write, read as _read, on as _on, data as _data, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queue as _queue, write as _write, on as _on, data as _data, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _hydrate() {
-  _on(0, "click", _read(3));
+function _hydrate(_scope) {
+  _on(_scope, 0, "click", _scope[3]);
 }
 
-function _apply_data(data) {
-  if (_write(2, data)) _data(1, data);
+function _apply_data(_scope, data) {
+  if (_write(_scope, 2, data)) _data(_scope, 1, data);
 }
 
-const _temp = function () {
-  _queue(_apply_data, 0, 1);
+const _temp = function (_scope) {
+  _queue(_scope, _apply_data, 0, 1);
 };
 
-function _apply() {
-  _apply_data(0);
+function _apply(_scope) {
+  _apply_data(_scope, 0);
 
-  _write(3, _bind(_temp));
+  _write(_scope, 3, _bind(_scope, _temp));
 
-  _hydrate();
+  _hydrate(_scope);
 }
 
 export const template = "<button><!></button>";

--- a/packages/translator/src/__tests__/fixtures/basic-handler-refless/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-refless/__snapshots__/html.expected.js
@@ -1,4 +1,4 @@
-import { markScopeOffset as _markScopeOffset, write as _write, read as _read, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markScopeOffset as _markScopeOffset, write as _write, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
 const _renderer = _register("packages/translator/src/__tests__/fixtures/basic-handler-refless/template.marko", input => {
   const data = 0;

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected.js
@@ -1,49 +1,49 @@
-import { queueInOwner as _queueInOwner, write as _write, read as _read, on as _on, attr as _attr, data as _data, setLoopOf as _setLoopOf, readInOwner as _readInOwner, queue as _queue, bind as _bind, queueForEach as _queueForEach, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queue as _queue, write as _write, on as _on, attr as _attr, data as _data, setLoopOf as _setLoopOf, bind as _bind, queueForEach as _queueForEach, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _hydrate_num(num = _read(2)) {
-  _on(0, "click", _read(3));
+function _hydrate_num(_scope, num = _scope[2]) {
+  _on(_scope, 0, "click", _scope[3]);
 }
 
-function _applyWith_selected_num(selected = _readInOwner(4), num = _read(2)) {
-  _attr(0, "data-selected", selected === num);
+function _applyWith_selected_num(_scope, selected = _scope._[4], num = _scope[2]) {
+  _attr(_scope, 0, "data-selected", selected === num);
 
-  _attr(0, "data-multiple", num % selected === 0);
+  _attr(_scope, 0, "data-multiple", num % selected === 0);
 }
 
-const _onclick = function () {
-  const num = _read(2);
+const _onclick = function (_scope) {
+  const num = _scope[2];
 
-  _queueInOwner(_apply_selected, 0, num);
+  _queue(_scope._, _apply_selected, 0, num);
 };
 
-function _apply_num(num) {
-  if (_write(2, num)) {
-    _write(3, _bind(_onclick));
+function _apply_num(_scope, num) {
+  if (_write(_scope, 2, num)) {
+    _write(_scope, 3, _bind(_scope, _onclick));
 
-    _data(1, num);
+    _data(_scope, 1, num);
 
-    _hydrate_num();
+    _hydrate_num(_scope);
 
-    _queue(_applyWith_selected_num, 2);
+    _queue(_scope, _applyWith_selected_num, 2);
   }
 }
 
-function _apply_selected2(selected = _readInOwner(4)) {
-  _queue(_applyWith_selected_num, 2);
+function _apply_selected2(_scope, selected = _scope._[4]) {
+  _queue(_scope, _applyWith_selected_num, 2);
 }
 
-function _apply2() {
-  _queue(_apply_selected2, 0);
+function _apply2(_scope) {
+  _queue(_scope, _apply_selected2, 0);
 }
 
-function _apply_selected(selected) {
-  if (_write(4, selected)) _queueForEach(0, _apply_selected2, 0, 3);
+function _apply_selected(_scope, selected) {
+  if (_write(_scope, 4, selected)) _queueForEach(_scope, 0, _apply_selected2, 0, 3);
 }
 
-function _apply() {
-  _apply_selected(0);
+function _apply(_scope) {
+  _apply_selected(_scope, 0);
 
-  _setLoopOf(0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], _for, null, _apply_num);
+  _setLoopOf(_scope, 0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], _for, null, _apply_num);
 }
 
 const _for = _createRenderer("<button><!></button>", " D%", _apply2);

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/html.expected.js
@@ -1,4 +1,4 @@
-import { markScopeOffset as _markScopeOffset, write as _write, read as _read, on as _on, attr as _attr, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markScopeOffset as _markScopeOffset, write as _write, on as _on, attr as _attr, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
 const _renderer = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-for/template.marko", input => {
   const selected = 0;

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected.js
@@ -1,37 +1,37 @@
-import { queueInOwner as _queueInOwner, write as _write, read as _read, on as _on, data as _data, setConditionalRenderer as _setConditionalRenderer, readInOwner as _readInOwner, queueInBranch as _queueInBranch, queue as _queue, bind as _bind, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queue as _queue, write as _write, on as _on, data as _data, setConditionalRenderer as _setConditionalRenderer, queueInBranch as _queueInBranch, bind as _bind, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _hydrate_clickCount(clickCount = _readInOwner(4)) {
-  _on(0, "click", _read(2));
+function _hydrate_clickCount(_scope, clickCount = _scope._[4]) {
+  _on(_scope, 0, "click", _scope[2]);
 }
 
-const _onclick = function () {
-  const clickCount = _readInOwner(4);
+const _onclick = function (_scope) {
+  const clickCount = _scope._[4];
 
-  _queueInOwner(_apply_clickCount, 0, clickCount + 1);
+  _queue(_scope._, _apply_clickCount, 0, clickCount + 1);
 };
 
-function _apply_clickCount2(clickCount = _readInOwner(4)) {
-  _write(2, _bind(_onclick));
+function _apply_clickCount2(_scope, clickCount = _scope._[4]) {
+  _write(_scope, 2, _bind(_scope, _onclick));
 
-  _data(1, clickCount);
+  _data(_scope, 1, clickCount);
 
-  _hydrate_clickCount();
+  _hydrate_clickCount(_scope);
 }
 
-function _apply2() {
-  _queue(_apply_clickCount2, 0);
+function _apply2(_scope) {
+  _queue(_scope, _apply_clickCount2, 0);
 }
 
-function _apply_clickCount(clickCount) {
-  if (_write(4, clickCount)) {
-    _setConditionalRenderer(0, clickCount < 3 ? _if : null);
+function _apply_clickCount(_scope, clickCount) {
+  if (_write(_scope, 4, clickCount)) {
+    _setConditionalRenderer(_scope, 0, clickCount < 3 ? _if : null);
 
-    _queueInBranch(0, _if, _apply_clickCount2, 0, 1);
+    _queueInBranch(_scope, 0, _if, _apply_clickCount2, 0, 1);
   }
 }
 
-function _apply() {
-  _apply_clickCount(0);
+function _apply(_scope) {
+  _apply_clickCount(_scope, 0);
 }
 
 const _if = _createRenderer("<button><!></button>", " D%", _apply2);

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/html.expected.js
@@ -1,4 +1,4 @@
-import { markScopeOffset as _markScopeOffset, write as _write, read as _read, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markScopeOffset as _markScopeOffset, write as _write, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
 const _renderer = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko", input => {
   const clickCount = 0;

--- a/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected.js
@@ -1,61 +1,60 @@
-import { queue as _queue, data as _data, setLoopOf as _setLoopOf, write as _write, read as _read, on as _on, bind as _bind, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queue as _queue, data as _data, setLoopOf as _setLoopOf, write as _write, on as _on, bind as _bind, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_item(item) {
-  if (_write(1, item)) _data(0, item);
+function _apply_item(_scope, item) {
+  if (_write(_scope, 1, item)) _data(_scope, 0, item);
 }
 
-function _hydrateWith_id_items(id = _read(6), items = _read(7)) {
-  _on(4, "click", _read(8));
+function _hydrateWith_id_items(_scope, id = _scope[6], items = _scope[7]) {
+  _on(_scope, 4, "click", _scope[8]);
 }
 
-function _hydrate_items(items = _read(7)) {
-  _on(5, "click", _read(9));
+function _hydrate_items(_scope, items = _scope[7]) {
+  _on(_scope, 5, "click", _scope[9]);
 }
 
-const _onclick = function () {
-  const id = _read(6),
-        items = _read(7);
-
+const _onclick = function (_scope) {
+  const id = _scope[6],
+        items = _scope[7];
   // TODO: nested writes ([...items, id++]) don't work
   const nextId = id + 1;
 
-  _queue(_apply_id, 0, nextId);
+  _queue(_scope, _apply_id, 0, nextId);
 
-  _queue(_apply_items, 1, [...items, nextId]);
+  _queue(_scope, _apply_items, 1, [...items, nextId]);
 };
 
-function _applyWith_id_items(id = _read(6), items = _read(7)) {
-  _write(8, _bind(_onclick));
+function _applyWith_id_items(_scope, id = _scope[6], items = _scope[7]) {
+  _write(_scope, 8, _bind(_scope, _onclick));
 
-  _hydrateWith_id_items();
+  _hydrateWith_id_items(_scope);
 }
 
-const _onclick2 = function () {
-  const items = _read(7);
+const _onclick2 = function (_scope) {
+  const items = _scope[7];
 
-  _queue(_apply_items, 1, items.slice(0, -1));
+  _queue(_scope, _apply_items, 1, items.slice(0, -1));
 };
 
-function _apply_items(items) {
-  if (_write(7, items)) {
-    _setLoopOf(0, items, _for, null, _apply_item);
+function _apply_items(_scope, items) {
+  if (_write(_scope, 7, items)) {
+    _setLoopOf(_scope, 0, items, _for, null, _apply_item);
 
-    _write(9, _bind(_onclick2));
+    _write(_scope, 9, _bind(_scope, _onclick2));
 
-    _hydrate_items();
+    _hydrate_items(_scope);
 
-    _queue(_applyWith_id_items, 2);
+    _queue(_scope, _applyWith_id_items, 2);
   }
 }
 
-function _apply_id(id) {
-  if (_write(6, id)) _queue(_applyWith_id_items, 2);
+function _apply_id(_scope, id) {
+  if (_write(_scope, 6, id)) _queue(_scope, _applyWith_id_items, 2);
 }
 
-function _apply() {
-  _apply_id(0);
+function _apply(_scope) {
+  _apply_id(_scope, 0);
 
-  _apply_items([]);
+  _apply_items(_scope, []);
 }
 
 const _for = _createRenderer("<!>", "%", null);

--- a/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/html.expected.js
@@ -1,4 +1,4 @@
-import { markScopeOffset as _markScopeOffset, write as _write, escapeXML as _escapeXML, read as _read, on as _on, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markScopeOffset as _markScopeOffset, write as _write, escapeXML as _escapeXML, on as _on, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
 const _renderer = _register("packages/translator/src/__tests__/fixtures/basic-push-pop-list/template.marko", input => {
   const id = 0;

--- a/packages/translator/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected.js
@@ -1,27 +1,27 @@
-import { queue as _queue, setConditionalRenderer as _setConditionalRenderer, write as _write, read as _read, on as _on, bind as _bind, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queue as _queue, setConditionalRenderer as _setConditionalRenderer, write as _write, on as _on, bind as _bind, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _hydrate_show(show = _read(5)) {
-  _on(4, "click", _read(6));
+function _hydrate_show(_scope, show = _scope[5]) {
+  _on(_scope, 4, "click", _scope[6]);
 }
 
-const _onclick = function () {
-  const show = _read(5);
+const _onclick = function (_scope) {
+  const show = _scope[5];
 
-  _queue(_apply_show, 0, !show);
+  _queue(_scope, _apply_show, 0, !show);
 };
 
-function _apply_show(show) {
-  if (_write(5, show)) {
-    _setConditionalRenderer(0, show ? _if : null);
+function _apply_show(_scope, show) {
+  if (_write(_scope, 5, show)) {
+    _setConditionalRenderer(_scope, 0, show ? _if : null);
 
-    _write(6, _bind(_onclick));
+    _write(_scope, 6, _bind(_scope, _onclick));
 
-    _hydrate_show();
+    _hydrate_show(_scope);
   }
 }
 
-function _apply() {
-  _apply_show(true);
+function _apply(_scope) {
+  _apply_show(_scope, true);
 }
 
 const _if = _createRenderer("Hello!", "", null);

--- a/packages/translator/src/__tests__/fixtures/basic-toggle-show/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-toggle-show/__snapshots__/html.expected.js
@@ -1,4 +1,4 @@
-import { markScopeOffset as _markScopeOffset, write as _write, read as _read, on as _on, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markScopeOffset as _markScopeOffset, write as _write, on as _on, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
 const _renderer = _register("packages/translator/src/__tests__/fixtures/basic-toggle-show/template.marko", input => {
   const show = true;

--- a/packages/translator/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected.js
@@ -1,39 +1,39 @@
-import { queue as _queue, write as _write, read as _read, on as _on, data as _data, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queue as _queue, write as _write, on as _on, data as _data, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _hydrate_clickCount(clickCount = _read(4)) {
-  _on(0, "click", _read(5));
+function _hydrate_clickCount(_scope, clickCount = _scope[4]) {
+  _on(_scope, 0, "click", _scope[5]);
 }
 
-const _onclick = function () {
-  const clickCount = _read(4);
+const _onclick = function (_scope) {
+  const clickCount = _scope[4];
 
-  _queue(_apply_clickCount, 2, clickCount + 1);
+  _queue(_scope, _apply_clickCount, 2, clickCount + 1);
 };
 
-function _apply_clickCount(clickCount) {
-  if (_write(4, clickCount)) {
-    _write(5, _bind(_onclick));
+function _apply_clickCount(_scope, clickCount) {
+  if (_write(_scope, 4, clickCount)) {
+    _write(_scope, 5, _bind(_scope, _onclick));
 
-    _data(1, clickCount);
+    _data(_scope, 1, clickCount);
 
-    _hydrate_clickCount();
+    _hydrate_clickCount(_scope);
   }
 }
 
-function _apply_unused_2(unused_2) {
-  if (_write(3, unused_2)) {}
+function _apply_unused_2(_scope, unused_2) {
+  if (_write(_scope, 3, unused_2)) {}
 }
 
-function _apply_unused_(unused_1) {
-  if (_write(2, unused_1)) {}
+function _apply_unused_(_scope, unused_1) {
+  if (_write(_scope, 2, unused_1)) {}
 }
 
-function _apply() {
-  _apply_unused_(123);
+function _apply(_scope) {
+  _apply_unused_(_scope, 123);
 
   _apply_unused_2(456);
 
-  _apply_clickCount(0);
+  _apply_clickCount(_scope, 0);
 }
 
 export const template = "<div><button><!></button></div>";

--- a/packages/translator/src/__tests__/fixtures/basic-unused-ref/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-unused-ref/__snapshots__/html.expected.js
@@ -1,4 +1,4 @@
-import { markScopeOffset as _markScopeOffset, write as _write, read as _read, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markScopeOffset as _markScopeOffset, write as _write, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
 const _renderer = _register("packages/translator/src/__tests__/fixtures/basic-unused-ref/template.marko", input => {
   const unused_1 = 123;

--- a/packages/translator/src/__tests__/fixtures/const-tag/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/const-tag/__snapshots__/dom.expected.js
@@ -1,14 +1,14 @@
 import { data as _data, write as _write, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_y(y) {
-  if (_write(3, y)) _data(1, y);
+function _apply_y(_scope, y) {
+  if (_write(_scope, 3, y)) _data(_scope, 1, y);
 }
 
-function _apply_x(x) {
-  if (_write(2, x)) _data(0, x);
+function _apply_x(_scope, x) {
+  if (_write(_scope, 2, x)) _data(_scope, 0, x);
 }
 
-function _apply() {
+function _apply(_scope) {
   _apply_x(1);
 
   _apply_y(1);

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-relative-path/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-relative-path/__snapshots__/dom.expected.js
@@ -1,6 +1,6 @@
 import Other from "./other.marko";
 
-_dynamicTag(Other, {}, _createRenderer("<!></span>", "D%", () => {
+_dynamicTag(_scope, Other, {}, _createRenderer("<!></span>", "D%", () => {
   _write("<span>");
 
   const message = _getInContext("packages/translator/src/__tests__/fixtures/context-tag-from-relative-path/other.marko");
@@ -8,8 +8,8 @@ _dynamicTag(Other, {}, _createRenderer("<!></span>", "D%", () => {
 
 import { write as _write, getInContext as _getInContext, data as _data, createRenderer as _createRenderer, dynamicTag as _dynamicTag, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_message(message) {
-  if (_write(1, message)) _data(0, message);
+function _apply_message(_scope, message) {
+  if (_write(_scope, 1, message)) _data(_scope, 0, message);
 }
 
 const _temp = _createRenderer("<!></span>", "D%", null);

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-self/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-self/__snapshots__/dom.expected.js
@@ -8,8 +8,8 @@ _popContext();
 
 import { pushContext as _pushContext, write as _write, getInContext as _getInContext, data as _data, popContext as _popContext, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_x(x) {
-  if (_write(1, x)) _data(0, x);
+function _apply_x(_scope, x) {
+  if (_write(_scope, 1, x)) _data(_scope, 0, x);
 }
 
 export const template = "<!></span></div>";

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected.js
@@ -1,11 +1,11 @@
 import { write as _write, getInContext as _getInContext, data as _data, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { apply as _other, template as _other_template, walks as _other_walks } from "./components/other.marko";
 
-function _apply_message(message) {
-  if (_write(1, message)) _data(0, message);
+function _apply_message(_scope, message) {
+  if (_write(_scope, 1, message)) _data(_scope, 0, message);
 }
 
-function _apply() {
+function _apply(_scope) {
   _other();
 }
 

--- a/packages/translator/src/__tests__/fixtures/custom-tag-parameters/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-parameters/__snapshots__/dom.expected.js
@@ -1,19 +1,19 @@
 import { data as _data, write as _write, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { apply as _customTag, template as _customTag_template, walks as _customTag_walks } from "./components/custom-tag.marko";
 
-function _apply_c(c) {
-  if (_write(5, c)) _data(2, c);
+function _apply_c(_scope, c) {
+  if (_write(_scope, 5, c)) _data(_scope, 2, c);
 }
 
-function _apply_b(b) {
-  if (_write(4, b)) _data(1, b);
+function _apply_b(_scope, b) {
+  if (_write(_scope, 4, b)) _data(_scope, 1, b);
 }
 
-function _apply_a(a) {
-  if (_write(3, a)) _data(0, a);
+function _apply_a(_scope, a) {
+  if (_write(_scope, 3, a)) _data(_scope, 0, a);
 }
 
-function _apply() {
+function _apply(_scope) {
   _customTag();
 }
 

--- a/packages/translator/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected.js
@@ -1,6 +1,6 @@
 import { apply as _child, template as _child_template, walks as _child_walks } from "./components/child/index.marko";
 
-function _apply() {
+function _apply(_scope) {
   _child();
 }
 

--- a/packages/translator/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.expected.js
@@ -1,6 +1,6 @@
 import { apply as _hello, template as _hello_template, walks as _hello_walks } from "./hello.marko";
 
-function _apply() {
+function _apply(_scope) {
   _hello();
 }
 

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected.js
@@ -1,11 +1,11 @@
 import { apply as _child, template as _child_template, walks as _child_walks } from "./components/child/index.marko";
 import { data as _data, write as _write, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_data(data) {
-  if (_write(1, data)) _data(0, data);
+function _apply_data(_scope, data) {
+  if (_write(_scope, 1, data)) _data(_scope, 0, data);
 }
 
-function _apply() {
+function _apply(_scope) {
   _child();
 }
 

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/dom.expected.js
@@ -1,36 +1,36 @@
 import tagA from "./components/tag-a/index.marko";
 import tagB from "./components/tag-b/index.marko";
 
-_dynamicTag(renderBody, {
+_dynamicTag(_scope, renderBody, {
   class: ["a", "b"],
   other: other
 });
 
-_dynamicTag(x, {
+_dynamicTag(_scope, x, {
   class: ["a", "b"],
   other: other
 });
 
 const _tagName = show ? "div" : null;
 
-_dynamicTag(_tagName, {
+_dynamicTag(_scope, _tagName, {
   class: ["a", "b"],
   other: other
 });
 
 const _tagName2 = show && "div";
 
-_dynamicTag(_tagName2, {
+_dynamicTag(_scope, _tagName2, {
   class: ["a", "b"],
   other: other
 });
 
-_dynamicTag(large ? "h1" : "h2", {
+_dynamicTag(_scope, large ? "h1" : "h2", {
   class: ["a", "b"],
   other: other
 });
 
-_dynamicTag(showTagA ? tagA : tagB, {
+_dynamicTag(_scope, showTagA ? tagA : tagB, {
   class: ["a", "b"],
   other: other,
   class: ["a", "b"],
@@ -39,78 +39,78 @@ _dynamicTag(showTagA ? tagA : tagB, {
 
 const _tagName3 = showTagA && tagA;
 
-_dynamicTag(_tagName3, {
+_dynamicTag(_scope, _tagName3, {
   class: ["a", "b"],
   other: other
 });
 
 const _tagName4 = showTagA && tagA;
 
-_dynamicTag(_tagName4, {
+_dynamicTag(_scope, _tagName4, {
   class: ["a", "b"],
   other: other
 });
 
-_dynamicTag(tag || tagA, {
+_dynamicTag(_scope, tag || tagA, {
   class: ["a", "b"],
   other: other
 });
 
 const _tagName5 = largeHeading || "h2";
 
-_dynamicTag(_tagName5, {
+_dynamicTag(_scope, _tagName5, {
   class: ["a", "b"],
   other: other
 });
 
-_dynamicTag(global.x = "a" + "b", {
+_dynamicTag(_scope, global.x = "a" + "b", {
   class: ["a", "b"],
   other: other
 });
 
-_dynamicTag("h" + level, {
+_dynamicTag(_scope, "h" + level, {
   class: ["a", "b"],
   other: other
 });
 
-_dynamicTag(`h${level}`, {
+_dynamicTag(_scope, `h${level}`, {
   class: ["a", "b"],
   other: other
 });
 
-_dynamicTag(tagConstA, {
+_dynamicTag(_scope, tagConstA, {
   class: ["a", "b"],
   other: other
 });
 
-_dynamicTag(tagConstB, {
+_dynamicTag(_scope, tagConstB, {
   class: ["a", "b"],
   other: other
 });
 
 import { dynamicTag as _dynamicTag, write as _write, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_tagConstB(tagConstB) {
-  if (_write(19, tagConstB)) {}
+function _apply_tagConstB(_scope, tagConstB) {
+  if (_write(_scope, 19, tagConstB)) {}
 }
 
-function _apply_tagConstA(tagConstA) {
-  if (_write(18, tagConstA)) {}
+function _apply_tagConstA(_scope, tagConstA) {
+  if (_write(_scope, 18, tagConstA)) {}
 }
 
-function _apply_largeHeading(largeHeading) {
-  if (_write(17, largeHeading)) {}
+function _apply_largeHeading(_scope, largeHeading) {
+  if (_write(_scope, 17, largeHeading)) {}
 }
 
-function _apply_isLarge(isLarge) {
-  if (_write(13, isLarge)) _apply_largeHeading(isLarge && "h1");
+function _apply_isLarge(_scope, isLarge) {
+  if (_write(_scope, 13, isLarge)) _apply_largeHeading(isLarge && "h1");
 }
 
-function _apply_show(show) {
-  if (_write(11, show)) _apply_tagConstB(show ? "div" : null);
+function _apply_show(_scope, show) {
+  if (_write(_scope, 11, show)) _apply_tagConstB(show ? "div" : null);
 }
 
-function _apply() {
+function _apply(_scope) {
   _apply_tagConstA("a");
 }
 

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-var/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-var/__snapshots__/dom.expected.js
@@ -1,16 +1,16 @@
 import child from "./components/child/index.marko";
 
-const data1 = _dynamicTag(child, null);
+const data1 = _dynamicTag(_scope, child, null);
 
 const _tagName = show && child;
 
-const data2 = _dynamicTag(_tagName, null);
+const data2 = _dynamicTag(_scope, _tagName, null);
 
-const data3 = _dynamicTag(dynamic, null);
+const data3 = _dynamicTag(_scope, dynamic, null);
 
 const _tagName2 = show && "div";
 
-const el1 = _dynamicTag(_tagName2, null);
+const el1 = _dynamicTag(_scope, _tagName2, null);
 
 import { dynamicTag as _dynamicTag, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 export const template = "";

--- a/packages/translator/src/__tests__/fixtures/event-handlers/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/event-handlers/__snapshots__/dom.expected.js
@@ -1,20 +1,20 @@
 import { apply as _child, template as _child_template, walks as _child_walks } from "./components/child/index.marko";
-import { write as _write, read as _read, on as _on, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { write as _write, on as _on, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _hydrate() {
-  _on(0, "click", _read(1));
+function _hydrate(_scope) {
+  _on(_scope, 0, "click", _scope[1]);
 }
 
-const _temp = () => {
+const _temp = _scope => {
   console.log("hello world");
 };
 
-function _apply() {
+function _apply(_scope) {
   _child();
 
-  _write(1, _bind(_temp));
+  _write(_scope, 1, _bind(_scope, _temp));
 
-  _hydrate();
+  _hydrate(_scope);
 }
 
 export const template = `${_child_template}<div class=hi></div>`;

--- a/packages/translator/src/__tests__/fixtures/event-handlers/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/event-handlers/__snapshots__/html.expected.js
@@ -1,5 +1,5 @@
 import _child from "./components/child/index.marko";
-import { markScopeOffset as _markScopeOffset, write as _write, read as _read, on as _on, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markScopeOffset as _markScopeOffset, write as _write, on as _on, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
 const _renderer = _register("packages/translator/src/__tests__/fixtures/event-handlers/template.marko", input => {
   _child({

--- a/packages/translator/src/__tests__/fixtures/for-tag-with-state/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag-with-state/__snapshots__/dom.expected.js
@@ -1,33 +1,33 @@
 import { data as _data, setLoopOf as _setLoopOf, write as _write, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_i2(i) {
-  if (_write(3, i)) _data(0, i);
+function _apply_i2(_scope, i) {
+  if (_write(_scope, 3, i)) _data(_scope, 0, i);
 }
 
-function _apply_val2(val) {
-  if (_write(2, val)) _data(1, val);
+function _apply_val2(_scope, val) {
+  if (_write(_scope, 2, val)) _data(_scope, 1, val);
 }
 
-function _apply_i(i) {
-  if (_write(3, i)) _data(0, i);
+function _apply_i(_scope, i) {
+  if (_write(_scope, 3, i)) _data(_scope, 0, i);
 }
 
-function _apply_val(val) {
-  if (_write(2, val)) _data(1, val);
+function _apply_val(_scope, val) {
+  if (_write(_scope, 2, val)) _data(_scope, 1, val);
 }
 
-function _apply_arrB(arrB) {
-  if (_write(9, arrB)) _setLoopOf(4, arrB, _for2, null, _apply_val2);
+function _apply_arrB(_scope, arrB) {
+  if (_write(_scope, 9, arrB)) _setLoopOf(_scope, 4, arrB, _for2, null, _apply_val2);
 }
 
-function _apply_arrA(arrA) {
-  if (_write(8, arrA)) _setLoopOf(0, arrA, _for, null, _apply_val);
+function _apply_arrA(_scope, arrA) {
+  if (_write(_scope, 8, arrA)) _setLoopOf(_scope, 0, arrA, _for, null, _apply_val);
 }
 
-function _apply() {
+function _apply(_scope) {
   _apply_arrA([1, 2, 3]);
 
-  _apply_arrB([1, 2, 3]);
+  _apply_arrB(_scope, [1, 2, 3]);
 }
 
 const _for = _createRenderer("<div><!>: <!></div>", "D%c%", null),

--- a/packages/translator/src/__tests__/fixtures/for-tag/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag/__snapshots__/dom.expected.js
@@ -9,111 +9,111 @@
 <for from=0 to=10/>
 import { data as _data, setLoopOf as _setLoopOf, attr as _attr, write as _write, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_i7(i) {
-  if (_write(3, i)) {
-    _attr(0, "key", i);
+function _apply_i7(_scope, i) {
+  if (_write(_scope, 3, i)) {
+    _attr(_scope, 0, "key", i);
 
-    _data(1, i);
+    _data(_scope, 1, i);
 
-    _attr(2, "key", `other-${i}`);
+    _attr(_scope, 2, "key", `other-${i}`);
   }
 }
 
-function _apply_i6(i) {
-  if (_write(3, i)) {
-    _attr(0, "key", i);
+function _apply_i6(_scope, i) {
+  if (_write(_scope, 3, i)) {
+    _attr(_scope, 0, "key", i);
 
-    _data(1, i);
+    _data(_scope, 1, i);
 
-    _attr(2, "key", `other-${i}`);
+    _attr(_scope, 2, "key", `other-${i}`);
   }
 }
 
-function _apply_i5(i) {
-  if (_write(7, i)) {
-    _attr(0, "key", i);
+function _apply_i5(_scope, i) {
+  if (_write(_scope, 7, i)) {
+    _attr(_scope, 0, "key", i);
 
-    _data(1, i);
+    _data(_scope, 1, i);
 
-    _attr(2, "key", `other-${i}`);
+    _attr(_scope, 2, "key", `other-${i}`);
   }
 }
 
-function _apply_val5(val) {
-  if (_write(5, val)) _data(2, val);
+function _apply_val5(_scope, val) {
+  if (_write(_scope, 5, val)) _data(_scope, 2, val);
 }
 
-function _apply_key2(key) {
-  if (_write(4, key)) {
-    _attr(0, "key", key);
+function _apply_key2(_scope, key) {
+  if (_write(_scope, 4, key)) {
+    _attr(_scope, 0, "key", key);
 
-    _data(1, key);
+    _data(_scope, 1, key);
 
-    _attr(3, "key", `other-${key}`);
+    _attr(_scope, 3, "key", `other-${key}`);
   }
 }
 
-function _apply_list(list) {
-  if (_write(5, list)) _data(1, list.length);
+function _apply_list(_scope, list) {
+  if (_write(_scope, 5, list)) _data(_scope, 1, list.length);
 }
 
-function _apply_i4(i) {
-  if (_write(4, i)) _attr(0, "key", i);
+function _apply_i4(_scope, i) {
+  if (_write(_scope, 4, i)) _attr(_scope, 0, "key", i);
 }
 
-function _apply_val4(val) {
-  if (_write(3, val)) _data(2, val);
+function _apply_val4(_scope, val) {
+  if (_write(_scope, 3, val)) _data(_scope, 2, val);
 }
 
-function _apply_i3(i) {
-  if (_write(5, i)) {
-    _attr(0, "key", i);
+function _apply_i3(_scope, i) {
+  if (_write(_scope, 5, i)) {
+    _attr(_scope, 0, "key", i);
 
-    _data(1, i);
+    _data(_scope, 1, i);
 
-    _attr(3, "key", `other-${i}`);
+    _attr(_scope, 3, "key", `other-${i}`);
   }
 }
 
-function _apply_val3(val) {
-  if (_write(4, val)) _data(2, val);
+function _apply_val3(_scope, val) {
+  if (_write(_scope, 4, val)) _data(_scope, 2, val);
 }
 
-function _apply_i2(i) {
-  if (_write(1, i)) _data(0, i);
+function _apply_i2(_scope, i) {
+  if (_write(_scope, 1, i)) _data(_scope, 0, i);
 }
 
-function _apply_val2(val) {
-  if (_write(3, val)) _data(1, val);
+function _apply_val2(_scope, val) {
+  if (_write(_scope, 3, val)) _data(_scope, 1, val);
 }
 
-function _apply_key(key) {
-  if (_write(2, key)) _data(0, key);
+function _apply_key(_scope, key) {
+  if (_write(_scope, 2, key)) _data(_scope, 0, key);
 }
 
-function _apply_i(i) {
-  if (_write(3, i)) _data(0, i);
+function _apply_i(_scope, i) {
+  if (_write(_scope, 3, i)) _data(_scope, 0, i);
 }
 
-function _apply_val(val) {
-  if (_write(2, val)) _data(1, val);
+function _apply_val(_scope, val) {
+  if (_write(_scope, 2, val)) _data(_scope, 1, val);
 }
 
-function _apply_obj(obj) {
-  if (_write(41, obj)) {}
+function _apply_obj(_scope, obj) {
+  if (_write(_scope, 41, obj)) {}
 }
 
-function _apply_arr(arr) {
-  if (_write(40, arr)) {
-    _setLoopOf(0, arr, _for, null, _apply_val);
+function _apply_arr(_scope, arr) {
+  if (_write(_scope, 40, arr)) {
+    _setLoopOf(_scope, 0, arr, _for, null, _apply_val);
 
-    _setLoopOf(12, arr, _for2, null, _apply_val3);
+    _setLoopOf(_scope, 12, arr, _for2, null, _apply_val3);
 
-    _setLoopOf(16, arr, _for3, null, _apply_val4);
+    _setLoopOf(_scope, 16, arr, _for3, null, _apply_val4);
   }
 }
 
-function _apply() {
+function _apply(_scope) {
   _apply_arr([1, 2, 3]);
 
   _apply_obj({

--- a/packages/translator/src/__tests__/fixtures/hello-dynamic/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/hello-dynamic/__snapshots__/dom.expected.js
@@ -1,14 +1,14 @@
 import { data as _data, html as _html, write as _write, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_missing(missing) {
-  if (_write(4, missing)) _html(2, missing);
+function _apply_missing(_scope, missing) {
+  if (_write(_scope, 4, missing)) _html(_scope, 2, missing);
 }
 
-function _apply_name(name) {
-  if (_write(3, name)) {
-    _data(0, name);
+function _apply_name(_scope, name) {
+  if (_write(_scope, 3, name)) {
+    _data(_scope, 0, name);
 
-    _html(1, name);
+    _html(_scope, 1, name);
   }
 }
 

--- a/packages/translator/src/__tests__/fixtures/if-tag/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/if-tag/__snapshots__/dom.expected.js
@@ -1,29 +1,29 @@
-import { setConditionalRenderer as _setConditionalRenderer, read as _read, queue as _queue, write as _write, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { setConditionalRenderer as _setConditionalRenderer, queue as _queue, write as _write, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _applyWith_x_y(x = _read(14), y = _read(15)) {
-  _setConditionalRenderer(8, x ? _if5 : y ? _if4 : _if3);
+function _applyWith_x_y(_scope, x = _scope[14], y = _scope[15]) {
+  _setConditionalRenderer(_scope, 8, x ? _if5 : y ? _if4 : _if3);
 }
 
-function _applyWith_a_b(a = _read(12), b = _read(13)) {
-  _setConditionalRenderer(0, a + b ? _if : null);
+function _applyWith_a_b(_scope, a = _scope[12], b = _scope[13]) {
+  _setConditionalRenderer(_scope, 0, a + b ? _if : null);
 
-  _setConditionalRenderer(4, (a, b) ? _if2 : null);
+  _setConditionalRenderer(_scope, 4, (a, b) ? _if2 : null);
 }
 
-function _apply_y(y) {
-  if (_write(15, y)) _queue(_applyWith_x_y, 5);
+function _apply_y(_scope, y) {
+  if (_write(_scope, 15, y)) _queue(_scope, _applyWith_x_y, 5);
 }
 
-function _apply_x(x) {
-  if (_write(14, x)) _queue(_applyWith_x_y, 5);
+function _apply_x(_scope, x) {
+  if (_write(_scope, 14, x)) _queue(_scope, _applyWith_x_y, 5);
 }
 
-function _apply_b(b) {
-  if (_write(13, b)) _queue(_applyWith_a_b, 4);
+function _apply_b(_scope, b) {
+  if (_write(_scope, 13, b)) _queue(_scope, _applyWith_a_b, 4);
 }
 
-function _apply_a(a) {
-  if (_write(12, a)) _queue(_applyWith_a_b, 4);
+function _apply_a(_scope, a) {
+  if (_write(_scope, 12, a)) _queue(_scope, _applyWith_a_b, 4);
 }
 
 const _if = _createRenderer("Hello", "", null),

--- a/packages/translator/src/__tests__/fixtures/import-tag-conflict/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/import-tag-conflict/__snapshots__/dom.expected.js
@@ -2,10 +2,10 @@ import { asset as asset1 } from "./asset1";
 import { asset as asset2 } from "./asset2";
 import { data as _data, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply() {
-  _data(0, asset1);
+function _apply(_scope) {
+  _data(_scope, 0, asset1);
 
-  _data(1, asset2);
+  _data(_scope, 1, asset2);
 }
 
 export const template = "<!> <!>";

--- a/packages/translator/src/__tests__/fixtures/import-tag/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/import-tag/__snapshots__/dom.expected.js
@@ -2,12 +2,12 @@ import "./foo";
 import { b as c } from "./bar";
 import baz from "./components/baz.marko";
 
-_dynamicTag(baz, null);
+_dynamicTag(_scope, baz, null);
 
 import { dynamicTag as _dynamicTag, data as _data, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply() {
-  _data(0, c);
+function _apply(_scope) {
+  _data(_scope, 0, c);
 }
 
 export const template = "<!>";

--- a/packages/translator/src/__tests__/fixtures/input-tracking/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/input-tracking/__snapshots__/dom.expected.js
@@ -1,15 +1,15 @@
 import { data as _data, write as _write, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_b(b) {
-  if (_write(4, b)) _data(1, b);
+function _apply_b(_scope, b) {
+  if (_write(_scope, 4, b)) _data(_scope, 1, b);
 }
 
-function _apply_a(a) {
-  if (_write(3, a)) _data(0, a);
+function _apply_a(_scope, a) {
+  if (_write(_scope, 3, a)) _data(_scope, 0, a);
 }
 
-function _apply_input(input) {
-  if (_write(2, input)) {
+function _apply_input(_scope, input) {
+  if (_write(_scope, 2, input)) {
     const {
       a,
       b

--- a/packages/translator/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected.js
@@ -1,35 +1,35 @@
-import { queue as _queue, write as _write, read as _read, on as _on, data as _data, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queue as _queue, write as _write, on as _on, data as _data, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _hydrateWith_x_y(x = _read(3), y = _read(4)) {
-  _on(0, "click", _read(5));
+function _hydrateWith_x_y(_scope, x = _scope[3], y = _scope[4]) {
+  _on(_scope, 0, "click", _scope[5]);
 }
 
-function _applyWith_x_y(x = _read(3), y = _read(4)) {
-  _write(5, _queue(_apply_x, 0, y = x + y));
+function _applyWith_x_y(_scope, x = _scope[3], y = _scope[4]) {
+  _write(_scope, 5, _queue(_scope, _apply_x, 0, y = x + y));
 
-  _hydrateWith_x_y();
+  _hydrateWith_x_y(_scope);
 }
 
-function _apply_y(y) {
-  if (_write(4, y)) {
-    _data(2, y);
+function _apply_y(_scope, y) {
+  if (_write(_scope, 4, y)) {
+    _data(_scope, 2, y);
 
-    _queue(_applyWith_x_y, 2);
+    _queue(_scope, _applyWith_x_y, 2);
   }
 }
 
-function _apply_x(x) {
-  if (_write(3, x)) {
-    _data(1, x);
+function _apply_x(_scope, x) {
+  if (_write(_scope, 3, x)) {
+    _data(_scope, 1, x);
 
-    _queue(_applyWith_x_y, 2);
+    _queue(_scope, _applyWith_x_y, 2);
   }
 }
 
-function _apply() {
-  _apply_x(1);
+function _apply(_scope) {
+  _apply_x(_scope, 1);
 
-  _apply_y(1);
+  _apply_y(_scope, 1);
 }
 
 export const template = "<div><!></div><!>";

--- a/packages/translator/src/__tests__/fixtures/let-tag/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/let-tag/__snapshots__/html.expected.js
@@ -1,4 +1,4 @@
-import { markScopeOffset as _markScopeOffset, write as _write, read as _read, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markScopeOffset as _markScopeOffset, write as _write, on as _on, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
 const _renderer = _register("packages/translator/src/__tests__/fixtures/let-tag/template.marko", input => {
   const x = 1;

--- a/packages/translator/src/__tests__/fixtures/placeholders/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/placeholders/__snapshots__/dom.expected.js
@@ -1,15 +1,15 @@
 import { data as _data, html as _html, write as _write, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_x(x) {
-  if (_write(3, x)) {
-    _data(0, x);
+function _apply_x(_scope, x) {
+  if (_write(_scope, 3, x)) {
+    _data(_scope, 0, x);
 
-    _html(1, x);
+    _html(_scope, 1, x);
   }
 }
 
-function _apply() {
-  _html(2, "Hello HTML <a/>");
+function _apply(_scope) {
+  _html(_scope, 2, "Hello HTML <a/>");
 }
 
 export const template = "<div><div>a</div><!>Hello Text &lt;a/><!><!><script>\n    Hello &lt;b> &lt;/script>\n  </script></div>";

--- a/packages/translator/src/__tests__/fixtures/tag-tag/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/tag-tag/__snapshots__/dom.expected.js
@@ -1,13 +1,13 @@
 const MyTag = input => {};
 
-_dynamicTag(MyTag, {
+_dynamicTag(_scope, MyTag, {
   name: "World"
 });
 
 import { data as _data, dynamicTag as _dynamicTag, write as _write, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_input(input) {
-  if (_write(1, input)) _data(0, input.name);
+function _apply_input(_scope, input) {
+  if (_write(_scope, 1, input)) _data(_scope, 0, input.name);
 }
 
 const _temp = _createRenderer("Hello <!>", "b%", null);

--- a/packages/translator/src/__tests__/fixtures/yield-tag/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/yield-tag/__snapshots__/dom.expected.js
@@ -3,8 +3,8 @@ var _return;
 return _return;
 import { setConditionalRenderer as _setConditionalRenderer, write as _write, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
-function _apply_show(show) {
-  if (_write(4, show)) _setConditionalRenderer(0, show ? _if2 : _if);
+function _apply_show(_scope, show) {
+  if (_write(_scope, 4, show)) _setConditionalRenderer(_scope, 0, show ? _if2 : _if);
 }
 
 const _if2 = _createRenderer("", "", null),

--- a/packages/translator/src/core/condition/if.ts
+++ b/packages/translator/src/core/condition/if.ts
@@ -17,6 +17,7 @@ import {
 import { isOutputDOM, isOutputHTML } from "../../util/marko-config";
 import analyzeAttributeTags from "../../util/nested-attribute-tags";
 import customTag from "../../visitors/tag/custom-tag";
+import { scopeIdentifier } from "../../visitors/program";
 
 export default {
   analyze: {
@@ -111,6 +112,7 @@ export function exitBranch(tag: t.NodePath<t.MarkoTag>) {
   setQueueBuilder(tag, ({ identifier, queuePriority }, closurePriority) =>
     callRuntime(
       "queueInBranch",
+      scopeIdentifier,
       t.numericLiteral(reserve.id),
       writer.getRenderer(bodySectionId),
       identifier,
@@ -162,6 +164,7 @@ export function exitBranch(tag: t.NodePath<t.MarkoTag>) {
         t.expressionStatement(
           callRuntime(
             "setConditionalRenderer",
+            scopeIdentifier,
             t.numericLiteral(extra.reserve!.id),
             expr
           )

--- a/packages/translator/src/core/for.ts
+++ b/packages/translator/src/core/for.ts
@@ -13,6 +13,7 @@ import { ReserveType, reserveScope } from "../util/reserve";
 import { callRuntime } from "../util/runtime";
 import analyzeAttributeTags from "../util/nested-attribute-tags";
 import customTag from "../visitors/tag/custom-tag";
+import { scopeIdentifier } from "../visitors/program";
 
 export default {
   analyze: {
@@ -137,6 +138,7 @@ const translateDOM = {
     setQueueBuilder(tag, ({ identifier, queuePriority }, closurePriority) => {
       return callRuntime(
         "queueForEach",
+        scopeIdentifier,
         t.numericLiteral(reserve!.id),
         identifier,
         queuePriority,
@@ -167,6 +169,7 @@ const translateDOM = {
         t.expressionStatement(
           callRuntime(
             "setLoopOf",
+            scopeIdentifier,
             t.numericLiteral(reserve!.id),
             ofAttrValue,
             rendererId,

--- a/packages/translator/src/core/let.ts
+++ b/packages/translator/src/core/let.ts
@@ -7,6 +7,7 @@ import { addStatement, bindingToApplyGroup } from "../util/apply-hydrate";
 import { callQueue } from "../util/runtime";
 import replaceAssignments from "../util/replace-assignments";
 import { getSectionId } from "../util/sections";
+import { scopeIdentifier } from "../visitors/program";
 
 export default {
   translate(tag) {
@@ -57,7 +58,9 @@ export default {
         "apply",
         sectionId,
         defaultAttr.extra?.valueReferences,
-        t.expressionStatement(t.callExpression(applyId, [defaultAttr.value]))
+        t.expressionStatement(
+          t.callExpression(applyId, [scopeIdentifier, defaultAttr.value])
+        )
       );
 
       replaceAssignments(

--- a/packages/translator/src/visitors/placeholder.ts
+++ b/packages/translator/src/visitors/placeholder.ts
@@ -8,6 +8,7 @@ import { ReserveType, reserveScope } from "../util/reserve";
 import { addStatement } from "../util/apply-hydrate";
 import * as writer from "../util/writer";
 import * as walks from "../util/walks";
+import { scopeIdentifier } from "./program";
 
 const ESCAPE_TYPES = {
   script: "escapeScript",
@@ -64,6 +65,7 @@ export default {
           t.expressionStatement(
             callRuntime(
               method as DOMMethod,
+              scopeIdentifier,
               t.numericLiteral(reserve!.id!),
               placeholder.node.value
             )

--- a/packages/translator/src/visitors/program/index.ts
+++ b/packages/translator/src/visitors/program/index.ts
@@ -6,6 +6,7 @@ import { startSection } from "../../util/sections";
 import { assignFinalIds } from "../../util/reserve";
 
 export let currentProgramPath: t.NodePath<t.Program>;
+export let scopeIdentifier: t.Identifier;
 
 export default {
   analyze: {
@@ -22,6 +23,7 @@ export default {
   translate: {
     enter(program: t.NodePath<t.Program>) {
       currentProgramPath = program;
+      scopeIdentifier = program.scope.generateUidIdentifier("scope");
     },
     exit(program: t.NodePath<t.Program>) {
       if (isOutputHTML()) {

--- a/packages/translator/src/visitors/tag/dynamic-tag.ts
+++ b/packages/translator/src/visitors/tag/dynamic-tag.ts
@@ -6,6 +6,7 @@ import { callRuntime } from "../../util/runtime";
 import translateVar from "../../util/translate-var";
 import { isOutputDOM, isOutputHTML } from "../../util/marko-config";
 import { getSectionId } from "../../util/sections";
+import { scopeIdentifier } from "../program";
 
 export default {
   translate: {
@@ -23,6 +24,8 @@ export default {
 
       if (isOutputHTML()) {
         writer.flushInto(tag);
+      } else {
+        args.unshift(scopeIdentifier);
       }
 
       if (renderBodyProp) {

--- a/packages/translator/src/visitors/tag/native-tag.ts
+++ b/packages/translator/src/visitors/tag/native-tag.ts
@@ -2,7 +2,7 @@ import { types as t } from "@marko/compiler";
 import { getTagDef } from "@marko/babel-utils";
 import { isOutputHTML } from "../../util/marko-config";
 import attrsToObject from "../../util/attrs-to-object";
-import { callRuntime, getHTMLRuntime } from "../../util/runtime";
+import { callRuntime, getHTMLRuntime, callRead } from "../../util/runtime";
 import translateVar from "../../util/translate-var";
 import evaluate from "../../util/evaluate";
 import { getOrCreateSectionId, getSectionId } from "../../util/sections";
@@ -10,6 +10,7 @@ import { ReserveType, reserveScope } from "../../util/reserve";
 import { addStatement } from "../../util/apply-hydrate";
 import * as writer from "../../util/writer";
 import * as walks from "../../util/walks";
+import { scopeIdentifier } from "../program";
 
 export default {
   analyze: {
@@ -73,7 +74,11 @@ export default {
       write`<${name.node}`;
 
       if (hasSpread) {
-        const attrsCallExpr = callRuntime("attrs", attrsToObject(tag)!);
+        const attrsCallExpr = callRuntime(
+          "attrs",
+          scopeIdentifier,
+          attrsToObject(tag)!
+        );
 
         if (isHTML) {
           write`${attrsCallExpr}`;
@@ -125,7 +130,12 @@ export default {
                     sectionId,
                     valueReferences,
                     t.expressionStatement(
-                      callRuntime("write", reserveIndex, value.node)
+                      callRuntime(
+                        "write",
+                        scopeIdentifier,
+                        reserveIndex,
+                        value.node
+                      )
                     )
                   );
 
@@ -136,9 +146,10 @@ export default {
                     t.expressionStatement(
                       callRuntime(
                         "on",
+                        scopeIdentifier,
                         visitIndex!,
                         t.stringLiteral(name.slice(2)),
-                        callRuntime("read", reserveIndex)
+                        callRead(extra.reserve!, sectionId)
                       )
                     )
                   );
@@ -150,6 +161,7 @@ export default {
                     t.expressionStatement(
                       callRuntime(
                         "attr",
+                        scopeIdentifier,
                         visitIndex!,
                         t.stringLiteral(name),
                         value.node


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Scopes are now represented by a single object, not a scope array and an offset in the scope array.  
3. Scopes are now passed as arguments, not read from module scope.  
 
This removes the need for a number of different runtime helpers: `read`, `readInOwner`, `queueInOwner`, `runInScope`, `runInChild` (maybe a few others I'm missing?).


## Motivation and Context



## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
