### PR TITLE
fix: change default to value for let and const tag

### DIFF
--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/csr-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,4 @@
+# Render undefined
+```html
+3 y
+```

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/csr.expected.md
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/csr.expected.md
@@ -1,0 +1,9 @@
+# Render undefined
+```html
+3 y
+```
+
+# Mutations
+```
+inserted #text0, #text1, #text2, #text3
+```

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/components/child.js
@@ -1,0 +1,11 @@
+import { data as _data, derivation as _derivation, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _value = /* @__PURE__ */_derivation("value", 1, [], (_scope, input = _scope["input"]) => input.value, (_scope, value) => _data(_scope["#text/0"], value));
+const _input = /* @__PURE__ */_source("input", [_value]);
+export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
+  _setSource(_scope, _input, input);
+});
+export { _input as _apply_input };
+export const template = "<!> ";
+export const walks = /* replace, over(2) */"%c";
+export const setup = function () {};
+export default /* @__PURE__ */_createRenderFn(template, walks, setup, attrs, null, "packages/translator/src/__tests__/fixtures/custom-tag-default-value/components/child.marko");

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/template.js
@@ -1,0 +1,19 @@
+import { setSource as _setSource, inChild as _inChild, source as _source, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { setup as _child, attrs as _child_attrs, template as _child_template, walks as _child_walks } from "./components/child.marko";
+const _child_attrs_inChild = _inChild(_child_attrs, "#childScope/0");
+const _x = /* @__PURE__ */_source("x", [_inChild(_child_attrs, "#childScope/1")], (_scope, x) => _setSource(_scope["#childScope/1"], _child_attrs, {
+  value: x
+}));
+const _setup = _scope => {
+  _setSource(_scope, _x, "y");
+  _child(_scope["#childScope/0"]);
+  _setSource(_scope["#childScope/0"], _child_attrs, {
+    value: 3
+  });
+  _child(_scope["#childScope/1"]);
+  _notifySignal(_scope, _child_attrs_inChild);
+};
+export const template = `${_child_template}${_child_template}`;
+export const walks = /* beginChild, _child_walks, endChild, beginChild, _child_walks, endChild */`/${_child_walks}&/${_child_walks}&`;
+export const setup = _setup;
+export default /* @__PURE__ */_createRenderFn(template, walks, setup, null, null, "packages/translator/src/__tests__/fixtures/custom-tag-default-value/template.marko");

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/html.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/html.expected/components/child.js
@@ -1,0 +1,8 @@
+import { escapeXML as _escapeXML, markHydrateNode as _markHydrateNode, write as _write, nextScopeId as _nextScopeId, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+const _renderer = _register((input, _tagVar, _scope0_) => {
+  const _scope0_id = _nextScopeId();
+  const value = input.value;
+  _write(`${_escapeXML(value)}${_markHydrateNode(_scope0_id, "#text/0")} `);
+}, "packages/translator/src/__tests__/fixtures/custom-tag-default-value/components/child.marko");
+export default _renderer;
+export const render = /* @__PURE__ */_createRenderer(_renderer);

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/html.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/html.expected/template.js
@@ -1,0 +1,20 @@
+import { nextScopeId as _nextScopeId, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+import _child from "./components/child.marko";
+const _renderer = _register((input, _tagVar, _scope0_) => {
+  const _scope0_id = _nextScopeId();
+  const x = "y";
+  _child({
+    value: 3,
+    renderBody() {
+      const _scope1_id = _nextScopeId();
+    }
+  });
+  _child({
+    value: x,
+    renderBody() {
+      const _scope2_id = _nextScopeId();
+    }
+  });
+}, "packages/translator/src/__tests__/fixtures/custom-tag-default-value/template.marko");
+export default _renderer;
+export const render = /* @__PURE__ */_createRenderer(_renderer);

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/hydrate-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/hydrate-sanitized.expected.md
@@ -1,0 +1,4 @@
+# Render undefined
+```html
+3 y
+```

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/hydrate.expected.md
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/hydrate.expected.md
@@ -1,0 +1,18 @@
+# Render undefined
+```html
+<html>
+  <head />
+  <body>
+    3
+    <!--M#1 #text/0-->
+     y
+    <!--M#2 #text/0-->
+     
+  </body>
+</html>
+```
+
+# Mutations
+```
+
+```

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,4 @@
+# Render "End"
+```html
+3 y
+```

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/ssr.expected.md
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/ssr.expected.md
@@ -1,0 +1,29 @@
+# Write
+  3<!M#1 #text/0> y<!M#2 #text/0> 
+
+
+# Render "End"
+```html
+<html>
+  <head />
+  <body>
+    3
+    <!--M#1 #text/0-->
+     y
+    <!--M#2 #text/0-->
+     
+  </body>
+</html>
+```
+
+# Mutations
+```
+inserted #document/html0
+inserted #document/html0/head0
+inserted #document/html0/body1
+inserted #document/html0/body1/#text0
+inserted #document/html0/body1/#comment1
+inserted #document/html0/body1/#text2
+inserted #document/html0/body1/#comment3
+inserted #document/html0/body1/#text4
+```

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/components/child.marko
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/components/child.marko
@@ -1,0 +1,3 @@
+<const/value value=input.value/>
+
+-- ${value} 

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/template.marko
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/template.marko
@@ -1,0 +1,5 @@
+<let/x value="y"/>
+
+
+<child=3/>
+<child=x/>

--- a/packages/translator/src/core/const.ts
+++ b/packages/translator/src/core/const.ts
@@ -28,7 +28,7 @@ export default {
     if (
       node.attributes.length > 1 ||
       !t.isMarkoAttribute(defaultAttr) ||
-      (!defaultAttr.default && defaultAttr.name !== "default")
+      (!defaultAttr.default && defaultAttr.name !== "value")
     ) {
       throw tag
         .get("name")

--- a/packages/translator/src/core/effect.ts
+++ b/packages/translator/src/core/effect.ts
@@ -39,7 +39,7 @@ export default {
       if (
         node.attributes.length > 1 ||
         !t.isMarkoAttribute(defaultAttr) ||
-        (!defaultAttr.default && defaultAttr.name !== "default")
+        (!defaultAttr.default && defaultAttr.name !== "value")
       ) {
         throw tag
           .get("name")


### PR DESCRIPTION
Updated the `let` and `const` tag so that they accept the `value` parameter instead of `default`, and added a test for default value.