### PR TITLE
feat(native-tag): align event handler naming conventions with v5

### DIFF
--- a/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/components/my-button.js
@@ -1,18 +1,18 @@
 import { on as _on, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _text = /* @__PURE__ */_source(3, [], (_scope, text) => _data(_scope[1], text));
-const _hydrate_onclick = _register("packages/translator/src/__tests__/fixtures/basic-component-attrs/components/my-button.marko_0_onclick", _scope => {
-  const onclick = _scope[2];
-  _on(_scope[0], "click", onclick);
+const _hydrate_onClick = _register("packages/translator/src/__tests__/fixtures/basic-component-attrs/components/my-button.marko_0_onClick", _scope => {
+  const onClick = _scope[2];
+  _on(_scope[0], "click", onClick);
 });
-const _onclick = /* @__PURE__ */_source(2, [], (_scope, onclick) => _queueHydrate(_scope, _hydrate_onclick));
-export const attrs = /* @__PURE__ */_destructureSources([_onclick, _text], (_scope, {
-  onclick,
+const _onClick = /* @__PURE__ */_source(2, [], (_scope, onClick) => _queueHydrate(_scope, _hydrate_onClick));
+export const attrs = /* @__PURE__ */_destructureSources([_onClick, _text], (_scope, {
+  onClick,
   text
 }) => {
-  _setSource(_scope, _onclick, onclick);
+  _setSource(_scope, _onClick, onClick);
   _setSource(_scope, _text, text);
 });
-export { _onclick as _apply_onclick, _text as _apply_text };
+export { _onClick as _apply_onClick, _text as _apply_text };
 export const template = "<button> </button>";
 export const walks = /* get, next(1), get, out(1) */" D l";
 export const setup = function () {};

--- a/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.js
@@ -1,12 +1,12 @@
 import { setSource as _setSource, queueSource as _queueSource, source as _source, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _myButton, attrs as _myButton_attrs, template as _myButton_template, walks as _myButton_walks } from "./components/my-button.marko";
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const clickCount = _scope[0];
   _queueSource(_scope, _clickCount, clickCount + 1);
 };
 const _clickCount = /* @__PURE__ */_source(0, [_myButton_attrs], (_scope, clickCount) => _setSource(_scope[1], _myButton_attrs, {
   text: clickCount,
-  onclick: /* @__PURE__ */_bind(_scope, _onclick)
+  onClick: /* @__PURE__ */_bind(_scope, _onClick)
 }));
 const _setup = _scope => {
   _setSource(_scope, _clickCount, 0);

--- a/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.expected/components/my-button.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.expected/components/my-button.js
@@ -1,13 +1,13 @@
 import { markHydrateNode as _markHydrateNode, escapeXML as _escapeXML, write as _write, nextScopeId as _nextScopeId, writeHydrateCall as _writeHydrateCall, writeHydrateScope as _writeHydrateScope, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 const _renderer = ({
-  onclick,
+  onClick,
   text
 }) => {
   const _scope = _nextScopeId();
   _write(`${_markHydrateNode(_scope, 0)}<button>${_markHydrateNode(_scope, 1)}${_escapeXML(text)}</button>`);
-  _writeHydrateCall(_scope, "packages/translator/src/__tests__/fixtures/basic-component-attrs/components/my-button.marko_0_onclick");
+  _writeHydrateCall(_scope, "packages/translator/src/__tests__/fixtures/basic-component-attrs/components/my-button.marko_0_onClick");
   _writeHydrateScope(_scope, {
-    2: onclick
+    2: onClick
   });
 };
 export default _renderer;

--- a/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.expected/template.js
@@ -5,7 +5,7 @@ const _renderer = input => {
   const clickCount = 0;
   _myButton({
     text: clickCount,
-    onclick: function () {
+    onClick: function () {
       clickCount++;
     },
     renderBody() {

--- a/packages/translator/src/__tests__/fixtures/basic-component-attrs/components/my-button.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-component-attrs/components/my-button.marko
@@ -1,2 +1,2 @@
-<attrs/{ onclick, text }/>
-<button onclick=onclick>${text}</button>
+<attrs/{ onClick, text }/>
+<button onClick=onClick>${text}</button>

--- a/packages/translator/src/__tests__/fixtures/basic-component-attrs/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-component-attrs/template.marko
@@ -1,7 +1,7 @@
 <let/clickCount = 0/>
 <my-button 
   text=clickCount
-  onclick() {
+  onClick() {
     clickCount++
   }
 />

--- a/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/components/my-button.js
@@ -1,19 +1,19 @@
 import { on as _on, conditional as _conditional, source as _source, register as _register, queueHydrate as _queueHydrate, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _dynamicTagName = /* @__PURE__ */_conditional(1, 1, (_scope, renderBody = _scope[8]) => renderBody);
 const _renderBody = /* @__PURE__ */_source(8, [_dynamicTagName]);
-const _hydrate_onclick = _register("packages/translator/src/__tests__/fixtures/basic-component-renderBody/components/my-button.marko_0_onclick", _scope => {
-  const onclick = _scope[7];
-  _on(_scope[0], "click", onclick);
+const _hydrate_onClick = _register("packages/translator/src/__tests__/fixtures/basic-component-renderBody/components/my-button.marko_0_onClick", _scope => {
+  const onClick = _scope[7];
+  _on(_scope[0], "click", onClick);
 });
-const _onclick = /* @__PURE__ */_source(7, [], (_scope, onclick) => _queueHydrate(_scope, _hydrate_onclick));
-export const attrs = /* @__PURE__ */_destructureSources([_onclick, _renderBody], (_scope, {
-  onclick,
+const _onClick = /* @__PURE__ */_source(7, [], (_scope, onClick) => _queueHydrate(_scope, _hydrate_onClick));
+export const attrs = /* @__PURE__ */_destructureSources([_onClick, _renderBody], (_scope, {
+  onClick,
   renderBody
 }) => {
-  _setSource(_scope, _onclick, onclick);
+  _setSource(_scope, _onClick, onClick);
   _setSource(_scope, _renderBody, renderBody);
 });
-export { _onclick as _apply_onclick, _renderBody as _apply_renderBody };
+export { _onClick as _apply_onClick, _renderBody as _apply_renderBody };
 export const template = "<button><!></button>";
 export const walks = /* get, next(1), replace, skip(5), out(1) */" D%-l";
 export const setup = function () {};

--- a/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
@@ -2,12 +2,12 @@ import { setSource as _setSource, queueSource as _queueSource, data as _data, bi
 import { setup as _myButton, attrs as _myButton_attrs, template as _myButton_template, walks as _myButton_walks } from "./components/my-button.marko";
 const _clickCount$myButtonBody = _dynamicClosure(1, 0, [], (_scope, clickCount) => _data(_scope[0], clickCount));
 const _myButtonBody = /* @__PURE__ */_createRenderer(" ", /* get */" ", null, [_clickCount$myButtonBody]);
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const clickCount = _scope[0];
   _queueSource(_scope, _clickCount, clickCount + 1);
 };
 const _clickCount = /* @__PURE__ */_source(0, [_myButton_attrs, _dynamicSubscribers(0)], (_scope, clickCount) => _setSource(_scope[1], _myButton_attrs, {
-  onclick: /* @__PURE__ */_bind(_scope, _onclick),
+  onClick: /* @__PURE__ */_bind(_scope, _onClick),
   renderBody: /* @__PURE__ */_bindRenderer(_scope, _myButtonBody)
 }));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/html.expected/components/my-button.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/html.expected/components/my-button.js
@@ -1,15 +1,15 @@
 import { markHydrateNode as _markHydrateNode, write as _write, dynamicTag as _dynamicTag, nextScopeId as _nextScopeId, writeHydrateCall as _writeHydrateCall, writeHydrateScope as _writeHydrateScope, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
 const _renderer = ({
-  onclick,
+  onClick,
   renderBody
 }) => {
   const _scope = _nextScopeId();
   _write(`${_markHydrateNode(_scope, 0)}<button>${_markHydrateNode(_scope, 1)}`);
   _dynamicTag(renderBody, null);
   _write("</button>");
-  _writeHydrateCall(_scope, "packages/translator/src/__tests__/fixtures/basic-component-renderBody/components/my-button.marko_0_onclick");
+  _writeHydrateCall(_scope, "packages/translator/src/__tests__/fixtures/basic-component-renderBody/components/my-button.marko_0_onClick");
   _writeHydrateScope(_scope, {
-    7: onclick
+    7: onClick
   });
 };
 export default _renderer;

--- a/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/html.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/html.expected/template.js
@@ -4,7 +4,7 @@ const _renderer = input => {
   const _scope = _nextScopeId();
   const clickCount = 0;
   _myButton({
-    onclick: function () {
+    onClick: function () {
       clickCount++;
     },
     renderBody() {

--- a/packages/translator/src/__tests__/fixtures/basic-component-renderBody/components/my-button.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-component-renderBody/components/my-button.marko
@@ -1,4 +1,4 @@
-<attrs/{ onclick, renderBody }/>
-<button onclick=onclick>
+<attrs/{ onClick, renderBody }/>
+<button onClick=onClick>
   <${renderBody}/>
 </button>

--- a/packages/translator/src/__tests__/fixtures/basic-component-renderBody/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-component-renderBody/template.marko
@@ -1,6 +1,6 @@
 <let/clickCount = 0/>
 <my-button
-  onclick() {
+  onClick() {
     clickCount++
   }
 >

--- a/packages/translator/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/components/counter.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/components/counter.js
@@ -1,11 +1,11 @@
 import { setSource as _setSource, queueSource as _queueSource, on as _on, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const clickCount = _scope[2];
   _queueSource(_scope, _clickCount, clickCount + 1);
 };
 const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixtures/basic-component/components/counter.marko_0_clickCount", _scope => {
   const clickCount = _scope[2];
-  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _clickCount = /* @__PURE__ */_source(2, [], (_scope, clickCount) => {
   _data(_scope[1], clickCount);

--- a/packages/translator/src/__tests__/fixtures/basic-component/components/counter.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-component/components/counter.marko
@@ -1,4 +1,4 @@
 <let/clickCount = 0/>
-<button onclick() {
+<button onClick() {
   clickCount++
 }>${clickCount}</button>

--- a/packages/translator/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected/template.js
@@ -1,11 +1,11 @@
 import { setSource as _setSource, queueSource as _queueSource, on as _on, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const clickCount = _scope[2];
   _queueSource(_scope, _clickCount, clickCount + 1);
 };
 const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixtures/basic-counter/template.marko_0_clickCount", _scope => {
   const clickCount = _scope[2];
-  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _clickCount = /* @__PURE__ */_source(2, [], (_scope, clickCount) => {
   _data(_scope[1], clickCount);

--- a/packages/translator/src/__tests__/fixtures/basic-counter/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-counter/template.marko
@@ -1,6 +1,6 @@
 <div>
   <let/clickCount = 0/>
-  <button onclick() {
+  <button onClick() {
     clickCount++
   }>${clickCount}</button>
 </div>

--- a/packages/translator/src/__tests__/fixtures/basic-execution-order/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-execution-order/template.marko
@@ -1,7 +1,7 @@
 <let/message = { text:"hi" }/>
 <let/show = true/>
   
-<button onclick() {
+<button onClick() {
   message = null;
   show = false;
 }>hide</button>

--- a/packages/translator/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected/template.js
@@ -1,5 +1,5 @@
 import { setSource as _setSource, queueSource as _queueSource, on as _on, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const count = _scope[2];
   {
     _queueSource(_scope, _count, count + 1);
@@ -7,7 +7,7 @@ const _onclick = function (_scope) {
 };
 const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/basic-fn-with-block/template.marko_0_count", _scope => {
   const count = _scope[2];
-  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _count = /* @__PURE__ */_source(2, [], (_scope, count) => {
   _data(_scope[1], count);

--- a/packages/translator/src/__tests__/fixtures/basic-fn-with-block/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-fn-with-block/template.marko
@@ -1,7 +1,7 @@
 <let/count = 0/>
 
 <button 
-  onclick() {
+  onClick() {
     {
       count++;
     }

--- a/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.js
@@ -1,16 +1,16 @@
 import { setSource as _setSource, queueSource as _queueSource, on as _on, data as _data, subscriber as _subscriber, register as _register, queueHydrate as _queueHydrate, source as _source, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _onclick = (_scope, a) => {
+const _onClick = (_scope, a) => {
   const b = _scope[3];
   return b;
 };
-const _onclick2 = function (_scope) {
+const _onClick2 = function (_scope) {
   const a = _scope[2];
-  _queueSource(_scope, _a, a.map( /* @__PURE__ */_bind(_scope, _onclick)));
+  _queueSource(_scope, _a, a.map( /* @__PURE__ */_bind(_scope, _onClick)));
 };
 const _hydrate_expr_a_b = _register("packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/template.marko_0_a_b", _scope => {
   const a = _scope[2],
     b = _scope[3];
-  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onclick2));
+  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onClick2));
 });
 const _expr_a_b = /* @__PURE__ */_subscriber([], 2, (_scope, a = _scope[2], b = _scope[3]) => _queueHydrate(_scope, _hydrate_expr_a_b));
 const _b = /* @__PURE__ */_source(3, [_expr_a_b]);

--- a/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/template.marko
@@ -1,6 +1,6 @@
 <let/a = [0]/>
 <let/b = 1/>
-<button onclick() {
+<button onClick() {
   a = a.map(a => b);
 }>
   ${a.join("")}

--- a/packages/translator/src/__tests__/fixtures/basic-handler-refless/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-refless/template.marko
@@ -1,5 +1,5 @@
 <let/data = 0/>
 
-<button onclick() { data = 1; }>
+<button onClick() { data = 1; }>
   ${data}
 </button>

--- a/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/components/comments.js
+++ b/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/components/comments.js
@@ -11,13 +11,13 @@ const _setup$ifBody = _scope => {
 };
 const _ifBody = /* @__PURE__ */_createRenderer(`${_comments_template}`, /* beginChild(0), _comments_walks, endChild */`/${_comments_walks}&`, _setup$ifBody, [_comment$ifBody, _id$ifBody]);
 const _if$forBody = /* @__PURE__ */_conditional(4, 1, (_scope, comment = _scope[10]) => comment.comments ? _ifBody : null);
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const open = _scope[13];
   _queueSource(_scope, _open$forBody, !open);
 };
 const _hydrate_open$forBody = _register("packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko_1_open", _scope => {
   const open = _scope[13];
-  _on(_scope[2], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[2], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _open$forBody = /* @__PURE__ */_source(13, [], (_scope, open) => {
   _attr(_scope[0], "hidden", !open);

--- a/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko
@@ -5,7 +5,7 @@
     <let/open=true/>
     <li id=id hidden=!open>
       <span>${comment.text}</span>
-      <button onclick() { open = !open }>
+      <button onClick() { open = !open }>
         ${open ? "[-]" : "[+]"}
       </button>
       <if=comment.comments>

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
@@ -4,13 +4,13 @@ const _expr_selected_num$forBody = /* @__PURE__ */_subscriber([], 2, (_scope, se
   _attr(_scope[0], "data-multiple", num % selected === 0);
 });
 const _selected$forBody = /* @__PURE__ */_closure(1, 7, [_expr_selected_num$forBody]);
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const num = _scope[2];
   _queueSource(_scope._, _selected, num);
 };
 const _hydrate_num$forBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-for/template.marko_1_num", _scope => {
   const num = _scope[2];
-  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _num$forBody = /* @__PURE__ */_source(2, [_expr_selected_num$forBody], (_scope, num) => {
   _data(_scope[1], num);

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/template.marko
@@ -1,7 +1,7 @@
 <let/selected=0/>
 
 <for|num| of=[1,2,3,4,5,6,7,8,9,10,11,12]>
-  <button onclick() { selected = num; } data-selected=(selected === num) data-multiple=(num % selected === 0)>
+  <button onClick() { selected = num; } data-selected=(selected === num) data-multiple=(num % selected === 0)>
     ${num}
   </button>
 </for>

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
@@ -1,13 +1,13 @@
 import { setSource as _setSource, queueSource as _queueSource, on as _on, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, queueHydrate as _queueHydrate, bind as _bind, conditional as _conditional, source as _source, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _clickCount$elseBody = /* @__PURE__ */_closure(1, 6, [], (_scope, clickCount) => _data(_scope[0], clickCount));
 const _elseBody = /* @__PURE__ */_createRenderer("<span>The button was clicked <!> times.</span>", /* next(1), over(1), replace */"Db%", null, [_clickCount$elseBody]);
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const clickCount = _scope._[6];
   _queueSource(_scope._, _clickCount, clickCount + 1);
 };
 const _hydrate_clickCount$ifBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_1_clickCount", _scope => {
   const clickCount = _scope._[6];
-  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _clickCount$ifBody = /* @__PURE__ */_closure(1, 6, [], (_scope, clickCount) => {
   _data(_scope[1], clickCount);

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko
@@ -1,7 +1,7 @@
 <div>
   <let/clickCount = 0/>
   <if=clickCount < 3>
-    <button onclick() {
+    <button onClick() {
       clickCount++
     }>${clickCount}</button>
   </if>

--- a/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
@@ -1,7 +1,7 @@
 import { setSource as _setSource, queueSource as _queueSource, data as _data, on as _on, source as _source, createRenderer as _createRenderer, subscriber as _subscriber, register as _register, queueHydrate as _queueHydrate, loop as _loop, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _item$forBody = /* @__PURE__ */_source(1, [], (_scope, item) => _data(_scope[0], item));
 const _forBody = /* @__PURE__ */_createRenderer(" ", /* get */" ");
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const id = _scope[9],
     items = _scope[10];
   // TODO: nested writes ([...items, id++]) don't work
@@ -12,17 +12,17 @@ const _onclick = function (_scope) {
 const _hydrate_expr_id_items = _register("packages/translator/src/__tests__/fixtures/basic-push-pop-list/template.marko_0_id_items", _scope => {
   const id = _scope[9],
     items = _scope[10];
-  _on(_scope[7], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[7], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _expr_id_items = /* @__PURE__ */_subscriber([], 2, (_scope, id = _scope[9], items = _scope[10]) => _queueHydrate(_scope, _hydrate_expr_id_items));
 const _for = /* @__PURE__ */_loop(0, 1, _forBody, [_item$forBody], (_scope, [item]) => _setSource(_scope, _item$forBody, item), (_scope, items = _scope[10]) => [items, null]);
-const _onclick2 = function (_scope) {
+const _onClick2 = function (_scope) {
   const items = _scope[10];
   _queueSource(_scope, _items, items.slice(0, -1));
 };
 const _hydrate_items = _register("packages/translator/src/__tests__/fixtures/basic-push-pop-list/template.marko_0_items", _scope => {
   const items = _scope[10];
-  _on(_scope[8], "click", /* @__PURE__ */_bind(_scope, _onclick2));
+  _on(_scope[8], "click", /* @__PURE__ */_bind(_scope, _onClick2));
 });
 const _items = /* @__PURE__ */_source(10, [_for, _expr_id_items], (_scope, items) => _queueHydrate(_scope, _hydrate_items));
 const _id = /* @__PURE__ */_source(9, [_expr_id_items]);

--- a/packages/translator/src/__tests__/fixtures/basic-push-pop-list/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-push-pop-list/template.marko
@@ -4,11 +4,11 @@
 
   <for|item| of=items>${item}</for>
 
-  <button id="add" onclick() { 
+  <button id="add" onClick() { 
     // TODO: nested writes ([...items, id++]) don't work
     const nextId = id + 1;
     id = nextId;
     items = [...items, nextId];
   }>Add</button>
-  <button id="remove" onclick() { items = items.slice(0, -1); }>Remove</button>
+  <button id="remove" onClick() { items = items.slice(0, -1); }>Remove</button>
 </div>

--- a/packages/translator/src/__tests__/fixtures/basic-scriptlet/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-scriptlet/__snapshots__/dom.expected/template.js
@@ -1,11 +1,11 @@
 import { setSource as _setSource, queueSource as _queueSource, on as _on, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const clickCount = _scope[2];
   _queueSource(_scope, _clickCount, clickCount + 1);
 };
 const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixtures/basic-scriptlet/template.marko_0_clickCount", _scope => {
   const clickCount = _scope[2];
-  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _clickCount = /* @__PURE__ */_source(2, [], (_scope, clickCount) => {
   const doubleCount = clickCount * 2;

--- a/packages/translator/src/__tests__/fixtures/basic-scriptlet/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-scriptlet/template.marko
@@ -1,7 +1,7 @@
 <div>
   <let/clickCount = 0/>
   $ const doubleCount = clickCount * 2;
-  <button onclick() {
+  <button onClick() {
     clickCount++
   }>${doubleCount}</button>
 </div>

--- a/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
@@ -5,22 +5,22 @@ const _temp3 = function (_scope, x) {
   return x;
 };
 const _ul_for = /* @__PURE__ */_loop(0, 1, _forBody, [_x$forBody], (_scope, [x]) => _setSource(_scope, _x$forBody, x), (_scope, list = _scope[10]) => [list, /* @__PURE__ */_bind(_scope, _temp3)]);
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const list = _scope[10];
   _queueSource(_scope, _list, [].concat(list).reverse());
 };
 const _hydrate_list = _register("packages/translator/src/__tests__/fixtures/basic-shared-node-ref/template.marko_0_list", _scope => {
   const list = _scope[10];
-  _on(_scope[8], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[8], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _list = /* @__PURE__ */_source(10, [_ul_for], (_scope, list) => _queueHydrate(_scope, _hydrate_list));
-const _onclick2 = function (_scope) {
+const _onClick2 = function (_scope) {
   const open = _scope[9];
   _queueSource(_scope, _open, !open);
 };
 const _hydrate_open = _register("packages/translator/src/__tests__/fixtures/basic-shared-node-ref/template.marko_0_open", _scope => {
   const open = _scope[9];
-  _on(_scope[7], "click", /* @__PURE__ */_bind(_scope, _onclick2));
+  _on(_scope[7], "click", /* @__PURE__ */_bind(_scope, _onClick2));
 });
 const _open = /* @__PURE__ */_source(9, [], (_scope, open) => {
   _attr(_scope[0], "hidden", !open);

--- a/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/template.marko
@@ -5,5 +5,5 @@
     <li>${x}</li>
   </for>
 </ul>
-<button#toggle onclick() { open=!open }>Toggle</button>
-<button#reverse onclick() { list = [].concat(list).reverse() }>Reverse</button>
+<button#toggle onClick() { open=!open }>Toggle</button>
+<button#reverse onClick() { list = [].concat(list).reverse() }>Reverse</button>

--- a/packages/translator/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.js
@@ -1,13 +1,13 @@
 import { setSource as _setSource, queueSource as _queueSource, on as _on, createRenderer as _createRenderer, conditional as _conditional, source as _source, register as _register, queueHydrate as _queueHydrate, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _ifBody = /* @__PURE__ */_createRenderer("Hello!", "");
 const _if = /* @__PURE__ */_conditional(0, 1, (_scope, show = _scope[7]) => show ? _ifBody : null);
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const show = _scope[7];
   _queueSource(_scope, _show, !show);
 };
 const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/basic-toggle-show/template.marko_0_show", _scope => {
   const show = _scope[7];
-  _on(_scope[6], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[6], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _show = /* @__PURE__ */_source(7, [_if], (_scope, show) => _queueHydrate(_scope, _hydrate_show));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/basic-toggle-show/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-toggle-show/template.marko
@@ -1,5 +1,5 @@
 <div>
   <let/show=true/>
   <if=show>Hello!</if>
-  <button onclick() { show = !show; }>Toggle</button>
+  <button onClick() { show = !show; }>Toggle</button>
 </div>

--- a/packages/translator/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.js
@@ -1,11 +1,11 @@
 import { setSource as _setSource, queueSource as _queueSource, on as _on, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, derivation as _derivation, notifySignal as _notifySignal, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const clickCount = _scope[4];
   _queueSource(_scope, _clickCount, clickCount + 1);
 };
 const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixtures/basic-unused-ref/template.marko_0_clickCount", _scope => {
   const clickCount = _scope[4];
-  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _clickCount = /* @__PURE__ */_source(4, [], (_scope, clickCount) => {
   _data(_scope[1], clickCount);

--- a/packages/translator/src/__tests__/fixtures/basic-unused-ref/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-unused-ref/template.marko
@@ -2,7 +2,7 @@
   <let/unused_1=123/>
   <const/unused_2=456/>
   <let/clickCount = 0/>
-  <button onclick() {
+  <button onClick() {
     clickCount++
   }>${clickCount}</button>
 </div>

--- a/packages/translator/src/__tests__/fixtures/effect-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/effect-counter/__snapshots__/dom.expected/template.js
@@ -1,12 +1,12 @@
 import { setSource as _setSource, queueSource as _queueSource, on as _on, source as _source, register as _register, queueHydrate as _queueHydrate, bind as _bind, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const clickCount = _scope[1];
   _queueSource(_scope, _clickCount, clickCount + 1);
 };
 const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixtures/effect-counter/template.marko_0_clickCount", _scope => {
   const clickCount = _scope[1];
   document.getElementById("button").textContent = clickCount;
-  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _clickCount = /* @__PURE__ */_source(1, [], (_scope, clickCount) => _queueHydrate(_scope, _hydrate_clickCount));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/effect-counter/template.marko
+++ b/packages/translator/src/__tests__/fixtures/effect-counter/template.marko
@@ -3,7 +3,7 @@
   <effect() {
     document.getElementById("button").textContent = clickCount;
   }/>
-  <button#button onclick() {
+  <button#button onClick() {
     clickCount++
   }>0</button>
 </div>

--- a/packages/translator/src/__tests__/fixtures/event-handlers/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/event-handlers/__snapshots__/dom.expected/template.js
@@ -11,7 +11,7 @@ const _setup = _scope => {
   _child(_scope[1]);
   _setSource(_scope[1], _child_attrs, {
     class: "hi",
-    onclick: /* @__PURE__ */_bind(_scope, _temp3)
+    onClick: /* @__PURE__ */_bind(_scope, _temp3)
   });
   _notifySignal(_scope, _child_attrs);
   _queueHydrate(_scope, _hydrate_setup);

--- a/packages/translator/src/__tests__/fixtures/event-handlers/__snapshots__/html.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/event-handlers/__snapshots__/html.expected/template.js
@@ -4,7 +4,7 @@ const _renderer = input => {
   const _scope = _nextScopeId();
   _child({
     class: "hi",
-    onclick: () => {
+    onClick: () => {
       console.log("hello world");
     },
     renderBody() {

--- a/packages/translator/src/__tests__/fixtures/event-handlers/template.marko
+++ b/packages/translator/src/__tests__/fixtures/event-handlers/template.marko
@@ -1,7 +1,7 @@
-<child class="hi" onclick=(() => {
+<child class="hi" onClick=(() => {
     console.log("hello world")
 })/>
 
-<div class="hi" onclick=(() => {
+<div class="hi" onClick=(() => {
     console.log("hello world")
 })/>

--- a/packages/translator/src/__tests__/fixtures/let-tag/template.marko
+++ b/packages/translator/src/__tests__/fixtures/let-tag/template.marko
@@ -1,7 +1,7 @@
 <let/x=1/>
 <let/y=1/>
 
-<div onclick=(() => x = y = x + y)>
+<div onClick=(() => x = y = x + y)>
   ${x}
 </div>
 

--- a/packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
@@ -21,22 +21,22 @@ const _hydrate_x$ifBody = _register("packages/translator/src/__tests__/fixtures/
 const _x$ifBody = /* @__PURE__ */_closure(1, 8, [], (_scope, x) => _queueHydrate(_scope, _hydrate_x$ifBody));
 const _ifBody = /* @__PURE__ */_createRenderer("", "", null, [_x$ifBody]);
 const _if = /* @__PURE__ */_conditional(0, 1, (_scope, show = _scope[9]) => show ? _ifBody : null);
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const show = _scope[9];
   _queueSource(_scope, _show, !show);
 };
 const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_0_show", _scope => {
   const show = _scope[9];
-  _on(_scope[7], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[7], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _show = /* @__PURE__ */_source(9, [_if], (_scope, show) => _queueHydrate(_scope, _hydrate_show));
-const _onclick2 = function (_scope) {
+const _onClick2 = function (_scope) {
   const x = _scope[8];
   _queueSource(_scope, _x, x + 1);
 };
 const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_0_x", _scope => {
   const x = _scope[8];
-  _on(_scope[6], "click", /* @__PURE__ */_bind(_scope, _onclick2));
+  _on(_scope[6], "click", /* @__PURE__ */_bind(_scope, _onClick2));
 });
 const _x = /* @__PURE__ */_source(8, [/* @__PURE__ */_inConditionalScope(_x$ifBody, 0)], (_scope, x) => _queueHydrate(_scope, _hydrate_x));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko
+++ b/packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko
@@ -8,5 +8,5 @@
 />
 </if>
 <div#ref/>
-<button#increment onclick() { x++ }>Increment</button>
-<button#toggle onclick() { show = !show }>Toggle</button>
+<button#increment on-click() { x++ }>Increment</button>
+<button#toggle on-click() { show = !show }>Toggle</button>

--- a/packages/translator/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.js
@@ -7,7 +7,7 @@ const _onUpdate = function (_scope) {
   const x = _scope[1];
   document.getElementById("ref").textContent = "Update " + x;
 };
-const _onclick = function (_scope) {
+const _onClick = function (_scope) {
   const x = _scope[1];
   _queueSource(_scope, _x, x + 1);
 };
@@ -17,7 +17,7 @@ const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/lifecyc
     onMount: /* @__PURE__ */_bind(_scope, _onMount),
     onUpdate: /* @__PURE__ */_bind(_scope, _onUpdate)
   });
-  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onclick));
+  _on(_scope[0], "click", /* @__PURE__ */_bind(_scope, _onClick));
 });
 const _x = /* @__PURE__ */_source(1, [], (_scope, x) => _queueHydrate(_scope, _hydrate_x));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/lifecycle-tag/template.marko
+++ b/packages/translator/src/__tests__/fixtures/lifecycle-tag/template.marko
@@ -4,4 +4,4 @@
   onUpdate() { document.getElementById("ref").textContent = "Update " + x; }
 />
 <div#ref/>
-<button#increment onclick() { x++ }>Increment</button>
+<button#increment onClick() { x++ }>Increment</button>

--- a/packages/translator/src/visitors/tag/native-tag.ts
+++ b/packages/translator/src/visitors/tag/native-tag.ts
@@ -34,7 +34,7 @@ export default {
           const attrNode = attr.node;
           const { name } = attrNode;
 
-          if (name.startsWith("on")) {
+          if (isEventHandler(name)) {
             sectionId ??= getOrCreateSectionId(tag);
             (currentProgramPath.node.extra ?? {}).isInteractive = true;
           } else if (!evaluate(attr).confident) {
@@ -127,7 +127,7 @@ export default {
               if (confident) {
                 write`${getHTMLRuntime().attr(name, computed)}`;
               } else if (isHTML) {
-                if (name.startsWith("on")) {
+                if (isEventHandler(name)) {
                   addHTMLHydrateCall(sectionId, extra.valueReferences);
                 } else {
                   write`${callRuntime(
@@ -136,7 +136,7 @@ export default {
                     value.node
                   )}`;
                 }
-              } else if (name.startsWith("on")) {
+              } else if (isEventHandler(name)) {
                 addStatement(
                   "hydrate",
                   sectionId,
@@ -145,7 +145,7 @@ export default {
                     callRuntime(
                       "on",
                       t.memberExpression(scopeIdentifier, visitIndex!, true),
-                      t.stringLiteral(name.slice(2)),
+                      t.stringLiteral(getEventHandlerName(name)),
                       value.node
                     )
                   )
@@ -235,4 +235,14 @@ function isSpreadAttr(
   attr: t.NodePath<t.MarkoAttribute | t.MarkoSpreadAttribute>
 ): attr is t.NodePath<t.MarkoAttribute> {
   return attr.type === "MarkoSpreadAttribute";
+}
+
+function isEventHandler(propName: string) {
+  return /^on[A-Z-]/.test(propName);
+}
+
+function getEventHandlerName(propName: string) {
+  return propName.charAt(2) === "-"
+    ? propName.slice(3)
+    : propName.charAt(2).toLowerCase() + propName.slice(3);
 }


### PR DESCRIPTION
## Description

- `onclick` -> not an event handler
- `onClick` -> event "click"
- `on-click` -> event "click"
- `on-Click` -> event "Click"

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
