### PR TITLE
fix(native-tag): replace true with empty string

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -7,9 +7,9 @@
     {
       "name": "*",
       "total": {
-        "min": 12741,
-        "gzip": 5401,
-        "brotli": 4909
+        "min": 12746,
+        "gzip": 5410,
+        "brotli": 4926
       }
     },
     {
@@ -51,19 +51,19 @@
     {
       "name": "comments",
       "user": {
-        "min": 1163,
-        "gzip": 710,
-        "brotli": 636
+        "min": 1158,
+        "gzip": 708,
+        "brotli": 639
       },
       "runtime": {
-        "min": 7284,
-        "gzip": 3291,
-        "brotli": 2990
+        "min": 7289,
+        "gzip": 3302,
+        "brotli": 2997
       },
       "total": {
         "min": 8447,
-        "gzip": 4001,
-        "brotli": 3626
+        "gzip": 4010,
+        "brotli": 3636
       }
     },
     {
@@ -71,17 +71,17 @@
       "user": {
         "min": 949,
         "gzip": 592,
-        "brotli": 545
+        "brotli": 538
       },
       "runtime": {
-        "min": 8333,
-        "gzip": 3753,
-        "brotli": 3397
+        "min": 8338,
+        "gzip": 3763,
+        "brotli": 3410
       },
       "total": {
-        "min": 9282,
-        "gzip": 4345,
-        "brotli": 3942
+        "min": 9287,
+        "gzip": 4355,
+        "brotli": 3948
       }
     }
   ]

