### PR TITLE
fix: use staticNodeFragment by default, associate non-default fragments with renderers

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -7,45 +7,45 @@
     {
       "name": "*",
       "total": {
-        "min": 12667,
-        "gzip": 5360,
-        "brotli": 4886
+        "min": 12699,
+        "gzip": 5372,
+        "brotli": 4872
       }
     },
     {
       "name": "counter",
       "user": {
-        "min": 348,
-        "gzip": 268,
-        "brotli": 249
+        "min": 343,
+        "gzip": 266,
+        "brotli": 230
       },
       "runtime": {
-        "min": 3163,
-        "gzip": 1492,
-        "brotli": 1336
+        "min": 3176,
+        "gzip": 1501,
+        "brotli": 1346
       },
       "total": {
-        "min": 3511,
-        "gzip": 1760,
-        "brotli": 1585
+        "min": 3519,
+        "gzip": 1767,
+        "brotli": 1576
       }
     },
     {
       "name": "counter 💧",
       "user": {
         "min": 207,
-        "gzip": 182,
-        "brotli": 153
+        "gzip": 181,
+        "brotli": 158
       },
       "runtime": {
-        "min": 2628,
-        "gzip": 1326,
-        "brotli": 1182
+        "min": 2633,
+        "gzip": 1329,
+        "brotli": 1186
       },
       "total": {
-        "min": 2835,
-        "gzip": 1508,
-        "brotli": 1335
+        "min": 2840,
+        "gzip": 1510,
+        "brotli": 1344
       }
     },
     {
@@ -56,14 +56,14 @@
         "brotli": 612
       },
       "runtime": {
-        "min": 7213,
-        "gzip": 3238,
-        "brotli": 2947
+        "min": 7250,
+        "gzip": 3268,
+        "brotli": 2965
       },
       "total": {
-        "min": 8346,
-        "gzip": 3925,
-        "brotli": 3559
+        "min": 8383,
+        "gzip": 3955,
+        "brotli": 3577
       }
     },
     {
@@ -74,14 +74,14 @@
         "brotli": 533
       },
       "runtime": {
-        "min": 8214,
-        "gzip": 3679,
-        "brotli": 3339
+        "min": 8244,
+        "gzip": 3713,
+        "brotli": 3361
       },
       "total": {
-        "min": 9144,
-        "gzip": 4258,
-        "brotli": 3872
+        "min": 9174,
+        "gzip": 4292,
+        "brotli": 3894
       }
     }
   ]

--- a/packages/runtime/src/dom/fragment.ts
+++ b/packages/runtime/src/dom/fragment.ts
@@ -96,3 +96,5 @@ function getFirstNode(
 function getLastNode(currentScope: Scope) {
   return getFirstNode(currentScope, currentScope.___endNode, true);
 }
+
+export const defaultFragment = staticNodesFragment;

--- a/packages/runtime/src/dom/reconcile-domdiff.ts
+++ b/packages/runtime/src/dom/reconcile-domdiff.ts
@@ -1,5 +1,5 @@
 import type { Scope } from "../common/types";
-import type { DOMFragment } from "./fragment";
+import { defaultFragment, DOMFragment } from "./fragment";
 import { destroyScope } from "./scope";
 
 // based off https://github.com/WebReflection/udomdiff/blob/master/esm/index.js
@@ -9,7 +9,7 @@ export function reconcile(
   oldScopes: Scope[],
   newScopes: Scope[],
   afterReference: Node | null,
-  fragment: DOMFragment
+  fragment: DOMFragment = defaultFragment
 ): void {
   const bLength = newScopes.length;
   let aEnd = oldScopes.length;

--- a/packages/runtime/src/dom/reconcile-listdiff.ts
+++ b/packages/runtime/src/dom/reconcile-listdiff.ts
@@ -1,5 +1,5 @@
 import type { Scope } from "../common/types";
-import type { DOMFragment } from "./fragment";
+import { defaultFragment, DOMFragment } from "./fragment";
 import { destroyScope } from "./scope";
 
 // based off https://github.com/luwes/sinuous/blob/master/packages/sinuous/map/src/diff.js
@@ -9,7 +9,7 @@ export function reconcile(
   oldScopes: Scope[],
   newScopes: Scope[],
   afterReference: Node | null,
-  fragment: DOMFragment
+  fragment: DOMFragment = defaultFragment
 ): void {
   let i: number;
   let j: number;

--- a/packages/runtime/src/dom/reconcile-longest-increasing-subsequence.ts
+++ b/packages/runtime/src/dom/reconcile-longest-increasing-subsequence.ts
@@ -1,5 +1,5 @@
 import type { Scope } from "../common/types";
-import type { DOMFragment } from "./fragment";
+import { defaultFragment, DOMFragment } from "./fragment";
 import { destroyScope } from "./scope";
 
 const WRONG_POS = 2147483647;
@@ -9,7 +9,7 @@ export function reconcile(
   oldScopes: Scope[],
   newScopes: Scope[],
   afterReference: Node | null,
-  fragment: DOMFragment
+  fragment: DOMFragment = defaultFragment
 ): void {
   let oldStart = 0;
   let newStart = 0;

--- a/packages/translator/src/__tests__/fixtures/toggle-nested/browser.ts
+++ b/packages/translator/src/__tests__/fixtures/toggle-nested/browser.ts
@@ -117,8 +117,7 @@ const value1$if0 = closure(1, INDEX.value1, [
 const _if0 = conditionalOnlyChild(
   INDEX.conditional,
   1,
-  (scope: ComponentScope) => (scope[INDEX.show] ? ifBody0 : undefined),
-  dynamicFragment
+  (scope: ComponentScope) => (scope[INDEX.show] ? ifBody0 : undefined)
 );
 
 export const value2_subscribers = [
@@ -152,6 +151,7 @@ const ifBody0 = createRenderer(
   undefined,
   [value1$if0, value2$if0],
   0,
+  dynamicFragment,
   INDEX_IF0.conditional0,
   INDEX_IF0.conditional1
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Use a fragment manager from the renderer
- Default to `staticNodesFragment` instead of `singleNodeFragment` until additional optimizations are in place

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
