### PR TITLE
Client Performance Improvements - Single Child, Placeholder Write

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -14,9 +14,9 @@
     {
       "name": "counter",
       "user": {
-        "min": 392,
-        "gzip": 281,
-        "brotli": 250
+        "min": 390,
+        "gzip": 278,
+        "brotli": 248
       },
       "runtime": {
         "min": 3094,
@@ -24,9 +24,9 @@
         "brotli": 1350
       },
       "total": {
-        "min": 3486,
-        "gzip": 1773,
-        "brotli": 1600
+        "min": 3484,
+        "gzip": 1770,
+        "brotli": 1598
       }
     },
     {

--- a/packages/runtime/src/dom/queue-dumb.ts
+++ b/packages/runtime/src/dom/queue-dumb.ts
@@ -1,0 +1,61 @@
+import type { Scope } from "../common/types";
+import { schedule } from "./schedule";
+
+type ExecFn<S extends Scope = Scope> = (scope: S, arg?: any) => void;
+
+let queuedFns: unknown[] = [];
+let queuedFnsHydrate: Array<Scope | ExecFn> = [];
+
+const enum QueueOffsets {
+  FN = 0,
+  SCOPE = 1,
+  OFFSET = 2,
+  PRIORITY = 3,
+  ARGUMENT = 4,
+  TOTAL = 5,
+}
+
+export function queue<S extends Scope, T extends ExecFn<S>>(
+  scope: S,
+  fn: T,
+  localPriority = 0,
+  argument: Parameters<T>[1] = undefined
+) {
+  const priority = scope.___id + localPriority;
+  const index = queuedFns.length;
+
+  schedule();
+  for (let i = queuedFns.length - 1; i >= index; i--) {
+    queuedFns[i + QueueOffsets.TOTAL] = queuedFns[i];
+  }
+
+  queuedFns[index + QueueOffsets.FN] = fn;
+  queuedFns[index + QueueOffsets.SCOPE] = scope;
+  queuedFns[index + QueueOffsets.PRIORITY] = priority;
+  queuedFns[index + QueueOffsets.ARGUMENT] = argument;
+}
+
+export function queueHydrate<S extends Scope, T extends ExecFn<S>>(
+  scope: S,
+  fn: T
+) {
+  queuedFnsHydrate.push(scope, fn as unknown as ExecFn);
+}
+
+export function run() {
+  if (queuedFns.length) {
+    for (let i = 0; i < queuedFns.length; i += QueueOffsets.TOTAL) {
+      (queuedFns[i + QueueOffsets.FN] as ExecFn)(
+        queuedFns[i + QueueOffsets.SCOPE] as Scope,
+        queuedFns[i + QueueOffsets.ARGUMENT]
+      );
+    }
+    queuedFns = [];
+  }
+  if (queuedFnsHydrate.length) {
+    for (let i = 0; i < queuedFnsHydrate.length; i += 2) {
+      (queuedFnsHydrate[i + 1] as ExecFn)(queuedFnsHydrate[i] as Scope);
+    }
+    queuedFnsHydrate = [];
+  }
+}

--- a/packages/runtime/src/dom/queue.ts
+++ b/packages/runtime/src/dom/queue.ts
@@ -1,1 +1,1 @@
-export { queue, queueHydrate, run } from "./queue-heap";
+export { queue, queueHydrate, run } from "./queue-dumb";

--- a/packages/runtime/src/dom/queue.ts
+++ b/packages/runtime/src/dom/queue.ts
@@ -1,1 +1,1 @@
-export { queue, queueHydrate, run } from "./queue-dumb";
+export { queue, queueHydrate, run } from "./queue-heap";

--- a/packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected.js
@@ -20,8 +20,8 @@ const _temp2 = _createRenderer("<!>",
 "%+", null),
       _if = _createRenderer("", "", null),
       _temp3 = _createRenderer("",
-/* replace */
-"%", _apply);
+/* get */
+" ", _apply);
 
 export const applyAttrs = function (_scope, {
   x

--- a/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/components/my-button.js
@@ -23,9 +23,9 @@ export const applyAttrs = function (_scope, {
   _apply_text(_scope, text);
 };
 export { _apply_onclick, _apply_text };
-export const template = "<button><!></button>";
+export const template = "<button> </button>";
 export const walks =
-/* get, next(1), replace, out(1) */
-" D%l";
+/* get, next(1), get, out(1) */
+" D l";
 export const apply = function () {};
 export default _createRenderFn(template, walks, apply, applyAttrs);

--- a/packages/translator/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/components/counter.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/components/counter.js
@@ -24,9 +24,9 @@ function _apply(_scope) {
   _apply_clickCount(_scope, 0);
 }
 
-export const template = "<button><!></button>";
+export const template = "<button> </button>";
 export const walks =
-/* get, next(1), replace, out(1) */
-" D%l";
+/* get, next(1), get, out(1) */
+" D l";
 export const apply = _apply;
 export default _createRenderFn(template, walks, apply);

--- a/packages/translator/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected.js
@@ -24,9 +24,9 @@ function _apply(_scope) {
   _apply_clickCount(_scope, 0);
 }
 
-export const template = "<div><button><!></button></div>";
+export const template = "<div><button> </button></div>";
 export const walks =
-/* next(1), get, next(1), replace, out(2) */
-"D D%m";
+/* next(1), get, next(1), get, out(2) */
+"D D m";
 export const apply = _apply;
 export default _createRenderFn(template, walks, apply);

--- a/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected.js
@@ -38,9 +38,9 @@ function _apply(_scope) {
   _queueHydrate(_scope, _hydrate);
 }
 
-const _if = _createRenderer("<!>",
-/* replace */
-"%", _apply2);
+const _if = _createRenderer(" ",
+/* get */
+" ", _apply2);
 
 export const template = "<button>hide</button><!>";
 export const walks =

--- a/packages/translator/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected.js
@@ -25,9 +25,9 @@ function _apply(_scope) {
   _apply_count(_scope, 0);
 }
 
-export const template = "<button><!></button>";
+export const template = "<button> </button>";
 export const walks =
-/* get, next(1), replace, out(1) */
-" D%l";
+/* get, next(1), get, out(1) */
+" D l";
 export const apply = _apply;
 export default _createRenderFn(template, walks, apply);

--- a/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected.js
@@ -39,9 +39,9 @@ function _apply(_scope) {
   _apply_b(_scope, 1);
 }
 
-export const template = "<button><!></button>";
+export const template = "<button> </button>";
 export const walks =
-/* get, next(1), replace, out(1) */
-" D%l";
+/* get, next(1), get, out(1) */
+" D l";
 export const apply = _apply;
 export default _createRenderFn(template, walks, apply);

--- a/packages/translator/src/__tests__/fixtures/basic-handler-refless/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-refless/__snapshots__/dom.expected.js
@@ -20,9 +20,9 @@ function _apply(_scope) {
   _queueHydrate(_scope, _hydrate);
 }
 
-export const template = "<button><!></button>";
+export const template = "<button> </button>";
 export const walks =
-/* get, next(1), replace, out(1) */
-" D%l";
+/* get, next(1), get, out(1) */
+" D l";
 export const apply = _apply;
 export default _createRenderFn(template, walks, apply);

--- a/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/components/comments.js
+++ b/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/components/comments.js
@@ -100,9 +100,9 @@ function _apply_comments(_scope, comments) {
   if (_write(_scope, 4, comments)) _setLoopOf(_scope, 0, comments, _for, null, _apply_comment);
 }
 
-const _for = _createRenderer("<li><span><!></span><button><!></button><!></li>",
-/* get, next(2), replace, out(1), get, next(1), replace, out(1), replace, skip(3) */
-" E%l D%l%+", _apply),
+const _for = _createRenderer("<li><span> </span><button> </button><!></li>",
+/* get, next(2), get, out(1), get, next(1), get, out(1), replace, skip(3) */
+" E l D l%+", _apply),
       _if = _createRenderer(`${_comments_template}`,
 /* beginChild(0), _comments_walks, endChild */
 `/${_comments_walks}&`, _apply2);
@@ -116,9 +116,9 @@ export const applyAttrs = function (_scope, {
   _apply_path2(_scope, path);
 };
 export { _apply_comments, _apply_path2 as _apply_path };
-export const template = "<ul><!></ul>";
+export const template = "<ul></ul>";
 export const walks =
-/* next(1), replace, skip(3), out(1) */
-"D%+l";
+/* get, skip(3), over(1) */
+" +b";
 export const apply = function () {};
 export default _createRenderFn(template, walks, apply, applyAttrs);

--- a/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/html.expected/components/comments.js
+++ b/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/html.expected/components/comments.js
@@ -7,7 +7,7 @@ const _renderer = ({
 }) => {
   const _scope = _nextScopeId();
 
-  _write(`<ul>${_markHydrateNode(_scope, 0)}`);
+  _write(`${_markHydrateNode(_scope, 0)}<ul>`);
 
   let _i = 0;
 

--- a/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/ssr.expected.md
+++ b/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/ssr.expected.md
@@ -1,14 +1,14 @@
 # Write
-  <ul><!M#0 1><!M#0 2><li id=c-0><span><!M#1 2>Hello World</span><!M#2 2><button><!M#3 2>[-]</button><!M#4 2><ul><!M#0 4><!M#0 5><li id=c-0-0><span><!M#1 5>testing 123</span><!M#2 5><button><!M#3 5>[-]</button><!M#4 5></li></ul></li><!M#0 6><li id=c-1><span><!M#1 6>Goodbye World</span><!M#2 6><button><!M#3 6>[-]</button><!M#4 6></li></ul><script>(M$h=[]).push((b,s)=>({"2":[,,,,,,,,,,,!0],"5":[,,,,,,,,,,,!0],"6":[,,,,,,,,,,,!0]}),["packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko_1_0",5,"packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko_1_0",2,"packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko_1_0",6,])</script>
+  <!M#0 1><ul><!M#0 2><li id=c-0><span><!M#1 2>Hello World</span><!M#2 2><button><!M#3 2>[-]</button><!M#4 2><!M#0 4><ul><!M#0 5><li id=c-0-0><span><!M#1 5>testing 123</span><!M#2 5><button><!M#3 5>[-]</button><!M#4 5></li></ul></li><!M#0 6><li id=c-1><span><!M#1 6>Goodbye World</span><!M#2 6><button><!M#3 6>[-]</button><!M#4 6></li></ul><script>(M$h=[]).push((b,s)=>({"2":[,,,,,,,,,,,!0],"5":[,,,,,,,,,,,!0],"6":[,,,,,,,,,,,!0]}),["packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko_1_0",5,"packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko_1_0",2,"packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko_1_0",6,])</script>
 
 
 # Render "End"
 ```html
+<!--M#0 1-->
 <html>
   <head />
   <body>
     <ul>
-      <!--M#0 1-->
       <!--M#0 2-->
       <li
         id="c-0"
@@ -23,8 +23,8 @@
           [-]
         </button>
         <!--M#4 2-->
+        <!--M#0 4-->
         <ul>
-          <!--M#0 4-->
           <!--M#0 5-->
           <li
             id="c-0-0"
@@ -67,55 +67,55 @@
 
 # Mutations
 ```
-inserted html0
-inserted html0/head0
-inserted html0/body1
-inserted html0/body1/ul0
-inserted html0/body1/ul0/#comment0
-inserted html0/body1/ul0/#comment1
-inserted html0/body1/ul0/li2
-inserted html0/body1/ul0/li2/span0
-inserted html0/body1/ul0/li2/span0/#comment0
-inserted html0/body1/ul0/li2/span0/#text1
-inserted html0/body1/ul0/li2/#comment1
-inserted html0/body1/ul0/li2/button2
-inserted html0/body1/ul0/li2/button2/#comment0
-inserted html0/body1/ul0/li2/button2/#text1
-inserted html0/body1/ul0/li2/#comment3
-inserted html0/body1/ul0/li2/ul4
-inserted html0/body1/ul0/li2/ul4/#comment0
-inserted html0/body1/ul0/li2/ul4/#comment1
-inserted html0/body1/ul0/li2/ul4/li2
-inserted html0/body1/ul0/li2/ul4/li2/span0
-inserted html0/body1/ul0/li2/ul4/li2/span0/#comment0
-inserted html0/body1/ul0/li2/ul4/li2/span0/#text1
-inserted html0/body1/ul0/li2/ul4/li2/#comment1
-inserted html0/body1/ul0/li2/ul4/li2/button2
-inserted html0/body1/ul0/li2/ul4/li2/button2/#comment0
-inserted html0/body1/ul0/li2/ul4/li2/button2/#text1
-inserted html0/body1/ul0/li2/ul4/li2/#comment3
-inserted html0/body1/ul0/#comment3
-inserted html0/body1/ul0/li4
-inserted html0/body1/ul0/li4/span0
-inserted html0/body1/ul0/li4/span0/#comment0
-inserted html0/body1/ul0/li4/span0/#text1
-inserted html0/body1/ul0/li4/#comment1
-inserted html0/body1/ul0/li4/button2
-inserted html0/body1/ul0/li4/button2/#comment0
-inserted html0/body1/ul0/li4/button2/#text1
-inserted html0/body1/ul0/li4/#comment3
-inserted html0/body1/script1
-inserted html0/body1/script1/#text0
+inserted #comment0
+inserted html1
+inserted html1/head0
+inserted html1/body1
+inserted html1/body1/ul0
+inserted html1/body1/ul0/#comment0
+inserted html1/body1/ul0/li1
+inserted html1/body1/ul0/li1/span0
+inserted html1/body1/ul0/li1/span0/#comment0
+inserted html1/body1/ul0/li1/span0/#text1
+inserted html1/body1/ul0/li1/#comment1
+inserted html1/body1/ul0/li1/button2
+inserted html1/body1/ul0/li1/button2/#comment0
+inserted html1/body1/ul0/li1/button2/#text1
+inserted html1/body1/ul0/li1/#comment3
+inserted html1/body1/ul0/li1/#comment4
+inserted html1/body1/ul0/li1/ul5
+inserted html1/body1/ul0/li1/ul5/#comment0
+inserted html1/body1/ul0/li1/ul5/li1
+inserted html1/body1/ul0/li1/ul5/li1/span0
+inserted html1/body1/ul0/li1/ul5/li1/span0/#comment0
+inserted html1/body1/ul0/li1/ul5/li1/span0/#text1
+inserted html1/body1/ul0/li1/ul5/li1/#comment1
+inserted html1/body1/ul0/li1/ul5/li1/button2
+inserted html1/body1/ul0/li1/ul5/li1/button2/#comment0
+inserted html1/body1/ul0/li1/ul5/li1/button2/#text1
+inserted html1/body1/ul0/li1/ul5/li1/#comment3
+inserted html1/body1/ul0/#comment2
+inserted html1/body1/ul0/li3
+inserted html1/body1/ul0/li3/span0
+inserted html1/body1/ul0/li3/span0/#comment0
+inserted html1/body1/ul0/li3/span0/#text1
+inserted html1/body1/ul0/li3/#comment1
+inserted html1/body1/ul0/li3/button2
+inserted html1/body1/ul0/li3/button2/#comment0
+inserted html1/body1/ul0/li3/button2/#text1
+inserted html1/body1/ul0/li3/#comment3
+inserted html1/body1/script1
+inserted html1/body1/script1/#text0
 ```
 
 
 # Render "Hydrate"
 ```html
+<!--M#0 1-->
 <html>
   <head />
   <body>
     <ul>
-      <!--M#0 1-->
       <!--M#0 2-->
       <li
         id="c-0"
@@ -130,8 +130,8 @@ inserted html0/body1/script1/#text0
           [-]
         </button>
         <!--M#4 2-->
+        <!--M#0 4-->
         <ul>
-          <!--M#0 4-->
           <!--M#0 5-->
           <li
             id="c-0-0"
@@ -182,11 +182,11 @@ inserted html0/body1/script1/#text0
 container.querySelector(`#c-${id} > button`).click();
 
 ```html
+<!--M#0 1-->
 <html>
   <head />
   <body>
     <ul>
-      <!--M#0 1-->
       <!--M#0 2-->
       <li
         hidden="true"
@@ -202,8 +202,8 @@ container.querySelector(`#c-${id} > button`).click();
           [+]
         </button>
         <!--M#4 2-->
+        <!--M#0 4-->
         <ul>
-          <!--M#0 4-->
           <!--M#0 5-->
           <li
             id="c-0-0"
@@ -246,8 +246,8 @@ container.querySelector(`#c-${id} > button`).click();
 
 # Mutations
 ```
-html0/body1/ul0/li2: attr(hidden) null => "true"
-html0/body1/ul0/li2/button2/#text1: "[-]" => "[+]"
+html1/body1/ul0/li1: attr(hidden) null => "true"
+html1/body1/ul0/li1/button2/#text1: "[-]" => "[+]"
 ```
 
 
@@ -255,11 +255,11 @@ html0/body1/ul0/li2/button2/#text1: "[-]" => "[+]"
 container.querySelector(`#c-${id} > button`).click();
 
 ```html
+<!--M#0 1-->
 <html>
   <head />
   <body>
     <ul>
-      <!--M#0 1-->
       <!--M#0 2-->
       <li
         id="c-0"
@@ -274,8 +274,8 @@ container.querySelector(`#c-${id} > button`).click();
           [-]
         </button>
         <!--M#4 2-->
+        <!--M#0 4-->
         <ul>
-          <!--M#0 4-->
           <!--M#0 5-->
           <li
             id="c-0-0"
@@ -318,8 +318,8 @@ container.querySelector(`#c-${id} > button`).click();
 
 # Mutations
 ```
-html0/body1/ul0/li2: attr(hidden) "true" => null
-html0/body1/ul0/li2/button2/#text1: "[+]" => "[-]"
+html1/body1/ul0/li1: attr(hidden) "true" => null
+html1/body1/ul0/li1/button2/#text1: "[+]" => "[-]"
 ```
 
 
@@ -327,11 +327,11 @@ html0/body1/ul0/li2/button2/#text1: "[+]" => "[-]"
 container.querySelector(`#c-${id} > button`).click();
 
 ```html
+<!--M#0 1-->
 <html>
   <head />
   <body>
     <ul>
-      <!--M#0 1-->
       <!--M#0 2-->
       <li
         id="c-0"
@@ -346,8 +346,8 @@ container.querySelector(`#c-${id} > button`).click();
           [-]
         </button>
         <!--M#4 2-->
+        <!--M#0 4-->
         <ul>
-          <!--M#0 4-->
           <!--M#0 5-->
           <li
             hidden="true"
@@ -391,8 +391,8 @@ container.querySelector(`#c-${id} > button`).click();
 
 # Mutations
 ```
-html0/body1/ul0/li2/ul4/li2: attr(hidden) null => "true"
-html0/body1/ul0/li2/ul4/li2/button2/#text1: "[-]" => "[+]"
+html1/body1/ul0/li1/ul5/li1: attr(hidden) null => "true"
+html1/body1/ul0/li1/ul5/li1/button2/#text1: "[-]" => "[+]"
 ```
 
 
@@ -400,11 +400,11 @@ html0/body1/ul0/li2/ul4/li2/button2/#text1: "[-]" => "[+]"
 container.querySelector(`#c-${id} > button`).click();
 
 ```html
+<!--M#0 1-->
 <html>
   <head />
   <body>
     <ul>
-      <!--M#0 1-->
       <!--M#0 2-->
       <li
         id="c-0"
@@ -419,8 +419,8 @@ container.querySelector(`#c-${id} > button`).click();
           [-]
         </button>
         <!--M#4 2-->
+        <!--M#0 4-->
         <ul>
-          <!--M#0 4-->
           <!--M#0 5-->
           <li
             hidden="true"
@@ -465,6 +465,6 @@ container.querySelector(`#c-${id} > button`).click();
 
 # Mutations
 ```
-html0/body1/ul0/li4: attr(hidden) null => "true"
-html0/body1/ul0/li4/button2/#text1: "[-]" => "[+]"
+html1/body1/ul0/li3: attr(hidden) null => "true"
+html1/body1/ul0/li3/button2/#text1: "[-]" => "[+]"
 ```

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected.js
@@ -46,9 +46,9 @@ function _apply(_scope) {
   _setLoopOf(_scope, 0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], _for, null, _apply_num);
 }
 
-const _for = _createRenderer("<button><!></button>",
-/* get, next(1), replace */
-" D%", _apply2);
+const _for = _createRenderer("<button> </button>",
+/* get, next(1), get */
+" D ", _apply2);
 
 export const template = "<!>";
 export const walks =

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected.js
@@ -34,9 +34,9 @@ function _apply(_scope) {
   _apply_clickCount(_scope, 0);
 }
 
-const _if = _createRenderer("<button><!></button>",
-/* get, next(1), replace */
-" D%", _apply2);
+const _if = _createRenderer("<button> </button>",
+/* get, next(1), get */
+" D ", _apply2);
 
 export const template = "<div><!></div>";
 export const walks =

--- a/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected.js
@@ -57,9 +57,9 @@ function _apply(_scope) {
   _apply_items(_scope, []);
 }
 
-const _for = _createRenderer("<!>",
-/* replace */
-"%", null);
+const _for = _createRenderer(" ",
+/* get */
+" ", null);
 
 export const template = "<div><!><button id=add>Add</button><button id=remove>Remove</button></div>";
 export const walks =

--- a/packages/translator/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected.js
@@ -36,9 +36,9 @@ function _apply(_scope) {
   _apply_clickCount(_scope, 0);
 }
 
-export const template = "<div><button><!></button></div>";
+export const template = "<div><button> </button></div>";
 export const walks =
-/* next(1), get, next(1), replace, out(2) */
-"D D%m";
+/* next(1), get, next(1), get, out(2) */
+"D D m";
 export const apply = _apply;
 export default _createRenderFn(template, walks, apply);

--- a/packages/translator/src/__tests__/fixtures/const-tag/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/const-tag/__snapshots__/dom.expected.js
@@ -14,9 +14,9 @@ function _apply(_scope) {
   _apply_y(1);
 }
 
-export const template = "<div><!></div><!>";
+export const template = "<div> </div><!>";
 export const walks =
-/* next(1), replace, out(1), replace, over(1) */
-"D%l%b";
+/* next(1), get, out(1), replace, over(1) */
+"D l%b";
 export const apply = _apply;
 export default _createRenderFn(template, walks, apply);

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-relative-path/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-relative-path/__snapshots__/dom.expected.js
@@ -1,8 +1,8 @@
 import Other from "./other.marko";
 
-_dynamicTag(_scope, Other, {}, _createRenderer("<!></span>",
-/* next(1), replace */
-"D%", () => {
+_dynamicTag(_scope, Other, {}, _createRenderer(" </span>",
+/* next(1), get */
+"D ", () => {
   _write("<span>");
 
   const message = _getInContext("packages/translator/src/__tests__/fixtures/context-tag-from-relative-path/other.marko");
@@ -14,9 +14,9 @@ function _apply_message(_scope, message) {
   if (_write(_scope, 1, message)) _data(_scope, 0, message);
 }
 
-const _temp = _createRenderer("<!></span>",
-/* next(1), replace */
-"D%", null);
+const _temp = _createRenderer(" </span>",
+/* next(1), get */
+"D ", null);
 
 export const template = "";
 export const walks = "";

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-self/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-self/__snapshots__/dom.expected.js
@@ -12,9 +12,9 @@ function _apply_x(_scope, x) {
   if (_write(_scope, 1, x)) _data(_scope, 0, x);
 }
 
-export const template = "<!></span></div>";
+export const template = " </span></div>";
 export const walks =
-/* next(2), replace, out(2) */
-"E%m";
+/* next(2), get, out(2) */
+"E m";
 export const apply = function () {};
 export default _createRenderFn(template, walks, apply);

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected.js
@@ -9,9 +9,9 @@ function _apply(_scope) {
   _other(_scope[0]);
 }
 
-const _temp = _createRenderer("<!></span>",
-/* next(1), replace */
-"D%", null);
+const _temp = _createRenderer(" </span>",
+/* next(1), get */
+"D ", null);
 
 export const template = `${_other_template}`;
 export const walks =

--- a/packages/translator/src/__tests__/fixtures/for-tag-siblings/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag-siblings/__snapshots__/dom.expected.js
@@ -20,10 +20,16 @@ function _apply(_scope) {
   _apply_arrA([1, 2, 3]);
 }
 
-const _for = _createRenderer("<div><!></div>", "D%", null),
-      _for2 = _createRenderer("<div><!></div>", "D%", null);
+const _for = _createRenderer("<div> </div>",
+/* next(1), get */
+"D ", null),
+      _for2 = _createRenderer("<div> </div>",
+/* next(1), get */
+"D ", null);
 
 export const template = "<div></div><div><!><div></div></div>";
-export const walks = " +bD%+l";
+export const walks =
+/* get, skip(3), over(1), next(1), replace, skip(3), out(1) */
+" +bD%+l";
 export const apply = _apply;
 export default _createRenderFn(template, walks, apply);

--- a/packages/translator/src/__tests__/fixtures/for-tag-siblings/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag-siblings/__snapshots__/dom.expected.js
@@ -1,0 +1,29 @@
+import { data as _data, setLoopOf as _setLoopOf, write as _write, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+
+function _apply_val2(_scope, val) {
+  if (_write(_scope, 1, val)) _data(_scope, 0, val);
+}
+
+function _apply_val(_scope, val) {
+  if (_write(_scope, 1, val)) _data(_scope, 0, val);
+}
+
+function _apply_arrA(_scope, arrA) {
+  if (_write(_scope, 8, arrA)) {
+    _setLoopOf(_scope, 0, arrA, _for, null, _apply_val);
+
+    _setLoopOf(_scope, 4, arrA, _for2, null, _apply_val2);
+  }
+}
+
+function _apply(_scope) {
+  _apply_arrA([1, 2, 3]);
+}
+
+const _for = _createRenderer("<div><!></div>", "D%", null),
+      _for2 = _createRenderer("<div><!></div>", "D%", null);
+
+export const template = "<div></div><div><!><div></div></div>";
+export const walks = " +bD%+l";
+export const apply = _apply;
+export default _createRenderFn(template, walks, apply);

--- a/packages/translator/src/__tests__/fixtures/for-tag-siblings/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag-siblings/__snapshots__/html.expected.js
@@ -1,0 +1,22 @@
+import { markScopeOffset as _markScopeOffset, write as _write, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+
+const _renderer = _register("packages/translator/src/__tests__/fixtures/for-tag-siblings/template.marko", input => {
+  const arrA = [1, 2, 3];
+
+  _write(`${_markScopeOffset(0)}<div>`);
+
+  for (const val of arrA) {
+    _write(`<div>${_markScopeOffset(0)}${_escapeXML(val)}</div>`);
+  }
+
+  _write(`</div><div>${_markScopeOffset(4)}`);
+
+  for (const val of arrA) {
+    _write(`<div>${_markScopeOffset(0)}${_escapeXML(val)}</div>`);
+  }
+
+  _write("<div></div></div>");
+});
+
+export default _renderer;
+export const render = _createRenderer(_renderer);

--- a/packages/translator/src/__tests__/fixtures/for-tag-siblings/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag-siblings/__snapshots__/html.expected.js
@@ -1,22 +1,28 @@
-import { markScopeOffset as _markScopeOffset, write as _write, escapeXML as _escapeXML, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import { markHydrateNode as _markHydrateNode, write as _write, escapeXML as _escapeXML, nextScopeId as _nextScopeId, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 
-const _renderer = _register("packages/translator/src/__tests__/fixtures/for-tag-siblings/template.marko", input => {
+const _renderer = input => {
+  const _scope = _nextScopeId();
+
   const arrA = [1, 2, 3];
 
-  _write(`${_markScopeOffset(0)}<div>`);
+  _write(`${_markHydrateNode(_scope, 0)}<div>`);
 
   for (const val of arrA) {
-    _write(`<div>${_markScopeOffset(0)}${_escapeXML(val)}</div>`);
+    const _scope = _nextScopeId();
+
+    _write(`<div>${_markHydrateNode(_scope, 0)}${_escapeXML(val)}</div>`);
   }
 
-  _write(`</div><div>${_markScopeOffset(4)}`);
+  _write(`</div><div>${_markHydrateNode(_scope, 4)}`);
 
   for (const val of arrA) {
-    _write(`<div>${_markScopeOffset(0)}${_escapeXML(val)}</div>`);
+    const _scope = _nextScopeId();
+
+    _write(`<div>${_markHydrateNode(_scope, 0)}${_escapeXML(val)}</div>`);
   }
 
   _write("<div></div></div>");
-});
+};
 
 export default _renderer;
 export const render = _createRenderer(_renderer);

--- a/packages/translator/src/__tests__/fixtures/for-tag-siblings/template.marko
+++ b/packages/translator/src/__tests__/fixtures/for-tag-siblings/template.marko
@@ -1,0 +1,14 @@
+<const/arrA=[1, 2, 3]/>
+
+<div>
+  <for|val| of=arrA>
+    <div>${val}</div>
+  </for>
+</div>
+
+<div>
+  <for|val| of=arrA>
+    <div>${val}</div>
+  </for>
+  <div />
+</div>

--- a/packages/translator/src/__tests__/fixtures/for-tag-siblings/test.ts
+++ b/packages/translator/src/__tests__/fixtures/for-tag-siblings/test.ts
@@ -1,0 +1,2 @@
+export const skip_csr = true;
+export const skip_ssr = true;

--- a/packages/translator/src/__tests__/fixtures/for-tag/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag/__snapshots__/dom.expected.js
@@ -129,9 +129,9 @@ const _for = _createRenderer("<div><!>: <!></div><div></div><div></div>",
       _temp4 = _createRenderer("<div><!>: <!></div><div></div><div></div>",
 /* next(1), replace, over(2), replace */
 "D%c%", null),
-      _temp5 = _createRenderer("<div><!></div><div></div><div></div>",
-/* next(1), replace */
-"D%", null),
+      _temp5 = _createRenderer("<div> </div><div></div><div></div>",
+/* next(1), get */
+"D ", null),
       _for2 = _createRenderer("<div><!>: <!></div><div></div><div></div>",
 /* get, next(1), replace, over(2), replace, out(1), over(1), get */
 " D%c%lb ", null),
@@ -141,15 +141,15 @@ const _for = _createRenderer("<div><!>: <!></div><div></div><div></div>",
       _temp6 = _createRenderer("<div><!>: <!></div><div></div><div></div>",
 /* get, next(1), replace, over(2), replace, out(1), over(1), get */
 " D%c%lb ", null),
-      _temp7 = _createRenderer("<div><!></div><div></div><div></div><!>",
-/* get, next(1), replace, out(1), over(1), get, over(1), replace, skip(3) */
-" D%lb b%+", null),
-      _temp8 = _createRenderer("<div><!></div><div></div><div></div>",
-/* get, next(1), replace, out(1), over(1), get */
-" D%lb ", null),
-      _temp9 = _createRenderer("<div><!></div><div></div><div></div>",
-/* get, next(1), replace, out(1), over(1), get */
-" D%lb ", null),
+      _temp7 = _createRenderer("<div> </div><div></div><div></div><!>",
+/* get, next(1), get, out(1), over(1), get, over(1), replace, skip(3) */
+" D lb b%+", null),
+      _temp8 = _createRenderer("<div> </div><div></div><div></div>",
+/* get, next(1), get, out(1), over(1), get */
+" D lb ", null),
+      _temp9 = _createRenderer("<div> </div><div></div><div></div>",
+/* get, next(1), get, out(1), over(1), get */
+" D lb ", null),
       _temp10 = _createRenderer("Hello", "", null),
       _temp11 = _createRenderer("Hello", "", null);
 

--- a/packages/translator/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected.js
@@ -32,9 +32,9 @@ function _apply(_scope) {
   _apply_y(_scope, 1);
 }
 
-export const template = "<div><!></div><!>";
+export const template = "<div> </div><!>";
 export const walks =
-/* get, next(1), replace, out(1), replace, over(1) */
-" D%l%b";
+/* get, next(1), get, out(1), replace, over(1) */
+" D l%b";
 export const apply = _apply;
 export default _createRenderFn(template, walks, apply);

--- a/packages/translator/src/__tests__/fixtures/placeholders/__snapshots__/dom.expected.js
+++ b/packages/translator/src/__tests__/fixtures/placeholders/__snapshots__/dom.expected.js
@@ -1,15 +1,19 @@
 import { data as _data, html as _html, write as _write, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 
 function _apply_x(_scope, x) {
-  if (_write(_scope, 3, x)) {
+  if (_write(_scope, 5, x)) {
     _data(_scope, 0, x);
 
-    _html(_scope, 1, x);
+    _data(_scope, 1, x);
+
+    _data(_scope, 2, x);
+
+    _html(_scope, 3, x);
   }
 }
 
 function _apply(_scope) {
-  _html(_scope, 2, "Hello HTML <a/>");
+  _html(_scope, 4, "Hello HTML <a/>");
 }
 
 export const applyAttrs = function (_scope, {
@@ -18,9 +22,9 @@ export const applyAttrs = function (_scope, {
   _apply_x(_scope, x);
 };
 export { _apply_x };
-export const template = "<div><div>a</div><!>Hello Text &lt;a/><!><!><script>\n    Hello &lt;b> &lt;/script>\n  </script></div>";
+export const template = "<!><span> <div></div></span><div><div>a</div><!>Hello Text &lt;a/><!><!><script>\n    Hello &lt;b> &lt;/script>\n  </script></div>";
 export const walks =
-/* next(1), over(1), replace, over(2), replace, over(2), replace, out(1) */
-"Db%c%c%l";
+/* replace, over(1), next(1), get, out(1), next(1), over(1), replace, over(2), replace, over(2), replace, out(1) */
+"%bD lDb%c%c%l";
 export const apply = _apply;
 export default _createRenderFn(template, walks, apply, applyAttrs);

--- a/packages/translator/src/__tests__/fixtures/placeholders/__snapshots__/html.expected.js
+++ b/packages/translator/src/__tests__/fixtures/placeholders/__snapshots__/html.expected.js
@@ -5,7 +5,7 @@ const _renderer = ({
 }) => {
   const _scope = _nextScopeId();
 
-  _write(`<div><div>a</div>${_markHydrateNode(_scope, 0)}${_escapeXML(x)}Hello Text &lt;a/>${_markHydrateNode(_scope, 1)}${_toString(x)}Hello HTML <a/><script>
+  _write(`${_markHydrateNode(_scope, 0)}${_escapeXML(x)}<span>${_markHydrateNode(_scope, 1)}${_escapeXML(x)}<div></div></span><div><div>a</div>${_markHydrateNode(_scope, 2)}${_escapeXML(x)}Hello Text &lt;a/>${_markHydrateNode(_scope, 3)}${_toString(x)}Hello HTML <a/><script>
     Hello &lt;b> &lt;/script>
   </script></div>`);
 };

--- a/packages/translator/src/__tests__/fixtures/placeholders/template.marko
+++ b/packages/translator/src/__tests__/fixtures/placeholders/template.marko
@@ -1,4 +1,6 @@
 <attrs/{ x }/>
+-- ${x}
+<span>${x}<div /></span>
 <div>
   <div>
     a

--- a/packages/translator/src/visitors/placeholder.ts
+++ b/packages/translator/src/visitors/placeholder.ts
@@ -9,6 +9,7 @@ import { addStatement } from "../util/apply-hydrate";
 import * as writer from "../util/writer";
 import * as walks from "../util/walks";
 import { scopeIdentifier } from "./program";
+import { isCoreTag } from "../util/is-core-tag";
 
 const ESCAPE_TYPES = {
   script: "escapeScript",
@@ -30,6 +31,7 @@ export default {
         node,
         "placeholder"
       );
+      needsMarker(placeholder);
     }
   },
   translate(placeholder: t.NodePath<t.MarkoPlaceholder>) {
@@ -50,7 +52,12 @@ export default {
     if (confident && canWriteHTML) {
       write`${getHTMLRuntime()[method as HTMLMethod](computed)}`;
     } else {
-      walks.visit(placeholder, walks.WalkCodes.Replace);
+      if (extra.needsMarker) {
+        walks.visit(placeholder, walks.WalkCodes.Replace);
+      } else {
+        write` `;
+        walks.visit(placeholder, walks.WalkCodes.Get);
+      }
 
       if (isHTML) {
         write`${callRuntime(
@@ -86,4 +93,42 @@ function getParentTagName({ parentPath }: t.NodePath<t.MarkoPlaceholder>) {
       (parentPath.node.name as t.StringLiteral).value) ||
     ""
   );
+}
+
+function noOutput(path: t.NodePath<t.Node>) {
+  return (
+    t.isMarkoComment(path) ||
+    (t.isMarkoTag(path) &&
+      isCoreTag(path) &&
+      ["let", "const", "effect", "lifecycle", "attrs", "get", "id"].includes(
+        path.node.name.value
+      ))
+  );
+}
+
+function needsMarker(placeholder: t.NodePath<t.MarkoPlaceholder>) {
+  let prev = placeholder.getPrevSibling();
+
+  while (prev.node && noOutput(prev)) {
+    prev = prev.getPrevSibling();
+  }
+  if (
+    (prev.node || t.isProgram(placeholder.parentPath)) &&
+    !(t.isMarkoTag(prev) && isNativeTag(prev as t.NodePath<t.MarkoTag>))
+  ) {
+    return (placeholder.node.extra.needsMarker = true);
+  }
+
+  let next = placeholder.getNextSibling();
+  while (next.node && noOutput(next)) {
+    next = next.getNextSibling();
+  }
+  if (
+    (next.node || t.isProgram(placeholder.parentPath)) &&
+    !(t.isMarkoTag(next) && isNativeTag(next as t.NodePath<t.MarkoTag>))
+  ) {
+    return (placeholder.node.extra.needsMarker = true);
+  }
+
+  return (placeholder.node.extra.needsMarker = false);
 }

--- a/packages/translator/src/visitors/placeholder.ts
+++ b/packages/translator/src/visitors/placeholder.ts
@@ -55,7 +55,7 @@ export default {
       if (extra.needsMarker) {
         walks.visit(placeholder, walks.WalkCodes.Replace);
       } else {
-        write` `;
+        if (!isHTML) write` `;
         walks.visit(placeholder, walks.WalkCodes.Get);
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds 2 important performance optimizations for client rendering:
1. Placeholders now include an empty text node where available in the template and are updated, rather than replacing a comment.
2. For loops are now optimized for being in control of all nodes under their parents. This allows us to clear all children with `parent.textContent = ""`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