--- a/packages/runtime/src/dom/dom.ts
+++ b/packages/runtime/src/dom/dom.ts
@@ -115,7 +115,9 @@ export function props(scope: Scope, nodeIndex: number, index: number) {
 }
 
 function normalizeAttrValue(value: unknown) {
-  return value || value === 0 ? value + "" : undefined;
+  if (value || value === 0) {
+    return value === true ? "" : value + "";
+  }
 }
 
 function normalizeString(value: unknown) {

--- a/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/csr-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,44 @@
+# Render {}
+```html
+<input
+  disabled=""
+/>
+<button>
+  enable
+</button>
+```
+
+
+# Render 
+container.querySelector("button").click();
+
+```html
+<input />
+<button>
+  disable
+</button>
+```
+
+
+# Render 
+container.querySelector("button").click();
+
+```html
+<input
+  disabled=""
+/>
+<button>
+  enable
+</button>
+```
+
+
+# Render 
+container.querySelector("button").click();
+
+```html
+<input />
+<button>
+  disable
+</button>
+```

--- a/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/csr.expected.md
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/csr.expected.md
@@ -1,0 +1,67 @@
+# Render {}
+```html
+<input
+  disabled=""
+/>
+<button>
+  enable
+</button>
+```
+
+# Mutations
+```
+inserted input0, button1
+```
+
+
+# Render 
+container.querySelector("button").click();
+
+```html
+<input />
+<button>
+  disable
+</button>
+```
+
+# Mutations
+```
+input0: attr(disabled) "" => null
+button1/#text0: "enable" => "disable"
+```
+
+
+# Render 
+container.querySelector("button").click();
+
+```html
+<input
+  disabled=""
+/>
+<button>
+  enable
+</button>
+```
+
+# Mutations
+```
+input0: attr(disabled) null => ""
+button1/#text0: "disable" => "enable"
+```
+
+
+# Render 
+container.querySelector("button").click();
+
+```html
+<input />
+<button>
+  disable
+</button>
+```
+
+# Mutations
+```
+input0: attr(disabled) "" => null
+button1/#text0: "enable" => "disable"
+```

--- a/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/dom.expected/template.js
@@ -1,0 +1,17 @@
+import { setSource as _setSource, attr as _attr, on as _on, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _hydrate_disabled = _register("packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko_0_disabled", _scope => _on(_scope["#button/1"], "click", function () {
+  const disabled = _scope["disabled"];
+  _queueSource(_scope, _disabled, !disabled);
+}));
+const _disabled = /* @__PURE__ */_source("disabled", [], (_scope, disabled) => {
+  _attr(_scope["#input/0"], "disabled", disabled);
+  _data(_scope["#text/2"], disabled ? "enable" : "disable");
+  _queueHydrate(_scope, _hydrate_disabled);
+});
+const _setup = _scope => {
+  _setSource(_scope, _disabled, true);
+};
+export const template = "<input><button> </button>";
+export const walks = /* get, over(1), get, next(1), get, out(1) */" b D l";
+export const setup = _setup;
+export default /* @__PURE__ */_createRenderFn(template, walks, setup, null, null, "packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko");

--- a/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/html.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/html.expected/template.js
@@ -1,0 +1,12 @@
+import { attr as _attr, markHydrateNode as _markHydrateNode, escapeXML as _escapeXML, write as _write, nextScopeId as _nextScopeId, writeHydrateCall as _writeHydrateCall, writeHydrateScope as _writeHydrateScope, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+const _renderer = _register((input, _tagVar, _scope0_) => {
+  const _scope0_id = _nextScopeId();
+  const disabled = true;
+  _write(`<input${_attr("disabled", disabled)}>${_markHydrateNode(_scope0_id, "#input/0")}<button>${_escapeXML(disabled ? "enable" : "disable")}${_markHydrateNode(_scope0_id, "#text/2")}</button>${_markHydrateNode(_scope0_id, "#button/1")}`);
+  _writeHydrateCall(_scope0_id, "packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko_0_disabled");
+  _writeHydrateScope(_scope0_id, {
+    "disabled": disabled
+  }, _scope0_);
+}, "packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko");
+export default _renderer;
+export const render = /* @__PURE__ */_createRenderer(_renderer);

--- a/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/hydrate-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/hydrate-sanitized.expected.md
@@ -1,0 +1,44 @@
+# Render {}
+```html
+<input
+  disabled=""
+/>
+<button>
+  enable
+</button>
+```
+
+
+# Render 
+container.querySelector("button").click();
+
+```html
+<input />
+<button>
+  disable
+</button>
+```
+
+
+# Render 
+container.querySelector("button").click();
+
+```html
+<input
+  disabled=""
+/>
+<button>
+  enable
+</button>
+```
+
+
+# Render 
+container.querySelector("button").click();
+
+```html
+<input />
+<button>
+  disable
+</button>
+```

--- a/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/hydrate.expected.md
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/hydrate.expected.md
@@ -1,0 +1,111 @@
+# Render {}
+```html
+<html>
+  <head />
+  <body>
+    <input
+      disabled=""
+    />
+    <!--M#0 #input/0-->
+    <button>
+      enable
+      <!--M#0 #text/2-->
+    </button>
+    <!--M#0 #button/1-->
+    <script>
+      (M$h=[]).push((b,s)=&gt;({0:{disabled:!0}}),[0,"packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko_0_disabled",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+
+```
+
+
+# Render 
+container.querySelector("button").click();
+
+```html
+<html>
+  <head />
+  <body>
+    <input />
+    <!--M#0 #input/0-->
+    <button>
+      disable
+      <!--M#0 #text/2-->
+    </button>
+    <!--M#0 #button/1-->
+    <script>
+      (M$h=[]).push((b,s)=&gt;({0:{disabled:!0}}),[0,"packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko_0_disabled",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+#document/html0/body1/input0: attr(disabled) "" => null
+#document/html0/body1/button2/#text0: "enable" => "disable"
+```
+
+
+# Render 
+container.querySelector("button").click();
+
+```html
+<html>
+  <head />
+  <body>
+    <input
+      disabled=""
+    />
+    <!--M#0 #input/0-->
+    <button>
+      enable
+      <!--M#0 #text/2-->
+    </button>
+    <!--M#0 #button/1-->
+    <script>
+      (M$h=[]).push((b,s)=&gt;({0:{disabled:!0}}),[0,"packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko_0_disabled",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+#document/html0/body1/input0: attr(disabled) null => ""
+#document/html0/body1/button2/#text0: "disable" => "enable"
+```
+
+
+# Render 
+container.querySelector("button").click();
+
+```html
+<html>
+  <head />
+  <body>
+    <input />
+    <!--M#0 #input/0-->
+    <button>
+      disable
+      <!--M#0 #text/2-->
+    </button>
+    <!--M#0 #button/1-->
+    <script>
+      (M$h=[]).push((b,s)=&gt;({0:{disabled:!0}}),[0,"packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko_0_disabled",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+#document/html0/body1/input0: attr(disabled) "" => null
+#document/html0/body1/button2/#text0: "enable" => "disable"
+```

--- a/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,9 @@
+# Render "End"
+```html
+<input
+  disabled=""
+/>
+<button>
+  enable
+</button>
+```

--- a/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/ssr.expected.md
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/ssr.expected.md
@@ -1,0 +1,39 @@
+# Write
+  <input disabled><!M#0 #input/0><button>enable<!M#0 #text/2></button><!M#0 #button/1><script>(M$h=[]).push((b,s)=>({0:{disabled:!0}}),[0,"packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko_0_disabled",])</script>
+
+
+# Render "End"
+```html
+<html>
+  <head />
+  <body>
+    <input
+      disabled=""
+    />
+    <!--M#0 #input/0-->
+    <button>
+      enable
+      <!--M#0 #text/2-->
+    </button>
+    <!--M#0 #button/1-->
+    <script>
+      (M$h=[]).push((b,s)=&gt;({0:{disabled:!0}}),[0,"packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko_0_disabled",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+inserted #document/html0
+inserted #document/html0/head0
+inserted #document/html0/body1
+inserted #document/html0/body1/input0
+inserted #document/html0/body1/#comment1
+inserted #document/html0/body1/button2
+inserted #document/html0/body1/button2/#text0
+inserted #document/html0/body1/button2/#comment1
+inserted #document/html0/body1/#comment3
+inserted #document/html0/body1/script4
+inserted #document/html0/body1/script4/#text0
+```

--- a/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko
@@ -1,0 +1,7 @@
+<let/disabled = true/>
+
+<input disabled=disabled/>
+
+<button onClick() { disabled = !disabled }>
+  ${disabled ? "enable" : "disable"}
+</button>

--- a/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/test.ts
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/test.ts
@@ -1,0 +1,5 @@
+export const steps = [{}, click, click, click];
+
+function click(container: Element) {
+  container.querySelector("button")!.click();
+}

--- a/packages/translator/src/__tests__/fixtures/attr-boolean/__snapshots__/csr-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,6 @@
+# Render undefined
+```html
+<input
+  checked=""
+/>
+```

--- a/packages/translator/src/__tests__/fixtures/attr-boolean/__snapshots__/csr.expected.md
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean/__snapshots__/csr.expected.md
@@ -1,0 +1,11 @@
+# Render undefined
+```html
+<input
+  checked=""
+/>
+```
+
+# Mutations
+```
+inserted input0
+```

--- a/packages/translator/src/__tests__/fixtures/attr-boolean/__snapshots__/hydrate-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean/__snapshots__/hydrate-sanitized.expected.md
@@ -1,0 +1,6 @@
+# Render undefined
+```html
+<input
+  checked=""
+/>
+```

--- a/packages/translator/src/__tests__/fixtures/attr-boolean/__snapshots__/hydrate.expected.md
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean/__snapshots__/hydrate.expected.md
@@ -1,0 +1,16 @@
+# Render undefined
+```html
+<html>
+  <head />
+  <body>
+    <input
+      checked=""
+    />
+  </body>
+</html>
+```
+
+# Mutations
+```
+
+```

--- a/packages/translator/src/__tests__/fixtures/attr-boolean/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,6 @@
+# Render "End"
+```html
+<input
+  checked=""
+/>
+```

--- a/packages/translator/src/__tests__/fixtures/attr-boolean/__snapshots__/ssr.expected.md
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean/__snapshots__/ssr.expected.md
@@ -1,0 +1,23 @@
+# Write
+  <input checked>
+
+
+# Render "End"
+```html
+<html>
+  <head />
+  <body>
+    <input
+      checked=""
+    />
+  </body>
+</html>
+```
+
+# Mutations
+```
+inserted #document/html0
+inserted #document/html0/head0
+inserted #document/html0/body1
+inserted #document/html0/body1/input0
+```

--- a/packages/translator/src/__tests__/fixtures/attr-boolean/test.ts
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean/test.ts
@@ -1,2 +1,0 @@
-export const skip_csr = true;
-export const skip_ssr = true;

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/csr-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/csr-sanitized.expected.md
@@ -47,8 +47,8 @@
   1
 </button>
 <button
-  data-multiple="true"
-  data-selected="true"
+  data-multiple=""
+  data-selected=""
 >
   2
 </button>
@@ -56,7 +56,7 @@
   3
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   4
 </button>
@@ -64,7 +64,7 @@
   5
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   6
 </button>
@@ -72,7 +72,7 @@
   7
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   8
 </button>
@@ -80,7 +80,7 @@
   9
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   10
 </button>
@@ -88,7 +88,7 @@
   11
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   12
 </button>
@@ -106,8 +106,8 @@
   2
 </button>
 <button
-  data-multiple="true"
-  data-selected="true"
+  data-multiple=""
+  data-selected=""
 >
   3
 </button>
@@ -118,7 +118,7 @@
   5
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   6
 </button>
@@ -129,7 +129,7 @@
   8
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   9
 </button>
@@ -140,7 +140,7 @@
   11
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   12
 </button>
@@ -164,8 +164,8 @@
   4
 </button>
 <button
-  data-multiple="true"
-  data-selected="true"
+  data-multiple=""
+  data-selected=""
 >
   5
 </button>
@@ -182,7 +182,7 @@
   9
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   10
 </button>

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/csr.expected.md
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/csr.expected.md
@@ -52,8 +52,8 @@ inserted button0, button1, button2, button3, button4, button5, button6, button7,
   1
 </button>
 <button
-  data-multiple="true"
-  data-selected="true"
+  data-multiple=""
+  data-selected=""
 >
   2
 </button>
@@ -61,7 +61,7 @@ inserted button0, button1, button2, button3, button4, button5, button6, button7,
   3
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   4
 </button>
@@ -69,7 +69,7 @@ inserted button0, button1, button2, button3, button4, button5, button6, button7,
   5
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   6
 </button>
@@ -77,7 +77,7 @@ inserted button0, button1, button2, button3, button4, button5, button6, button7,
   7
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   8
 </button>
@@ -85,7 +85,7 @@ inserted button0, button1, button2, button3, button4, button5, button6, button7,
   9
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   10
 </button>
@@ -93,7 +93,7 @@ inserted button0, button1, button2, button3, button4, button5, button6, button7,
   11
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   12
 </button>
@@ -101,13 +101,13 @@ inserted button0, button1, button2, button3, button4, button5, button6, button7,
 
 # Mutations
 ```
-button1: attr(data-selected) null => "true"
-button1: attr(data-multiple) null => "true"
-button3: attr(data-multiple) null => "true"
-button5: attr(data-multiple) null => "true"
-button7: attr(data-multiple) null => "true"
-button9: attr(data-multiple) null => "true"
-button11: attr(data-multiple) null => "true"
+button1: attr(data-selected) null => ""
+button1: attr(data-multiple) null => ""
+button3: attr(data-multiple) null => ""
+button5: attr(data-multiple) null => ""
+button7: attr(data-multiple) null => ""
+button9: attr(data-multiple) null => ""
+button11: attr(data-multiple) null => ""
 ```
 
 
@@ -122,8 +122,8 @@ button11: attr(data-multiple) null => "true"
   2
 </button>
 <button
-  data-multiple="true"
-  data-selected="true"
+  data-multiple=""
+  data-selected=""
 >
   3
 </button>
@@ -134,7 +134,7 @@ button11: attr(data-multiple) null => "true"
   5
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   6
 </button>
@@ -145,7 +145,7 @@ button11: attr(data-multiple) null => "true"
   8
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   9
 </button>
@@ -156,7 +156,7 @@ button11: attr(data-multiple) null => "true"
   11
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   12
 </button>
@@ -164,16 +164,16 @@ button11: attr(data-multiple) null => "true"
 
 # Mutations
 ```
-button1: attr(data-selected) "true" => null
-button1: attr(data-multiple) "true" => null
-button2: attr(data-selected) null => "true"
-button2: attr(data-multiple) null => "true"
-button3: attr(data-multiple) "true" => null
-button5: attr(data-multiple) "true" => "true"
-button7: attr(data-multiple) "true" => null
-button8: attr(data-multiple) null => "true"
-button9: attr(data-multiple) "true" => null
-button11: attr(data-multiple) "true" => "true"
+button1: attr(data-selected) "" => null
+button1: attr(data-multiple) "" => null
+button2: attr(data-selected) null => ""
+button2: attr(data-multiple) null => ""
+button3: attr(data-multiple) "" => null
+button5: attr(data-multiple) "" => ""
+button7: attr(data-multiple) "" => null
+button8: attr(data-multiple) null => ""
+button9: attr(data-multiple) "" => null
+button11: attr(data-multiple) "" => ""
 ```
 
 
@@ -194,8 +194,8 @@ button11: attr(data-multiple) "true" => "true"
   4
 </button>
 <button
-  data-multiple="true"
-  data-selected="true"
+  data-multiple=""
+  data-selected=""
 >
   5
 </button>
@@ -212,7 +212,7 @@ button11: attr(data-multiple) "true" => "true"
   9
 </button>
 <button
-  data-multiple="true"
+  data-multiple=""
 >
   10
 </button>
@@ -226,12 +226,12 @@ button11: attr(data-multiple) "true" => "true"
 
 # Mutations
 ```
-button2: attr(data-selected) "true" => null
-button2: attr(data-multiple) "true" => null
-button4: attr(data-selected) null => "true"
-button4: attr(data-multiple) null => "true"
-button5: attr(data-multiple) "true" => null
-button8: attr(data-multiple) "true" => null
-button9: attr(data-multiple) null => "true"
-button11: attr(data-multiple) "true" => null
+button2: attr(data-selected) "" => null
+button2: attr(data-multiple) "" => null
+button4: attr(data-selected) null => ""
+button4: attr(data-multiple) null => ""
+button5: attr(data-multiple) "" => null
+button8: attr(data-multiple) "" => null
+button9: attr(data-multiple) null => ""
+button11: attr(data-multiple) "" => null
 ```

--- a/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/csr-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/csr-sanitized.expected.md
@@ -29,7 +29,7 @@ container.querySelector("#toggle").click();
 
 ```html
 <ul
-  hidden="true"
+  hidden=""
 >
   <li>
     1

--- a/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/csr.expected.md
+++ b/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/csr.expected.md
@@ -34,7 +34,7 @@ container.querySelector("#toggle").click();
 
 ```html
 <ul
-  hidden="true"
+  hidden=""
 >
   <li>
     1
@@ -60,7 +60,7 @@ container.querySelector("#toggle").click();
 
 # Mutations
 ```
-ul0: attr(hidden) null => "true"
+ul0: attr(hidden) null => ""
 ```
 
 
@@ -93,7 +93,7 @@ container.querySelector("#toggle").click();
 
 # Mutations
 ```
-ul0: attr(hidden) "true" => null
+ul0: attr(hidden) "" => null
 ```
 
 


### PR DESCRIPTION
- resolves #145 

Required for parity between server and client, and consistent with previous versions of Marko (I think).