### PR TITLE
refactor: switch to new signal implementation

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -1,87 +1,50 @@
 {
   "examples": {
-    "counter": "./packages/translator/src/__tests__/fixtures/basic-counter/template.marko",
-    "comments": "./packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/template.marko"
+    "counter": "./packages/translator/src/__tests__/fixtures/basic-counter/template.marko"
   },
   "results": [
     {
       "name": "*",
       "total": {
-        "min": 12778,
-        "gzip": 5430,
-        "brotli": 4947
+        "min": 12114,
+        "gzip": 5244,
+        "brotli": 4742
       }
     },
     {
       "name": "counter",
       "user": {
-        "min": 369,
-        "gzip": 285,
-        "brotli": 272
+        "min": 357,
+        "gzip": 277,
+        "brotli": 260
       },
       "runtime": {
-        "min": 3214,
-        "gzip": 1528,
-        "brotli": 1372
+        "min": 2997,
+        "gzip": 1449,
+        "brotli": 1296
       },
       "total": {
-        "min": 3583,
-        "gzip": 1813,
-        "brotli": 1644
+        "min": 3354,
+        "gzip": 1726,
+        "brotli": 1556
       }
     },
     {
       "name": "counter 💧",
       "user": {
-        "min": 207,
-        "gzip": 181,
-        "brotli": 153
+        "min": 204,
+        "gzip": 180,
+        "brotli": 150
       },
       "runtime": {
-        "min": 2722,
-        "gzip": 1382,
-        "brotli": 1229
+        "min": 2451,
+        "gzip": 1276,
+        "brotli": 1137
       },
       "total": {
-        "min": 2929,
-        "gzip": 1563,
-        "brotli": 1382
-      }
-    },
-    {
-      "name": "comments",
-      "user": {
-        "min": 1158,
-        "gzip": 708,
-        "brotli": 639
-      },
-      "runtime": {
-        "min": 7289,
-        "gzip": 3302,
-        "brotli": 2997
-      },
-      "total": {
-        "min": 8447,
-        "gzip": 4010,
-        "brotli": 3636
-      }
-    },
-    {
-      "name": "comments 💧",
-      "user": {
-        "min": 949,
-        "gzip": 592,
-        "brotli": 538
-      },
-      "runtime": {
-        "min": 8338,
-        "gzip": 3763,
-        "brotli": 3410
-      },
-      "total": {
-        "min": 9287,
-        "gzip": 4355,
-        "brotli": 3948
+        "min": 2655,
+        "gzip": 1456,
+        "brotli": 1287
       }
     }
   ]

--- a/.sizes.json
+++ b/.sizes.json
@@ -1,6 +1,7 @@
 {
   "examples": {
-    "counter": "./packages/translator/src/__tests__/fixtures/basic-counter/template.marko"
+    "counter": "./packages/translator/src/__tests__/fixtures/basic-counter/template.marko",
+    "comments": "./packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/template.marko"
   },
   "results": [
     {
@@ -45,6 +46,42 @@
         "min": 2655,
         "gzip": 1456,
         "brotli": 1287
+      }
+    },
+    {
+      "name": "comments",
+      "user": {
+        "min": 1280,
+        "gzip": 704,
+        "brotli": 642
+      },
+      "runtime": {
+        "min": 6791,
+        "gzip": 3127,
+        "brotli": 2831
+      },
+      "total": {
+        "min": 8071,
+        "gzip": 3831,
+        "brotli": 3473
+      }
+    },
+    {
+      "name": "comments 💧",
+      "user": {
+        "min": 1079,
+        "gzip": 598,
+        "brotli": 563
+      },
+      "runtime": {
+        "min": 7778,
+        "gzip": 3566,
+        "brotli": 3226
+      },
+      "total": {
+        "min": 8857,
+        "gzip": 4164,
+        "brotli": 3789
       }
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "lerna": "^6.0.3",
         "lint-staged": "^12.1.7",
         "magic-string": "^0.25.7",
-        "mocha": "^9.2.2",
+        "mocha": "^10.2.0",
         "mocha-snap": "^4.2.4",
         "prettier": "^2.5.1",
         "pretty-format": "^27.4.6",
@@ -3646,12 +3646,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
-    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -5110,9 +5104,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -7046,15 +7040,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
       "dev": true
-    },
-    "node_modules/growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.x"
-      }
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
@@ -9319,42 +9304,39 @@
       }
     },
     "node_modules/mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
-        "debug": "4.3.3",
+        "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.2.0",
-        "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.1",
+        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
+        "workerpool": "6.2.1",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
+        "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9370,6 +9352,15 @@
         "fast-glob": "^3.2.7"
       }
     },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/mocha/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -9380,12 +9371,12 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
@@ -9479,9 +9470,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -12826,9 +12817,9 @@
       "dev": true
     },
     "node_modules/workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -16068,12 +16059,6 @@
         "eslint-visitor-keys": "^3.0.0"
       }
     },
-    "@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
-    },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -17199,9 +17184,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -18571,12 +18556,6 @@
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-      "dev": true
-    },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "handlebars": {
@@ -20290,37 +20269,43 @@
       }
     },
     "mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
-        "debug": "4.3.3",
+        "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.2.0",
-        "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.1",
+        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
+        "workerpool": "6.2.1",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -20328,12 +20313,12 @@
           "dev": true
         },
         "minimatch": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-          "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "^2.0.1"
           }
         },
         "ms": {
@@ -20416,9 +20401,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
     },
     "natural-compare": {
@@ -22948,9 +22933,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lerna": "^6.0.3",
     "lint-staged": "^12.1.7",
     "magic-string": "^0.25.7",
-    "mocha": "^9.2.2",
+    "mocha": "^10.2.0",
     "mocha-snap": "^4.2.4",
     "prettier": "^2.5.1",
     "pretty-format": "^27.4.6",

--- a/packages/runtime/src/dom/index.ts
+++ b/packages/runtime/src/dom/index.ts
@@ -30,7 +30,7 @@ export { pushContext, popContext, getInContext } from "../common/context";
 
 export { queueSource, queueHydrate, run } from "./queue";
 
-export { write, bind, bindRenderer } from "./scope";
+export { write, bindFunction, bindRenderer } from "./scope";
 
 export type { Scope } from "../common/types";
 
@@ -42,20 +42,14 @@ export {
 } from "./renderer";
 
 export {
-  setSource,
-  notifySignal,
-  source,
-  destructureSources,
-  derivation,
-  nextTagId,
-  subscriber,
+  value,
+  intersection,
   closure,
   dynamicClosure,
+  contextClosure,
   dynamicSubscribers,
+  childClosures,
   setTagVar,
   tagVarSignal,
-  contextClosure,
-  inChildMany,
-  inChild,
-  dynamicAttrsProxy,
+  nextTagId,
 } from "./signals";

--- a/packages/runtime/src/dom/queue.ts
+++ b/packages/runtime/src/dom/queue.ts
@@ -1,5 +1,5 @@
 import type { Scope } from "../common/types";
-import type { Signal } from "./signals";
+import type { ValueSignal } from "./signals";
 import { schedule } from "./schedule";
 
 const enum BatchOffsets {
@@ -20,9 +20,9 @@ type ExecFn<S extends Scope = Scope> = (scope: S, arg?: any) => void;
 let currentBatch: unknown[] = [];
 let currentHydrate: unknown[] = [];
 
-export function queueSource<T>(scope: Scope, signal: Signal, value: T) {
+export function queueSource<T>(scope: Scope, signal: ValueSignal, value: T) {
   schedule();
-  signal.___mark(scope);
+  signal(scope, null, null);
   currentBatch.push(scope, signal, value);
   return value;
 }
@@ -38,9 +38,9 @@ export function run() {
   try {
     for (let i = 0; i < currentBatch.length; i += BatchOffsets.TOTAL) {
       const scope = currentBatch[i + BatchOffsets.SCOPE] as Scope;
-      const signal = currentBatch[i + BatchOffsets.SIGNAL] as Signal;
+      const signal = currentBatch[i + BatchOffsets.SIGNAL] as ValueSignal;
       const value = currentBatch[i + BatchOffsets.VALUE] as unknown;
-      signal.___apply(scope, value);
+      signal(scope, value, true);
     }
   } finally {
     currentBatch = [];

--- a/packages/runtime/src/dom/signals.ts
+++ b/packages/runtime/src/dom/signals.ts
@@ -203,26 +203,6 @@ export function childClosures(
   });
 }
 
-// TODO: remove this
-export function destructureValue<T>(fn: ValueSignal<T>): ValueSignal<T> {
-  return fn;
-}
-
-export function destructureValue2<T>(
-  fn: (input: T) => unknown[],
-  subscribers: ValueSignal[]
-): ValueSignal<T> {
-  return (scope: Scope, input: T, dirty = true) => {
-    let values;
-    if (dirty) {
-      values = fn(input);
-    }
-    for (let i = 0; i < subscribers.length; i++) {
-      subscribers[i](scope, values?.[i], dirty);
-    }
-  };
-}
-
 export function dynamicSubscribers(
   subscribers: BoundIntersectionSignal[],
   dirty = true

--- a/packages/runtime/src/dom/signals.ts
+++ b/packages/runtime/src/dom/signals.ts
@@ -223,50 +223,6 @@ export function destructureValue2<T>(
   };
 }
 
-/*
-<const/{ a, b: { c } } = input/>
-
-<const/a = input.a/>
-<const/c = input.b.c/>
-
-
-const destructureAttrs = (scope, { a, b: { c } } = EmptyProxy, dirty) => {
-  _a(scope, a, dirty);
-  _c(scope, c, dirty);
-}
-
-const destructureAttrs = (scope, value, dirty) => {
-  _a(scope, dirty && value.a, dirty);
-  _c(scope, dirty && value.b.c, dirty);
-}
-
-const destructureAttrs = (scope, value, dirty) => {
-  let a, c;
-  if (dirty) {
-    ({ a, b: { c } } = value);
-  }
-  _a(scope, a, dirty);
-  _c(scope, c, dirty);
-}
-
-
-const destructureAttrs = destructureValue2(({ a, b: { c } }) => [a,c], [_a, _c]);
-
-// const destructureAttrs = (scope, { a, b: { c } }) => {
-//   _a(scope, a);
-//   _c(scope, c);
-// }
-
-*/
-
-// TODO:
-// export function derivedSource?() {
-// }
-
-// TODO:
-// export function controllableSource() {
-// }
-
 export function dynamicSubscribers(
   subscribers: BoundIntersectionSignal[],
   dirty = true

--- a/packages/runtime/src/dom/signals.ts
+++ b/packages/runtime/src/dom/signals.ts
@@ -1,559 +1,321 @@
 import { Scope, AccessorChars, Accessor } from "../common/types";
-import { bindSignal, getOwnerScope, write } from "./scope";
-import type { Renderer } from "./renderer";
+import { bindFunction } from "./scope";
+import type { RendererOrElementName } from "./renderer";
 
-export type Signal = {
-  ___mark(scope: Scope): void;
-  ___notify(scope: Scope, stale: boolean): void;
-  ___apply(scope: Scope, data?: unknown): void;
+export type Signal = ValueSignal | IntersectionSignal;
+
+export type ValueSignal<T = unknown> = (
+  scope: Scope,
+  value: T,
+  dirty?: null | boolean
+) => void;
+
+export type BoundValueSignal<T = unknown> = (
+  value: T,
+  dirty?: null | boolean
+) => void;
+
+export type IntersectionSignal = ((
+  scope: Scope,
+  dirty?: null | boolean
+) => void) & {
   ___subscribe?(scope: Scope): void;
   ___unsubscribe?(scope: Scope): void;
 };
 
+export type BoundIntersectionSignal = ((dirty?: null | boolean) => void) & {
+  ___subscribe?(scope: Scope): void;
+  ___unsubscribe?(scope: Scope): void;
+};
+
+export function value<T>(
+  valueAccessor: Accessor,
+  fn: ValueSignal<T>
+): ValueSignal<T> {
+  const markAccessor = valueAccessor + AccessorChars.MARK;
+  const alwaysCall = fn.length === 3;
+  return (scope, nextValue, dirty = true) => {
+    let creation, currentMark;
+    if (dirty === null) {
+      currentMark = scope[markAccessor] = (scope[markAccessor] ?? 0) + 1;
+    } else {
+      creation = scope[markAccessor] === undefined;
+      currentMark = scope[markAccessor] ||= 1;
+    }
+    if (currentMark === 1) {
+      if (
+        creation ||
+        alwaysCall ||
+        (dirty &&= scope[valueAccessor] !== nextValue)
+      ) {
+        scope[valueAccessor] = nextValue;
+        fn(scope, nextValue, dirty);
+      }
+    }
+    if (dirty !== null) {
+      // closure needs this to be called after the fn
+      // so it is marked until all downstream have been called
+      scope[markAccessor]--;
+    }
+  };
+}
+
 let accessorId = 0;
 
-function markSubscribers(scope: Scope, subscribers: Signal[]) {
-  for (const subscriber of subscribers) {
-    subscriber.___mark(scope);
-  }
-}
-function notifySubscribers(
-  scope: Scope,
-  stale: boolean,
-  subscribers: Signal[]
-) {
-  for (const subscriber of subscribers) {
-    subscriber.___notify(scope, stale);
-  }
-}
-
-function applyValue<S extends Scope, V>(
-  scope: S,
-  value: V,
-  valueAccessor: Accessor,
-  subscribers: Signal[],
-  isCreate: boolean,
-  action?: (scope: S, value: V) => void
-) {
-  const stale = write(scope, valueAccessor as number, value);
-  if (stale || isCreate) {
-    action?.(scope, value);
-  }
-  notifySubscribers(scope, stale as any as boolean, subscribers);
-}
-
-export function setSource(scope: Scope, signal: Signal, value: unknown) {
-  signal.___apply(scope, value);
-}
-
-export function notifySignal(scope: Scope, signal: Signal) {
-  signal.___notify(scope, true);
-}
-
-export function source<S extends Scope, V>(
-  valueAccessor: Accessor,
-  subscribers: Signal[],
-  action?: (scope: S, value: V) => void
-): Signal {
-  const markAccessor = valueAccessor + AccessorChars.MARK;
-  const signal: Signal = {
-    ___mark(scope) {
-      scope[markAccessor] = 1;
-      markSubscribers(scope, subscribers);
-    },
-    ___notify(scope, stale) {
-      if (!stale) {
-        notifySubscribers(scope, stale, subscribers);
+export function intersection(
+  count: number,
+  fn: IntersectionSignal
+): IntersectionSignal {
+  const dirtyAccessor = AccessorChars.DYNAMIC + accessorId++;
+  const markAccessor = dirtyAccessor + AccessorChars.MARK;
+  const alwaysCall = fn.length === 2;
+  return (scope, dirty = true) => {
+    let currentMark;
+    if (dirty === null) {
+      currentMark = scope[markAccessor] = (scope[markAccessor] ?? 0) + 1;
+    } else {
+      if (scope[markAccessor] === undefined) {
+        scope[markAccessor] = count - 1;
+        scope[dirtyAccessor] = true;
+      } else {
+        currentMark = scope[markAccessor]--;
+        dirty = scope[dirtyAccessor] ||= dirty;
       }
-    },
-    ___apply(scope, data) {
-      const isCreate = scope[markAccessor] === undefined;
-      scope[markAccessor] = 1;
-      applyValue(
-        scope as S,
-        data as V,
-        valueAccessor,
-        subscribers,
-        isCreate,
-        action
+    }
+    if (currentMark === 1) {
+      if (dirty || alwaysCall) {
+        scope[dirtyAccessor] = false;
+        fn(scope, dirty);
+      }
+    }
+  };
+}
+
+export function closure<T>(
+  ownerValueAccessor: Accessor | ((scope: Scope) => Accessor),
+  fn: ValueSignal<T>,
+  getOwnerScope = (scope: Scope) => scope._!
+): IntersectionSignal {
+  const dirtyAccessor = AccessorChars.DYNAMIC + accessorId++;
+  const markAccessor = dirtyAccessor + 1;
+  const alwaysCall = fn.length === 3;
+  const getOwnerValueAccessor =
+    typeof ownerValueAccessor === "function"
+      ? ownerValueAccessor
+      : () => ownerValueAccessor as Accessor;
+  return (scope, dirty = true) => {
+    let ownerScope, ownerValueAccessor, currentMark;
+    if (dirty === null) {
+      currentMark = scope[markAccessor] = (scope[markAccessor] ?? 0) + 1;
+    } else {
+      if (scope[markAccessor] === undefined) {
+        ownerScope = getOwnerScope(scope);
+        ownerValueAccessor = getOwnerValueAccessor(scope);
+        const ownerMark = ownerScope[ownerValueAccessor + AccessorChars.MARK];
+        const ownerHasRun =
+          ownerMark === undefined ? !ownerScope.___client : ownerMark === 0;
+        scope[markAccessor] = (currentMark = ownerHasRun ? 1 : 2) - 1;
+        scope[dirtyAccessor] = true;
+      } else {
+        currentMark = scope[markAccessor]--;
+        dirty = scope[dirtyAccessor] ||= dirty;
+      }
+    }
+    if (currentMark === 1) {
+      if (dirty || alwaysCall) {
+        scope[dirtyAccessor] = false;
+        ownerScope ??= getOwnerScope(scope);
+        ownerValueAccessor ??= getOwnerValueAccessor(scope);
+        fn(scope, dirty && ownerScope[ownerValueAccessor], dirty);
+      }
+    }
+  };
+}
+
+export function dynamicClosure<T>(
+  ownerValueAccessor: Accessor | ((scope: Scope) => Accessor),
+  fn: ValueSignal<T>,
+  getOwnerScope = (scope: Scope) => scope._!
+): IntersectionSignal {
+  const getOwnerValueAccessor =
+    typeof ownerValueAccessor === "function"
+      ? ownerValueAccessor
+      : () => ownerValueAccessor as string;
+  const signalFn = closure(getOwnerValueAccessor, fn, getOwnerScope);
+  return Object.assign(signalFn, {
+    ___subscribe(scope: Scope) {
+      const ownerScope = getOwnerScope(scope);
+      const providerSubscriptionsAccessor =
+        getOwnerValueAccessor(scope) + AccessorChars.SUBSCRIBERS;
+      ownerScope[providerSubscriptionsAccessor] ??= new Set();
+      ownerScope[providerSubscriptionsAccessor].add(
+        bindFunction(scope, signalFn as any)
       );
-      scope[markAccessor] = 0;
     },
-  };
-
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "source", {
-      valueAccessor,
-      markAccessor,
-      subscribers,
-      action,
-    });
-  }
-
-  return signal;
+    ___unsubscribe(scope: Scope) {
+      const ownerScope = getOwnerScope(scope);
+      const providerSubscriptionsAccessor =
+        getOwnerValueAccessor(scope) + AccessorChars.SUBSCRIBERS;
+      ownerScope[providerSubscriptionsAccessor]?.delete(
+        bindFunction(scope, signalFn as any)
+      );
+    },
+  });
 }
 
-export function destructureSources<S extends Scope, V>(
-  subscribers: Signal[],
-  action?: (scope: S, value: V) => void
-): Signal {
-  const signal: Signal = {
-    ___mark(scope) {
-      markSubscribers(scope, subscribers);
-    },
-    ___notify(scope, stale) {
-      if (!stale) {
-        notifySubscribers(scope, stale, subscribers);
+export function contextClosure<T>(
+  valueAccessor: Accessor,
+  contextKey: string,
+  fn: ValueSignal<T>
+) {
+  // TODO: might be viable as a reliable way to get a unique id
+  // const dirtyAccessor = valueAccessor - 2;
+  return dynamicClosure(
+    (scope) => scope.___context![contextKey][1],
+    value(valueAccessor, fn),
+    (scope) => scope.___context![contextKey][0]
+  );
+}
+
+export function childClosures(
+  closureSignals: IntersectionSignal[],
+  childAccessor: Accessor
+) {
+  const signal = (scope: Scope, dirty = true) => {
+    const childScope = scope[childAccessor] as Scope;
+    for (const closureSignal of closureSignals) {
+      closureSignal(childScope, dirty);
+    }
+  };
+  return Object.assign(signal, {
+    ___subscribe(scope: Scope) {
+      const childScope = scope[childAccessor] as Scope;
+      for (const closureSignal of closureSignals) {
+        closureSignal.___subscribe?.(childScope);
       }
     },
-    ___apply: action as (scope: Scope, data: unknown) => void,
-  };
-
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "destructureSources", { subscribers, action });
-  }
-
-  return signal;
+    ___unsubscribe(scope: Scope) {
+      const childScope = scope[childAccessor] as Scope;
+      for (const closureSignal of closureSignals) {
+        closureSignal.___unsubscribe?.(childScope);
+      }
+    },
+  });
 }
 
+// TODO: remove this
+export function destructureValue<T>(fn: ValueSignal<T>): ValueSignal<T> {
+  return fn;
+}
+
+export function destructureValue2<T>(
+  fn: (input: T) => unknown[],
+  subscribers: ValueSignal[]
+): ValueSignal<T> {
+  return (scope: Scope, input: T, dirty = true) => {
+    let values;
+    if (dirty) {
+      values = fn(input);
+    }
+    for (let i = 0; i < subscribers.length; i++) {
+      subscribers[i](scope, values?.[i], dirty);
+    }
+  };
+}
+
+/*
+<const/{ a, b: { c } } = input/>
+
+<const/a = input.a/>
+<const/c = input.b.c/>
+
+
+const destructureAttrs = (scope, { a, b: { c } } = EmptyProxy, dirty) => {
+  _a(scope, a, dirty);
+  _c(scope, c, dirty);
+}
+
+const destructureAttrs = (scope, value, dirty) => {
+  _a(scope, dirty && value.a, dirty);
+  _c(scope, dirty && value.b.c, dirty);
+}
+
+const destructureAttrs = (scope, value, dirty) => {
+  let a, c;
+  if (dirty) {
+    ({ a, b: { c } } = value);
+  }
+  _a(scope, a, dirty);
+  _c(scope, c, dirty);
+}
+
+
+const destructureAttrs = destructureValue2(({ a, b: { c } }) => [a,c], [_a, _c]);
+
+// const destructureAttrs = (scope, { a, b: { c } }) => {
+//   _a(scope, a);
+//   _c(scope, c);
+// }
+
+*/
+
+// TODO:
 // export function derivedSource?() {
 // }
 
+// TODO:
 // export function controllableSource() {
 // }
 
-function baseSubscriber<S extends Scope>(
-  accessorId: Accessor,
-  subscribers: Signal[],
-  defaultMark: number | ((scope: S) => number),
-  apply: (scope: S) => void
-): Signal {
-  const markAccessor: Accessor = accessorId + AccessorChars.MARK;
-  const staleAccessor: Accessor = accessorId + AccessorChars.STALE;
-  const signal: Signal = {
-    ___mark(scope) {
-      const mark = (scope[markAccessor] = (scope[markAccessor] || 0) + 1);
-      if (mark === 1) {
-        markSubscribers(scope, subscribers);
-      }
-    },
-    ___notify(scope, stale) {
-      if (stale) {
-        scope[staleAccessor] = true;
-      }
-      if (scope[markAccessor] === undefined) {
-        scope[markAccessor] =
-          typeof defaultMark === "number"
-            ? defaultMark
-            : defaultMark(scope as S);
-        scope[staleAccessor] = true; // TODO: figure out if this helps for closures
-      }
-      if (scope[markAccessor] === 1) {
-        if (scope[staleAccessor]) {
-          scope[staleAccessor] = false;
-          apply(scope as S);
-        } else {
-          notifySubscribers(scope, false, subscribers);
-        }
-      }
-      scope[markAccessor]--;
-    },
-    ___apply() {
-      if (MARKO_DEBUG) {
-        throw new Error("Derivations should not be directly applied");
-      }
-    },
-  };
-
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "baseSubscriber", {
-      accessorId,
-      markAccessor,
-      staleAccessor,
-      subscribers,
-      defaultMark,
-      apply,
-    });
-  }
-
-  return signal;
-}
-
-export function subscriber<S extends Scope>(
-  subscribers: Signal[],
-  defaultMark: number,
-  apply: (scope: S) => void
-): Signal {
-  const signal: Signal = baseSubscriber(
-    AccessorChars.DYNAMIC + accessorId++,
-    subscribers,
-    defaultMark,
-    apply
-  );
-
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "subscriber", { subscribers, defaultMark, apply });
-  }
-
-  return signal;
-}
-
-export function derivation<S extends Scope, V>(
-  valueAccessor: Accessor,
-  defaultMark: number,
-  subscribers: Signal[],
-  compute: (scope: S) => V,
-  action?: (scope: S, value: V) => void
-): Signal {
-  const signal = baseSubscriber(
-    valueAccessor,
-    subscribers,
-    defaultMark,
-    (scope: S) => {
-      applyValue(
-        scope,
-        compute(scope),
-        valueAccessor,
-        subscribers,
-        false, // TODO: This should be true on creation
-        action
-      );
-    }
-  );
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "derivation", {
-      valueAccessor,
-      defaultMark,
-      subscribers,
-      compute,
-      action,
-    });
-  }
-  return signal;
-}
-
-export function child<S extends Scope, V>(
-  childAccessor: Accessor,
-  valueAccessor: Accessor,
-  defaultMark: number,
-  subscribers: Signal[],
-  compute: (scope: S) => V,
-  action?: (scope: S, value: V) => void
-): Signal {
-  const childDerivation = derivation(
-    valueAccessor,
-    defaultMark,
-    subscribers,
-    compute,
-    action
-  );
-  const signal: Signal = inChild(childDerivation, childAccessor);
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "child", {
-      childAccessor,
-      valueAccessor,
-      defaultMark,
-      subscribers,
-      compute,
-      action,
-    });
-  }
-  return signal;
-}
-
-export function closure<S extends Scope, V>(
-  ownerLevel: number | ((scope: Scope) => Scope),
-  providerAccessor: Accessor | ((scope: Scope) => Accessor),
-  subscribers: Signal[],
-  action?: (scope: S, value: V) => void
-): Signal {
-  const getOwner =
-    typeof ownerLevel === "function"
-      ? ownerLevel
-      : (scope: Scope) => getOwnerScope(scope, ownerLevel);
-  const getProviderAccessor =
-    typeof providerAccessor === "function"
-      ? providerAccessor
-      : () => providerAccessor;
-
-  const getDefaultMark = (scope: Scope) => {
-    const ownerScope = getOwner(scope);
-    const providerMarkAccessor =
-      getProviderAccessor(scope) + AccessorChars.MARK;
-    const providerMark = ownerScope[providerMarkAccessor];
-    const providerHasRun =
-      (providerMark === undefined && !ownerScope.___client) ||
-      providerMark === 0;
-    // we hit this branch when we're creating a new scope that closes over a value that has already run.
-    // (it could have run on the server, earlier in setup, in the current batch, or in a previous batch)
-    // the defaultMark includes this value, so we decrement our mark since the value could not.
-    // (this scope did not exist at the time the value ran)
-    return providerHasRun ? 1 : 2;
-  };
-  const apply = (scope: Scope) => {
-    const ownerScope = getOwner(scope);
-    const providerValueAccessor = getProviderAccessor(scope);
-    action?.(scope as S, ownerScope[providerValueAccessor]);
-    notifySubscribers(scope, true, subscribers);
-  };
-  const signal: Signal = baseSubscriber(
-    AccessorChars.DYNAMIC + accessorId++,
-    subscribers,
-    getDefaultMark,
-    apply
-  );
-
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "closure", {
-      ownerLevel,
-      providerAccessor,
-      subscribers,
-      action,
-    });
-  }
-  return signal;
-}
-
-export function dynamicClosure<S extends Scope, V>(
-  ownerLevel: number | ((scope: Scope) => Scope),
-  providerAccessor: Accessor | ((scope: Scope) => Accessor),
-  subscribers: Signal[],
-  action?: (scope: S, value: V) => void
-): Signal {
-  const getOwner =
-    typeof ownerLevel === "function"
-      ? ownerLevel
-      : (scope: Scope) => getOwnerScope(scope, ownerLevel);
-  const getProviderAccessor =
-    typeof providerAccessor === "function"
-      ? providerAccessor
-      : () => providerAccessor;
-
-  const signal = {
-    ...closure(ownerLevel, providerAccessor, subscribers, action),
-    ___subscribe(scope: Scope) {
-      const ownerScope = getOwner(scope);
-      const providerSubscriptionsAccessor =
-        getProviderAccessor(scope) + AccessorChars.SUBSCRIBERS;
-      ownerScope[providerSubscriptionsAccessor] ??= new Set();
-      ownerScope[providerSubscriptionsAccessor].add(bindSignal(scope, signal));
-    },
-    ___unsubscribe(scope: Scope) {
-      const ownerScope = getOwner(scope);
-      const providerSubscriptionsAccessor =
-        getProviderAccessor(scope) + AccessorChars.SUBSCRIBERS;
-      (ownerScope[providerSubscriptionsAccessor] as Set<Signal>)?.delete(
-        bindSignal(scope, signal)
-      );
-    },
-  };
-
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "derivation", {
-      ownerLevel,
-      providerAccessor,
-      subscribers,
-      action,
-    });
-  }
-
-  return signal;
-}
-
-export function dynamicSubscribers(valueAccessor: Accessor) {
-  const subscriptionsAccessor = valueAccessor + AccessorChars.SUBSCRIBERS;
-  const signal: Signal = wrapSignal((methodName) => (scope, extraArg) => {
-    const subscribers = scope[subscriptionsAccessor];
-    if (subscribers) {
-      for (const subscriber of subscribers) {
-        subscriber[methodName](scope, extraArg);
-      }
-    }
-  });
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "dynamicSubscribers", {
-      valueAccessor,
-      subscriptionsAccessor,
-    });
-  }
-  return signal;
-}
-
-export function contextClosure<S extends Scope, V>(
-  valueAccessor: Accessor,
-  contextKey: string,
-  subscribers: Signal[],
-  action?: (scope: S, value: V) => void
-): Signal {
-  const signal: Signal = dynamicClosure(
-    (scope) => scope.___context![contextKey][0],
-    (scope) => scope.___context![contextKey][1],
-    subscribers,
-    (scope: Scope, value: V) => {
-      scope[valueAccessor] = value;
-      action?.(scope as S, value);
-    }
-  );
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "contextClosure", {
-      valueAccessor,
-      contextKey,
-      subscribers,
-      action,
-    });
-  }
-  return signal;
-}
-
-// function getOwnerScope(scope: Scope, level: number) {
-//   for(; level--;) scope = scope._!;
-//   return scope;
-// }
-
-export function wrapSignal(
-  wrapper: (
-    methodName: "___mark" | "___notify" | "___apply"
-  ) => (scope: Scope, arg?: any) => void
+export function dynamicSubscribers(
+  subscribers: BoundIntersectionSignal[],
+  dirty = true
 ) {
-  const signal: Signal = {
-    ___mark: wrapper("___mark"),
-    ___notify: wrapper("___notify"),
-    ___apply: wrapper("___apply"),
-  };
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "wrapSignal", { wrapper });
+  if (subscribers) {
+    for (const subscriber of subscribers) {
+      subscriber(dirty);
+    }
   }
-  return signal;
 }
 
 export function setTagVar(
   scope: Scope,
   childAccessor: Accessor,
-  tagVarSignal: Signal
+  tagVarSignal: ValueSignal
 ) {
-  scope[childAccessor][AccessorChars.TAG_VARIABLE] = bindSignal(
+  scope[childAccessor][AccessorChars.TAG_VARIABLE] = bindFunction(
     scope,
-    tagVarSignal
-  );
+    tagVarSignal as any
+  ) as BoundValueSignal;
 }
 
-export const tagVarSignal = wrapSignal(
-  (methodName) => (scope, extraArg) =>
-    scope[AccessorChars.TAG_VARIABLE]?.[methodName](null, extraArg)
-);
+export const tagVarSignal = (scope: Scope, value: unknown, dirty = true) =>
+  scope[AccessorChars.TAG_VARIABLE]?.(value, dirty);
 
-if (MARKO_DEBUG) {
-  setDebugInfo(tagVarSignal, "tagVar", {});
-}
-
-export function wrapSignalWithSubscription(
-  wrapper: (
-    methodName:
-      | "___mark"
-      | "___notify"
-      | "___apply"
-      | "___subscribe"
-      | "___unsubscribe"
-  ) => (scope: Scope, arg?: any) => void
-) {
-  const signal: Signal = {
-    ...wrapSignal(wrapper),
-    ___subscribe: wrapper("___subscribe"),
-    ___unsubscribe: wrapper("___unsubscribe"),
-  };
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "wrapSignalWithSubscription", { wrapper });
-  }
-  return signal;
-}
-
-export function inChild(
-  subscriber: Signal,
-  childScopeAccessor: Accessor
-): Signal {
-  const signal: Signal = wrapSignal(
-    (methodName) => (scope, extraArg) =>
-      subscriber[methodName](scope[childScopeAccessor], extraArg)
-  );
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "inChild", { subscriber, childScopeAccessor });
-  }
-  return signal;
-}
-
-export function inChildMany(
-  subscribers: Signal[],
-  childScopeAccessor: Accessor
-): Signal {
-  const signal: Signal = wrapSignalWithSubscription(
-    (methodName) => (scope, extraArg) => {
-      const childScope = scope[childScopeAccessor] as Scope;
-      for (const signal of subscribers) {
-        signal[methodName]?.(childScope, extraArg);
-      }
-    }
-  );
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "inChildMany", { subscribers, childScopeAccessor });
-  }
-  return signal;
-}
-
-export function inRenderBody(
-  renderBodyIndex: Accessor,
-  childScopeAccessor: Accessor
-): Signal {
-  const signal: Signal = wrapSignal((methodName) => (scope, extraArg) => {
-    const childScope = scope[childScopeAccessor] as Scope;
-    const signals =
-      (scope[renderBodyIndex] as Renderer)?.___closureSignals ?? [];
+export const renderBodyClosures = (
+  renderBody: RendererOrElementName | undefined,
+  childScope: Scope,
+  dirty: null | boolean = true
+) => {
+  const signals = renderBody?.___closureSignals;
+  if (signals) {
     for (const signal of signals) {
-      signal[methodName](childScope, extraArg);
+      signal(childScope, dirty);
     }
-  });
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "inRenderBody", {
-      renderBodyIndex,
-      childScopeAccessor,
-    });
   }
-  return signal;
-}
+};
 
-export function dynamicAttrsProxy(nodeAccessor: Accessor): Signal {
-  const signal: Signal = wrapSignal((methodName) => (scope, extraArg) => {
-    const renderer = scope[nodeAccessor + AccessorChars.COND_RENDERER] as
-      | Renderer
-      | undefined;
-    const childScope = scope[nodeAccessor + AccessorChars.COND_SCOPE] as Scope;
-
-    renderer?.___attrs?.[methodName](childScope, extraArg);
-  });
-  if (MARKO_DEBUG) {
-    setDebugInfo(signal, "dynamicAttrsProxy", {
-      nodeAccessor,
-    });
+export const inMany = (
+  scopes: Scope[],
+  dirty: null | boolean,
+  signal: IntersectionSignal
+) => {
+  for (const scope of scopes) {
+    signal(scope, dirty);
   }
-  return signal;
-}
+};
 
 let tagId = 0;
 export function nextTagId() {
   return "c" + tagId++;
-}
-
-function setDebugInfo(
-  signal: Signal,
-  type: string,
-  data: Record<string, unknown>
-) {
-  const signalCopy = { ...signal };
-  for (const key in signal) {
-    delete (signal as any)[key];
-  }
-  Object.setPrototypeOf(
-    signal,
-    new Function(`return new (class ${type} {})()`)()
-  );
-  Object.assign(signal, data, signalCopy, data);
 }

--- a/packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/dom.expected/template.js
@@ -3,11 +3,7 @@ import { write as _write, bindRenderer as _bindRenderer, createRenderer as _crea
 import { setup as _customTag, template as _customTag_template, walks as _customTag_walks } from "./components/custom-tag/index.marko";
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/template.marko_2_renderer", /* @__PURE__ */_createRenderer("", ""));
 const _if$customTagBody = /* @__PURE__ */_conditional("#text/0");
-const _x$customTagBody = /* @__PURE__ */_dynamicClosure("x", (_scope, x, _dirty) => {
-  if (_dirty) {
-    _if$customTagBody(_scope, x ? _ifBody : null);
-  }
-});
+const _x$customTagBody = /* @__PURE__ */_dynamicClosure("x", (_scope, x) => _if$customTagBody(_scope, x ? _ifBody : null));
 const _customTagBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_x$customTagBody]);
 const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => _dynamicSubscribers(_scope["x*"], _dirty));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/dom.expected/template.js
@@ -1,9 +1,13 @@
 let _thing;
-import { write as _write, bindRenderer as _bindRenderer, createRenderer as _createRenderer, register as _register, conditional as _conditional, dynamicSubscribers as _dynamicSubscribers, dynamicClosure as _dynamicClosure, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { write as _write, bindRenderer as _bindRenderer, createRenderer as _createRenderer, register as _register, conditional as _conditional, dynamicClosure as _dynamicClosure, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _customTag, template as _customTag_template, walks as _customTag_walks } from "./components/custom-tag/index.marko";
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/template.marko_2_renderer", /* @__PURE__ */_createRenderer("", ""));
 const _if$customTagBody = /* @__PURE__ */_conditional("#text/0");
-const _x$customTagBody = /* @__PURE__ */_dynamicClosure("x", (_scope, x) => _if$customTagBody(_scope, x ? _ifBody : null));
+const _x$customTagBody = /* @__PURE__ */_dynamicClosure("x", (_scope, x, _dirty) => {
+  if (_dirty) {
+    _if$customTagBody(_scope, x ? _ifBody : null);
+  }
+});
 const _customTagBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_x$customTagBody]);
 const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => _dynamicSubscribers(_scope["x*"], _dirty));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/dom.expected/template.js
@@ -1,19 +1,21 @@
 let _thing;
-import { write as _write, bindRenderer as _bindRenderer, createRenderer as _createRenderer, register as _register, conditional as _conditional, dynamicSubscribers as _dynamicSubscribers, dynamicClosure as _dynamicClosure, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { write as _write, bindRenderer as _bindRenderer, createRenderer as _createRenderer, register as _register, conditional as _conditional, dynamicSubscribers as _dynamicSubscribers, dynamicClosure as _dynamicClosure, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _customTag, template as _customTag_template, walks as _customTag_walks } from "./components/custom-tag/index.marko";
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/template.marko_2_renderer", /* @__PURE__ */_createRenderer("", ""));
-const _if$customTagBody = /* @__PURE__ */_conditional("#text/0", 1, (_scope, x = _scope._["x"]) => x ? _ifBody : null);
-const _x$customTagBody = _dynamicClosure(1, "x", [_if$customTagBody]);
+const _if$customTagBody = /* @__PURE__ */_conditional("#text/0");
+const _x$customTagBody = /* @__PURE__ */_dynamicClosure("x", (_scope, x) => _if$customTagBody(_scope, x ? _ifBody : null));
 const _customTagBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_x$customTagBody]);
-const _x = /* @__PURE__ */_source("x", [_dynamicSubscribers("x")]);
+const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => _dynamicSubscribers(_scope["x*"], _dirty));
 const _setup = _scope => {
   _customTag(_scope["#childScope/0"]);
 };
-export const attrs = /* @__PURE__ */_destructureSources([_x], (_scope, {
-  x
-}) => {
-  _setSource(_scope, _x, x);
-});
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let x;
+  if (_dirty) ({
+    x
+  } = _destructure);
+  _x(_scope, x, _dirty);
+};
 export { _x as _apply_x };
 export const template = `${_customTag_template}`;
 export const walks = /* beginChild, _customTag_walks, endChild */`/${_customTag_walks}&`;

--- a/packages/translator/src/__tests__/fixtures/at-tags-dynamic-tag-parent/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags-dynamic-tag-parent/__snapshots__/dom.expected/template.js
@@ -1,6 +1,7 @@
 import { write as _write, dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _xBody = /* @__PURE__ */_createRenderer("Body content", "");
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => {
+  let _dynamicBody_attrs;
   if (_dirty) {
     _dynamicBody_attrs = () => ({
       header: {
@@ -17,14 +18,13 @@ const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) 
       }
     });
   }
-  var _dynamicBody_attrs;
   _dynamicTagAttrs(_scope, "#text/0", _dynamicBody_attrs, _xBody, _dirty);
 });
 const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  let _dynamicTagName_value;
   if (_dirty) {
     _dynamicTagName_value = x || _xBody;
   }
-  var _dynamicTagName_value;
   _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
 });
 export const attrs = (_scope, _destructure, _dirty = true) => {

--- a/packages/translator/src/__tests__/fixtures/at-tags-dynamic-tag-parent/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags-dynamic-tag-parent/__snapshots__/dom.expected/template.js
@@ -1,25 +1,39 @@
-import { write as _write, dynamicAttrsProxy as _dynamicAttrsProxy, dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, conditional as _conditional, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { write as _write, dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _xBody = /* @__PURE__ */_createRenderer("Body content", "");
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", 1, (_scope, x = _scope["x"]) => x || _xBody, _dynamicAttrsProxy("#text/0"), _scope => _dynamicTagAttrs(_scope, "#text/0", () => ({
-  header: {
-    class: "my-header",
-    renderBody() {
-      _write("Header content");
-    }
-  },
-  footer: {
-    class: "my-footer",
-    renderBody() {
-      _write("Footer content");
-    }
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => {
+  if (_dirty) {
+    _dynamicBody_attrs = () => ({
+      header: {
+        class: "my-header",
+        renderBody() {
+          _write("Header content");
+        }
+      },
+      footer: {
+        class: "my-footer",
+        renderBody() {
+          _write("Footer content");
+        }
+      }
+    });
   }
-}), _xBody));
-const _x = /* @__PURE__ */_source("x", [_dynamicTagName]);
-export const attrs = /* @__PURE__ */_destructureSources([_x], (_scope, {
-  x
-}) => {
-  _setSource(_scope, _x, x);
+  var _dynamicBody_attrs;
+  _dynamicTagAttrs(_scope, "#text/0", _dynamicBody_attrs, _xBody, _dirty);
 });
+const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  if (_dirty) {
+    _dynamicTagName_value = x || _xBody;
+  }
+  var _dynamicTagName_value;
+  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
+});
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let x;
+  if (_dirty) ({
+    x
+  } = _destructure);
+  _x(_scope, x, _dirty);
+};
 export { _x as _apply_x };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected/template.js
@@ -1,5 +1,5 @@
 let _item;
-import { data as _data, write as _write, bindRenderer as _bindRenderer, createRenderer as _createRenderer, register as _register, conditional as _conditional, dynamicSubscribers as _dynamicSubscribers, dynamicClosure as _dynamicClosure, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { data as _data, write as _write, bindRenderer as _bindRenderer, createRenderer as _createRenderer, register as _register, conditional as _conditional, dynamicClosure as _dynamicClosure, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _hello, template as _hello_template, walks as _hello_walks } from "./components/hello/index.marko";
 const _setup$itemBody = _scope => {
   _data(_scope["#text/0"], y);
@@ -7,7 +7,11 @@ const _setup$itemBody = _scope => {
 const _itemBody = /* @__PURE__ */_createRenderer("", /* get */" ", _setup$itemBody);
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/template.marko_2_renderer", /* @__PURE__ */_createRenderer("", ""));
 const _if$helloBody = /* @__PURE__ */_conditional("#text/0");
-const _x$helloBody = /* @__PURE__ */_dynamicClosure("x", (_scope, x) => _if$helloBody(_scope, x ? _ifBody : null));
+const _x$helloBody = /* @__PURE__ */_dynamicClosure("x", (_scope, x, _dirty) => {
+  if (_dirty) {
+    _if$helloBody(_scope, x ? _ifBody : null);
+  }
+});
 const _helloBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_x$helloBody]);
 const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => _dynamicSubscribers(_scope["x*"], _dirty));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected/template.js
@@ -1,23 +1,25 @@
 let _item;
-import { data as _data, write as _write, bindRenderer as _bindRenderer, createRenderer as _createRenderer, register as _register, conditional as _conditional, dynamicSubscribers as _dynamicSubscribers, dynamicClosure as _dynamicClosure, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { data as _data, write as _write, bindRenderer as _bindRenderer, createRenderer as _createRenderer, register as _register, conditional as _conditional, dynamicSubscribers as _dynamicSubscribers, dynamicClosure as _dynamicClosure, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _hello, template as _hello_template, walks as _hello_walks } from "./components/hello/index.marko";
 const _setup$itemBody = _scope => {
   _data(_scope["#text/0"], y);
 };
 const _itemBody = /* @__PURE__ */_createRenderer("", /* get */" ", _setup$itemBody);
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/template.marko_2_renderer", /* @__PURE__ */_createRenderer("", ""));
-const _if$helloBody = /* @__PURE__ */_conditional("#text/0", 1, (_scope, x = _scope._["x"]) => x ? _ifBody : null);
-const _x$helloBody = _dynamicClosure(1, "x", [_if$helloBody]);
+const _if$helloBody = /* @__PURE__ */_conditional("#text/0");
+const _x$helloBody = /* @__PURE__ */_dynamicClosure("x", (_scope, x) => _if$helloBody(_scope, x ? _ifBody : null));
 const _helloBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_x$helloBody]);
-const _x = /* @__PURE__ */_source("x", [_dynamicSubscribers("x")]);
+const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => _dynamicSubscribers(_scope["x*"], _dirty));
 const _setup = _scope => {
   _hello(_scope["#childScope/0"]);
 };
-export const attrs = /* @__PURE__ */_destructureSources([_x], (_scope, {
-  x
-}) => {
-  _setSource(_scope, _x, x);
-});
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let x;
+  if (_dirty) ({
+    x
+  } = _destructure);
+  _x(_scope, x, _dirty);
+};
 export { _x as _apply_x };
 export const template = `${_hello_template}`;
 export const walks = /* beginChild, _hello_walks, endChild */`/${_hello_walks}&`;

--- a/packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected/template.js
@@ -7,11 +7,7 @@ const _setup$itemBody = _scope => {
 const _itemBody = /* @__PURE__ */_createRenderer("", /* get */" ", _setup$itemBody);
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/template.marko_2_renderer", /* @__PURE__ */_createRenderer("", ""));
 const _if$helloBody = /* @__PURE__ */_conditional("#text/0");
-const _x$helloBody = /* @__PURE__ */_dynamicClosure("x", (_scope, x, _dirty) => {
-  if (_dirty) {
-    _if$helloBody(_scope, x ? _ifBody : null);
-  }
-});
+const _x$helloBody = /* @__PURE__ */_dynamicClosure("x", (_scope, x) => _if$helloBody(_scope, x ? _ifBody : null));
 const _helloBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_x$helloBody]);
 const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => _dynamicSubscribers(_scope["x*"], _dirty));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/dom.expected/template.js
@@ -1,15 +1,15 @@
-import { setSource as _setSource, attr as _attr, on as _on, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { attr as _attr, on as _on, queueSource as _queueSource, data as _data, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_disabled = _register("packages/translator/src/__tests__/fixtures/attr-boolean-dynamic/template.marko_0_disabled", _scope => _on(_scope["#button/1"], "click", function () {
   const disabled = _scope["disabled"];
   _queueSource(_scope, _disabled, !disabled);
 }));
-const _disabled = /* @__PURE__ */_source("disabled", [], (_scope, disabled) => {
+const _disabled = /* @__PURE__ */_value("disabled", (_scope, disabled) => {
   _attr(_scope["#input/0"], "disabled", disabled);
   _data(_scope["#text/2"], disabled ? "enable" : "disable");
   _queueHydrate(_scope, _hydrate_disabled);
 });
 const _setup = _scope => {
-  _setSource(_scope, _disabled, true);
+  _disabled(_scope, true);
 };
 export const template = "<input><button> </button>";
 export const walks = /* get, over(1), get, next(1), get, out(1) */" b D l";

--- a/packages/translator/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/template.js
@@ -1,36 +1,53 @@
-import { classAttr as _classAttr, write as _write, dynamicAttrsProxy as _dynamicAttrsProxy, dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, subscriber as _subscriber, conditional as _conditional, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { classAttr as _classAttr, write as _write, dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, intersection as _intersection, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _customTag, template as _customTag_template, walks as _customTag_walks } from "./components/custom-tag.marko";
 const _dynamicBody2 = /* @__PURE__ */_createRenderer("", "");
-const _expr_dynamicTagName_c_d = /* @__PURE__ */_subscriber([_dynamicAttrsProxy("#text/3")], 3, (_scope, dynamicTagName = _scope["#text/3"], c = _scope["c"], d = _scope["d"]) => _dynamicTagAttrs(_scope, "#text/3", () => ({
-  class: ["a", {
+const _expr_dynamicTagName_c_d = /* @__PURE__ */_intersection(3, (_scope, _dirty) => {
+  if (_dirty) {
+    const dynamicTagName = _scope["#text/3"],
+      c = _scope["c"],
+      d = _scope["d"];
+    _dynamicBody_attrs = () => ({
+      class: ["a", {
+        b: c,
+        d
+      }],
+      test: {
+        class: ["a", {
+          b: c,
+          d
+        }],
+        renderBody() {
+          _write("Hello");
+        }
+      }
+    });
+  }
+  var _dynamicBody_attrs;
+  _dynamicTagAttrs(_scope, "#text/3", _dynamicBody_attrs, _dynamicBody2, _dirty);
+});
+const _expr_c_d = /* @__PURE__ */_intersection(2, _scope => {
+  const c = _scope["c"],
+    d = _scope["d"];
+  _classAttr(_scope["#div/0"], ["a", {
     b: c,
     d
-  }],
-  test: {
-    class: ["a", {
-      b: c,
-      d
-    }],
-    renderBody() {
-      _write("Hello");
-    }
-  }
-}), _dynamicBody2));
-const _expr_c_d = /* @__PURE__ */_subscriber([], 2, (_scope, c = _scope["c"], d = _scope["d"]) => _classAttr(_scope["#div/0"], ["a", {
-  b: c,
-  d
-}]));
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/3", 1, (_scope, input = _scope["input"]) => input.test || _dynamicBody2, _expr_dynamicTagName_c_d);
+  }]);
+});
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/3", (_scope, _dirty) => _expr_dynamicTagName_c_d(_scope, _dirty));
 const _d = "SIGNAL NOT INITIALIZED";
 const _c = "SIGNAL NOT INITIALIZED";
-const _input = /* @__PURE__ */_source("input", [_dynamicTagName]);
+const _input = /* @__PURE__ */_value("input", (_scope, input, _dirty) => {
+  if (_dirty) {
+    _dynamicTagName_value = input.test || _dynamicBody2;
+  }
+  var _dynamicTagName_value;
+  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
+});
 const _setup = _scope => {
   _customTag(_scope["#childScope/1"]);
   _customTag(_scope["#childScope/2"]);
 };
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = `<div></div><div class="a b"></div><div class="a b c"></div>${_customTag_template}${_customTag_template}<!>`;
 export const walks = /* get, over(3), beginChild, _customTag_walks, endChild, beginChild, _customTag_walks, endChild, replace, over(1) */` d/${_customTag_walks}&/${_customTag_walks}&%b`;

--- a/packages/translator/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/template.js
@@ -2,6 +2,7 @@ import { classAttr as _classAttr, write as _write, dynamicTagAttrs as _dynamicTa
 import { setup as _customTag, template as _customTag_template, walks as _customTag_walks } from "./components/custom-tag.marko";
 const _dynamicBody2 = /* @__PURE__ */_createRenderer("", "");
 const _expr_dynamicTagName_c_d = /* @__PURE__ */_intersection(3, (_scope, _dirty) => {
+  let _dynamicBody_attrs;
   if (_dirty) {
     const dynamicTagName = _scope["#text/3"],
       c = _scope["c"],
@@ -22,7 +23,6 @@ const _expr_dynamicTagName_c_d = /* @__PURE__ */_intersection(3, (_scope, _dirty
       }
     });
   }
-  var _dynamicBody_attrs;
   _dynamicTagAttrs(_scope, "#text/3", _dynamicBody_attrs, _dynamicBody2, _dirty);
 });
 const _expr_c_d = /* @__PURE__ */_intersection(2, _scope => {
@@ -37,10 +37,10 @@ const _dynamicTagName = /* @__PURE__ */_conditional("#text/3", (_scope, _dirty) 
 const _d = "SIGNAL NOT INITIALIZED";
 const _c = "SIGNAL NOT INITIALIZED";
 const _input = /* @__PURE__ */_value("input", (_scope, input, _dirty) => {
+  let _dynamicTagName_value;
   if (_dirty) {
     _dynamicTagName_value = input.test || _dynamicBody2;
   }
-  var _dynamicTagName_value;
   _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/attr-escape/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/attr-escape/__snapshots__/dom.expected/template.js
@@ -1,13 +1,11 @@
-import { classAttr as _classAttr, attr as _attr, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _input = /* @__PURE__ */_source("input", [], (_scope, input) => {
+import { classAttr as _classAttr, attr as _attr, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _input = /* @__PURE__ */_value("input", (_scope, input) => {
   _classAttr(_scope["#div/0"], input.foo);
   _attr(_scope["#div/0"], "foo", 'a' + input.foo + 'b');
   _attr(_scope["#div/0"], "bar", `a ${input.bar} b`);
   _attr(_scope["#div/0"], "nested", `a ${input.foo + ` nested ${input.bar}`} b`);
 });
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<div></div>";
 export const walks = /* get, over(1) */" b";

--- a/packages/translator/src/__tests__/fixtures/attr-style/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/attr-style/__snapshots__/dom.expected/template.js
@@ -2,6 +2,7 @@ import { styleAttr as _styleAttr, write as _write, dynamicTagAttrs as _dynamicTa
 import { setup as _customTag, template as _customTag_template, walks as _customTag_walks } from "./components/custom-tag.marko";
 const _testBody = /* @__PURE__ */_createRenderer("", "");
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/4", (_scope, _dirty) => {
+  let _dynamicBody_attrs;
   if (_dirty) {
     _dynamicBody_attrs = () => ({
       style: {
@@ -17,14 +18,13 @@ const _dynamicTagName = /* @__PURE__ */_conditional("#text/4", (_scope, _dirty) 
       }
     });
   }
-  var _dynamicBody_attrs;
   _dynamicTagAttrs(_scope, "#text/4", _dynamicBody_attrs, _testBody, _dirty);
 });
 const _test = /* @__PURE__ */_value("test", (_scope, test, _dirty) => {
+  let _dynamicTagName_value;
   if (_dirty) {
     _dynamicTagName_value = test || _testBody;
   }
-  var _dynamicTagName_value;
   _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
 });
 const _color = /* @__PURE__ */_value("color", (_scope, color) => _styleAttr(_scope["#div/0"], {

--- a/packages/translator/src/__tests__/fixtures/attr-style/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/attr-style/__snapshots__/dom.expected/template.js
@@ -1,21 +1,33 @@
-import { styleAttr as _styleAttr, write as _write, dynamicAttrsProxy as _dynamicAttrsProxy, dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, conditional as _conditional, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { styleAttr as _styleAttr, write as _write, dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _customTag, template as _customTag_template, walks as _customTag_walks } from "./components/custom-tag.marko";
 const _testBody = /* @__PURE__ */_createRenderer("", "");
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/4", 1, (_scope, test = _scope["test"]) => test || _testBody, _dynamicAttrsProxy("#text/4"), _scope => _dynamicTagAttrs(_scope, "#text/4", () => ({
-  style: {
-    color: "green"
-  },
-  test: {
-    style: {
-      color: "green"
-    },
-    renderBody() {
-      _write("Hello");
-    }
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/4", (_scope, _dirty) => {
+  if (_dirty) {
+    _dynamicBody_attrs = () => ({
+      style: {
+        color: "green"
+      },
+      test: {
+        style: {
+          color: "green"
+        },
+        renderBody() {
+          _write("Hello");
+        }
+      }
+    });
   }
-}), _testBody));
-const _test = /* @__PURE__ */_source("test", [_dynamicTagName]);
-const _color = /* @__PURE__ */_source("color", [], (_scope, color) => _styleAttr(_scope["#div/0"], {
+  var _dynamicBody_attrs;
+  _dynamicTagAttrs(_scope, "#text/4", _dynamicBody_attrs, _testBody, _dirty);
+});
+const _test = /* @__PURE__ */_value("test", (_scope, test, _dirty) => {
+  if (_dirty) {
+    _dynamicTagName_value = test || _testBody;
+  }
+  var _dynamicTagName_value;
+  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
+});
+const _color = /* @__PURE__ */_value("color", (_scope, color) => _styleAttr(_scope["#div/0"], {
   color: color
 }));
 const _setup = _scope => {
@@ -23,13 +35,15 @@ const _setup = _scope => {
   _customTag(_scope["#childScope/2"]);
   _customTag(_scope["#childScope/3"]);
 };
-export const attrs = /* @__PURE__ */_destructureSources([_color, _test], (_scope, {
-  color,
-  test
-}) => {
-  _setSource(_scope, _color, color);
-  _setSource(_scope, _test, test);
-});
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let color, test;
+  if (_dirty) ({
+    color,
+    test
+  } = _destructure);
+  _color(_scope, color, _dirty);
+  _test(_scope, test, _dirty);
+};
 export { _color as _apply_color, _test as _apply_test };
 export const template = `<div></div><div style=width:100px></div><div style="color: green"></div>${_customTag_template}${_customTag_template}${_customTag_template}<!>`;
 export const walks = /* get, over(3), beginChild, _customTag_walks, endChild, beginChild, _customTag_walks, endChild, beginChild, _customTag_walks, endChild, replace, over(1) */` d/${_customTag_walks}&/${_customTag_walks}&/${_customTag_walks}&%b`;

--- a/packages/translator/src/__tests__/fixtures/attr-template-literal-escape/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/attr-template-literal-escape/__snapshots__/dom.expected/template.js
@@ -1,8 +1,6 @@
-import { attr as _attr, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _input = /* @__PURE__ */_source("input", [], (_scope, input) => _attr(_scope["#div/0"], "foo", `Hello ${input.name}`));
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+import { attr as _attr, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _attr(_scope["#div/0"], "foo", `Hello ${input.name}`));
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<div></div>";
 export const walks = /* get, over(1) */" b";

--- a/packages/translator/src/__tests__/fixtures/basic-chain/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-chain/__snapshots__/dom.expected/template.js
@@ -1,9 +1,9 @@
-import { setSource as _setSource, data as _data, derivation as _derivation, source as _source, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _z = /* @__PURE__ */_derivation("z", 1, [], (_scope, y = _scope["y"]) => y * 3, (_scope, z) => _data(_scope["#text/0"], z));
-const _y = /* @__PURE__ */_derivation("y", 1, [_z], (_scope, x = _scope["x"]) => x * 2);
-const _x = /* @__PURE__ */_source("x", [_y]);
+import { data as _data, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _z = /* @__PURE__ */_value("z", (_scope, z) => _data(_scope["#text/0"], z));
+const _y = /* @__PURE__ */_value("y", (_scope, y) => _z(_scope, y * 3));
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _y(_scope, x * 2));
 const _setup = _scope => {
-  _setSource(_scope, _x, 1);
+  _x(_scope, 1);
 };
 export const template = "<div> </div>";
 export const walks = /* next(1), get, out(1) */"D l";

--- a/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/components/my-button.js
@@ -1,17 +1,19 @@
-import { on as _on, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _text = /* @__PURE__ */_source("text", [], (_scope, text) => _data(_scope["#text/1"], text));
+import { on as _on, data as _data, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _text = /* @__PURE__ */_value("text", (_scope, text) => _data(_scope["#text/1"], text));
 const _hydrate_onClick = _register("packages/translator/src/__tests__/fixtures/basic-component-attrs/components/my-button.marko_0_onClick", _scope => {
   const onClick = _scope["onClick"];
   _on(_scope["#button/0"], "click", onClick);
 });
-const _onClick = /* @__PURE__ */_source("onClick", [], (_scope, onClick) => _queueHydrate(_scope, _hydrate_onClick));
-export const attrs = /* @__PURE__ */_destructureSources([_onClick, _text], (_scope, {
-  onClick,
-  text
-}) => {
-  _setSource(_scope, _onClick, onClick);
-  _setSource(_scope, _text, text);
-});
+const _onClick = /* @__PURE__ */_value("onClick", (_scope, onClick) => _queueHydrate(_scope, _hydrate_onClick));
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let onClick, text;
+  if (_dirty) ({
+    onClick,
+    text
+  } = _destructure);
+  _onClick(_scope, onClick, _dirty);
+  _text(_scope, text, _dirty);
+};
 export { _onClick as _apply_onClick, _text as _apply_text };
 export const template = "<button> </button>";
 export const walks = /* get, next(1), get, out(1) */" D l";

--- a/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.js
@@ -1,15 +1,21 @@
-import { setSource as _setSource, queueSource as _queueSource, inChild as _inChild, source as _source, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queueSource as _queueSource, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _myButton, attrs as _myButton_attrs, template as _myButton_template, walks as _myButton_walks } from "./components/my-button.marko";
-const _clickCount = /* @__PURE__ */_source("clickCount", [_inChild(_myButton_attrs, "#childScope/0")], (_scope, clickCount) => _setSource(_scope["#childScope/0"], _myButton_attrs, {
-  text: clickCount,
-  onClick: function () {
-    const clickCount = _scope["clickCount"];
-    _queueSource(_scope, _clickCount, clickCount + 1);
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount, _dirty) => {
+  if (_dirty) {
+    _myButton_attrs_value = {
+      text: clickCount,
+      onClick: function () {
+        const clickCount = _scope["clickCount"];
+        _queueSource(_scope, _clickCount, clickCount + 1);
+      }
+    };
   }
-}));
+  var _myButton_attrs_value;
+  _myButton_attrs(_scope["#childScope/0"], _myButton_attrs_value, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _clickCount, 0);
   _myButton(_scope["#childScope/0"]);
+  _clickCount(_scope, 0);
 };
 export const template = `${_myButton_template}`;
 export const walks = /* beginChild, _myButton_walks, endChild */`/${_myButton_walks}&`;

--- a/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.js
@@ -1,6 +1,7 @@
 import { queueSource as _queueSource, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _myButton, attrs as _myButton_attrs, template as _myButton_template, walks as _myButton_walks } from "./components/my-button.marko";
 const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount, _dirty) => {
+  let _myButton_attrs_value;
   if (_dirty) {
     _myButton_attrs_value = {
       text: clickCount,
@@ -10,7 +11,6 @@ const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount, _di
       }
     };
   }
-  var _myButton_attrs_value;
   _myButton_attrs(_scope["#childScope/0"], _myButton_attrs_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/components/my-button.js
@@ -1,18 +1,20 @@
-import { on as _on, conditional as _conditional, source as _source, register as _register, queueHydrate as _queueHydrate, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/1", 1, (_scope, renderBody = _scope["renderBody"]) => renderBody);
-const _renderBody = /* @__PURE__ */_source("renderBody", [_dynamicTagName]);
+import { on as _on, conditional as _conditional, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/1");
+const _renderBody = /* @__PURE__ */_value("renderBody", (_scope, renderBody) => _dynamicTagName(_scope, renderBody));
 const _hydrate_onClick = _register("packages/translator/src/__tests__/fixtures/basic-component-renderBody/components/my-button.marko_0_onClick", _scope => {
   const onClick = _scope["onClick"];
   _on(_scope["#button/0"], "click", onClick);
 });
-const _onClick = /* @__PURE__ */_source("onClick", [], (_scope, onClick) => _queueHydrate(_scope, _hydrate_onClick));
-export const attrs = /* @__PURE__ */_destructureSources([_onClick, _renderBody], (_scope, {
-  onClick,
-  renderBody
-}) => {
-  _setSource(_scope, _onClick, onClick);
-  _setSource(_scope, _renderBody, renderBody);
-});
+const _onClick = /* @__PURE__ */_value("onClick", (_scope, onClick) => _queueHydrate(_scope, _hydrate_onClick));
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let onClick, renderBody;
+  if (_dirty) ({
+    onClick,
+    renderBody
+  } = _destructure);
+  _onClick(_scope, onClick, _dirty);
+  _renderBody(_scope, renderBody, _dirty);
+};
 export { _onClick as _apply_onClick, _renderBody as _apply_renderBody };
 export const template = "<button><!></button>";
 export const walks = /* get, next(1), replace, out(1) */" D%l";

--- a/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
@@ -1,8 +1,13 @@
-import { queueSource as _queueSource, data as _data, bindRenderer as _bindRenderer, dynamicSubscribers as _dynamicSubscribers, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queueSource as _queueSource, data as _data, bindRenderer as _bindRenderer, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _myButton, attrs as _myButton_attrs, template as _myButton_template, walks as _myButton_walks } from "./components/my-button.marko";
-const _clickCount$myButtonBody = /* @__PURE__ */_dynamicClosure("clickCount", (_scope, clickCount) => _data(_scope["#text/0"], clickCount));
+const _clickCount$myButtonBody = /* @__PURE__ */_dynamicClosure("clickCount", (_scope, clickCount, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/0"], clickCount);
+  }
+});
 const _myButtonBody = /* @__PURE__ */_createRenderer(" ", /* get */" ", null, [_clickCount$myButtonBody]);
 const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount, _dirty) => {
+  let _myButton_attrs_value;
   if (_dirty) {
     _myButton_attrs_value = {
       onClick: function () {
@@ -12,7 +17,6 @@ const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount, _di
       renderBody: /* @__PURE__ */_bindRenderer(_scope, _myButtonBody)
     };
   }
-  var _myButton_attrs_value;
   _myButton_attrs(_scope["#childScope/0"], _myButton_attrs_value, _dirty);
   _dynamicSubscribers(_scope["clickCount*"], _dirty);
 });

--- a/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
@@ -1,10 +1,6 @@
 import { queueSource as _queueSource, data as _data, bindRenderer as _bindRenderer, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _myButton, attrs as _myButton_attrs, template as _myButton_template, walks as _myButton_walks } from "./components/my-button.marko";
-const _clickCount$myButtonBody = /* @__PURE__ */_dynamicClosure("clickCount", (_scope, clickCount, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/0"], clickCount);
-  }
-});
+const _clickCount$myButtonBody = /* @__PURE__ */_dynamicClosure("clickCount", (_scope, clickCount) => _data(_scope["#text/0"], clickCount));
 const _myButtonBody = /* @__PURE__ */_createRenderer(" ", /* get */" ", null, [_clickCount$myButtonBody]);
 const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount, _dirty) => {
   let _myButton_attrs_value;

--- a/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
@@ -1,17 +1,24 @@
-import { setSource as _setSource, queueSource as _queueSource, data as _data, bindRenderer as _bindRenderer, inChild as _inChild, dynamicSubscribers as _dynamicSubscribers, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, source as _source, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queueSource as _queueSource, data as _data, bindRenderer as _bindRenderer, dynamicSubscribers as _dynamicSubscribers, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _myButton, attrs as _myButton_attrs, template as _myButton_template, walks as _myButton_walks } from "./components/my-button.marko";
-const _clickCount$myButtonBody = _dynamicClosure(1, "clickCount", [], (_scope, clickCount) => _data(_scope["#text/0"], clickCount));
+const _clickCount$myButtonBody = /* @__PURE__ */_dynamicClosure("clickCount", (_scope, clickCount) => _data(_scope["#text/0"], clickCount));
 const _myButtonBody = /* @__PURE__ */_createRenderer(" ", /* get */" ", null, [_clickCount$myButtonBody]);
-const _clickCount = /* @__PURE__ */_source("clickCount", [_inChild(_myButton_attrs, "#childScope/0"), _dynamicSubscribers("clickCount")], (_scope, clickCount) => _setSource(_scope["#childScope/0"], _myButton_attrs, {
-  onClick: function () {
-    const clickCount = _scope["clickCount"];
-    _queueSource(_scope, _clickCount, clickCount + 1);
-  },
-  renderBody: /* @__PURE__ */_bindRenderer(_scope, _myButtonBody)
-}));
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount, _dirty) => {
+  if (_dirty) {
+    _myButton_attrs_value = {
+      onClick: function () {
+        const clickCount = _scope["clickCount"];
+        _queueSource(_scope, _clickCount, clickCount + 1);
+      },
+      renderBody: /* @__PURE__ */_bindRenderer(_scope, _myButtonBody)
+    };
+  }
+  var _myButton_attrs_value;
+  _myButton_attrs(_scope["#childScope/0"], _myButton_attrs_value, _dirty);
+  _dynamicSubscribers(_scope["clickCount*"], _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _clickCount, 0);
   _myButton(_scope["#childScope/0"]);
+  _clickCount(_scope, 0);
 };
 export const template = `${_myButton_template}`;
 export const walks = /* beginChild, _myButton_walks, endChild */`/${_myButton_walks}&`;

--- a/packages/translator/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/components/counter.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/components/counter.js
@@ -1,14 +1,14 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixtures/basic-component/components/counter.marko_0_clickCount", _scope => _on(_scope["#button/0"], "click", function () {
   const clickCount = _scope["clickCount"];
   _queueSource(_scope, _clickCount, clickCount + 1);
 }));
-const _clickCount = /* @__PURE__ */_source("clickCount", [], (_scope, clickCount) => {
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => {
   _data(_scope["#text/1"], clickCount);
   _queueHydrate(_scope, _hydrate_clickCount);
 });
 const _setup = _scope => {
-  _setSource(_scope, _clickCount, 0);
+  _clickCount(_scope, 0);
 };
 export const template = "<button> </button>";
 export const walks = /* get, next(1), get, out(1) */" D l";

--- a/packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
@@ -1,5 +1,9 @@
-import { on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _count$ifBody = /* @__PURE__ */_closure("count", (_scope, count) => _data(_scope["#text/0"], count));
+import { on as _on, queueSource as _queueSource, data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueHydrate as _queueHydrate, inConditionalScope as _inConditionalScope, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _count$ifBody = /* @__PURE__ */_closure("count", (_scope, count, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/0"], count);
+  }
+});
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/template.marko_1_renderer", /* @__PURE__ */_createRenderer("The count is <!>", /* over(1), replace */"b%", null, [_count$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/2");
 const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/template.marko_0_count", _scope => _on(_scope["#button/0"], "click", function () {
@@ -17,11 +21,11 @@ const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/basi
   _queueSource(_scope, _show, !show);
 }));
 const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
+  let _if_value;
   if (_dirty) {
-    _if_value = show ? _ifBody : null;
     _queueHydrate(_scope, _hydrate_show);
+    _if_value = show ? _ifBody : null;
   }
-  var _if_value;
   _if(_scope, _if_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
@@ -1,9 +1,5 @@
 import { on as _on, queueSource as _queueSource, data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueHydrate as _queueHydrate, inConditionalScope as _inConditionalScope, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _count$ifBody = /* @__PURE__ */_closure("count", (_scope, count, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/0"], count);
-  }
-});
+const _count$ifBody = /* @__PURE__ */_closure("count", (_scope, count) => _data(_scope["#text/0"], count));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/template.marko_1_renderer", /* @__PURE__ */_createRenderer("The count is <!>", /* over(1), replace */"b%", null, [_count$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/2");
 const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/template.marko_0_count", _scope => _on(_scope["#button/0"], "click", function () {

--- a/packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
@@ -1,20 +1,32 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, source as _source, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _count$ifBody = /* @__PURE__ */_closure(1, "count", [], (_scope, count) => _data(_scope["#text/0"], count));
+import { on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _count$ifBody = /* @__PURE__ */_closure("count", (_scope, count) => _data(_scope["#text/0"], count));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/template.marko_1_renderer", /* @__PURE__ */_createRenderer("The count is <!>", /* over(1), replace */"b%", null, [_count$ifBody]));
-const _if = /* @__PURE__ */_conditional("#text/2", 1, (_scope, show = _scope["show"]) => show ? _ifBody : null);
+const _if = /* @__PURE__ */_conditional("#text/2");
 const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/template.marko_0_count", _scope => _on(_scope["#button/0"], "click", function () {
   const count = _scope["count"];
   _queueSource(_scope, _count, count + 1);
 }));
-const _count = /* @__PURE__ */_source("count", [/* @__PURE__ */_inConditionalScope(_count$ifBody, "#text/2")], (_scope, count) => _queueHydrate(_scope, _hydrate_count));
+const _count = /* @__PURE__ */_value("count", (_scope, count, _dirty) => {
+  if (_dirty) {
+    _queueHydrate(_scope, _hydrate_count);
+  }
+  _inConditionalScope(_scope, _dirty, _count$ifBody, "#text/2");
+});
 const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/template.marko_0_show", _scope => _on(_scope["#button/1"], "click", function () {
   const show = _scope["show"];
   _queueSource(_scope, _show, !show);
 }));
-const _show = /* @__PURE__ */_source("show", [_if], (_scope, show) => _queueHydrate(_scope, _hydrate_show));
+const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
+  if (_dirty) {
+    _if_value = show ? _ifBody : null;
+    _queueHydrate(_scope, _hydrate_show);
+  }
+  var _if_value;
+  _if(_scope, _if_value, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _show, true);
-  _setSource(_scope, _count, 0);
+  _show(_scope, true);
+  _count(_scope, 0);
 };
 export const template = "<button class=inc></button><button class=toggle></button><!>";
 export const walks = /* get, over(1), get, over(1), replace, over(1) */" b b%b";

--- a/packages/translator/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
@@ -1,5 +1,9 @@
-import { on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _count$ifBody = /* @__PURE__ */_closure("count", (_scope, count) => _data(_scope["#text/0"], count));
+import { on as _on, queueSource as _queueSource, data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueHydrate as _queueHydrate, inConditionalScope as _inConditionalScope, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _count$ifBody = /* @__PURE__ */_closure("count", (_scope, count, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/0"], count);
+  }
+});
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_count$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/2");
 const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter/template.marko_0_count", _scope => _on(_scope["#button/0"], "click", function () {
@@ -17,11 +21,11 @@ const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/basi
   _queueSource(_scope, _show, !show);
 }));
 const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
+  let _if_value;
   if (_dirty) {
-    _if_value = show ? _ifBody : null;
     _queueHydrate(_scope, _hydrate_show);
+    _if_value = show ? _ifBody : null;
   }
-  var _if_value;
   _if(_scope, _if_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
@@ -1,9 +1,5 @@
 import { on as _on, queueSource as _queueSource, data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueHydrate as _queueHydrate, inConditionalScope as _inConditionalScope, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _count$ifBody = /* @__PURE__ */_closure("count", (_scope, count, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/0"], count);
-  }
-});
+const _count$ifBody = /* @__PURE__ */_closure("count", (_scope, count) => _data(_scope["#text/0"], count));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_count$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/2");
 const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter/template.marko_0_count", _scope => _on(_scope["#button/0"], "click", function () {

--- a/packages/translator/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
@@ -1,20 +1,32 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, source as _source, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _count$ifBody = /* @__PURE__ */_closure(1, "count", [], (_scope, count) => _data(_scope["#text/0"], count));
+import { on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _count$ifBody = /* @__PURE__ */_closure("count", (_scope, count) => _data(_scope["#text/0"], count));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_count$ifBody]));
-const _if = /* @__PURE__ */_conditional("#text/2", 1, (_scope, show = _scope["show"]) => show ? _ifBody : null);
+const _if = /* @__PURE__ */_conditional("#text/2");
 const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter/template.marko_0_count", _scope => _on(_scope["#button/0"], "click", function () {
   const count = _scope["count"];
   _queueSource(_scope, _count, count + 1);
 }));
-const _count = /* @__PURE__ */_source("count", [/* @__PURE__ */_inConditionalScope(_count$ifBody, "#text/2")], (_scope, count) => _queueHydrate(_scope, _hydrate_count));
+const _count = /* @__PURE__ */_value("count", (_scope, count, _dirty) => {
+  if (_dirty) {
+    _queueHydrate(_scope, _hydrate_count);
+  }
+  _inConditionalScope(_scope, _dirty, _count$ifBody, "#text/2");
+});
 const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter/template.marko_0_show", _scope => _on(_scope["#button/1"], "click", function () {
   const show = _scope["show"];
   _queueSource(_scope, _show, !show);
 }));
-const _show = /* @__PURE__ */_source("show", [_if], (_scope, show) => _queueHydrate(_scope, _hydrate_show));
+const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
+  if (_dirty) {
+    _if_value = show ? _ifBody : null;
+    _queueHydrate(_scope, _hydrate_show);
+  }
+  var _if_value;
+  _if(_scope, _if_value, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _show, true);
-  _setSource(_scope, _count, 0);
+  _show(_scope, true);
+  _count(_scope, 0);
 };
 export const template = "<button class=inc></button><button class=toggle></button><!>";
 export const walks = /* get, over(1), get, over(1), replace, over(1) */" b b%b";

--- a/packages/translator/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/dom.expected/template.js
@@ -1,15 +1,19 @@
-import { setSource as _setSource, data as _data, subscriber as _subscriber, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, conditional as _conditional, source as _source, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _expr_a_b$ifBody = /* @__PURE__ */_subscriber([], 2, (_scope, a = _scope._["a"], b = _scope._["b"]) => _data(_scope["#text/0"], a + b));
-const _b$ifBody = /* @__PURE__ */_closure(1, "b", [_expr_a_b$ifBody]);
-const _a$ifBody = /* @__PURE__ */_closure(1, "a", [_expr_a_b$ifBody]);
+import { data as _data, intersection as _intersection, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _expr_a_b$ifBody = /* @__PURE__ */_intersection(2, _scope => {
+  const a = _scope._["a"],
+    b = _scope._["b"];
+  _data(_scope["#text/0"], a + b);
+});
+const _b$ifBody = /* @__PURE__ */_closure("b", (_scope, b, _dirty) => _expr_a_b$ifBody(_scope, _dirty));
+const _a$ifBody = /* @__PURE__ */_closure("a", (_scope, a, _dirty) => _expr_a_b$ifBody(_scope, _dirty));
 const _ifBody = /* @__PURE__ */_createRenderer(" ", /* get */" ", null, [_a$ifBody, _b$ifBody]);
-const _if = /* @__PURE__ */_conditional("#text/0", 1, _scope => true ? _ifBody : null);
-const _b = /* @__PURE__ */_source("b", [/* @__PURE__ */_inConditionalScope(_b$ifBody, "#text/0")]);
-const _a = /* @__PURE__ */_source("a", [/* @__PURE__ */_inConditionalScope(_a$ifBody, "#text/0")]);
+const _if = /* @__PURE__ */_conditional("#text/0");
+const _b = /* @__PURE__ */_value("b", (_scope, b, _dirty) => _inConditionalScope(_scope, _dirty, _b$ifBody, "#text/0"));
+const _a = /* @__PURE__ */_value("a", (_scope, a, _dirty) => _inConditionalScope(_scope, _dirty, _a$ifBody, "#text/0"));
 const _setup = _scope => {
-  _setSource(_scope, _a, 0);
-  _setSource(_scope, _b, 0);
-  _notifySignal(_scope, _if);
+  _a(_scope, 0);
+  _b(_scope, 0);
+  _if(_scope, true ? _ifBody : null);
 };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { data as _data, intersection as _intersection, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { data as _data, intersection as _intersection, closure as _closure, createRenderer as _createRenderer, conditional as _conditional, inConditionalScope as _inConditionalScope, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _expr_a_b$ifBody = /* @__PURE__ */_intersection(2, _scope => {
   const a = _scope._["a"],
     b = _scope._["b"];

--- a/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/csr-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,76 @@
+# Render {}
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (1)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  0
+</div>
+```
+
+
+# Render 
+container.querySelector("button#count").click();
+
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (1)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  1
+</div>
+```
+
+
+# Render 
+container.querySelector("button#count").click();
+
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (1)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  2
+</div>
+```
+
+
+# Render 
+container.querySelector("button#multiplier").click();
+
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (2)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  4
+</div>
+```

--- a/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/csr.expected.md
+++ b/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/csr.expected.md
@@ -1,0 +1,97 @@
+# Render {}
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (1)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  0
+</div>
+```
+
+# Mutations
+```
+inserted button0, button1, div2
+```
+
+
+# Render 
+container.querySelector("button#count").click();
+
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (1)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  1
+</div>
+```
+
+# Mutations
+```
+div2/#text0: "0" => "1"
+```
+
+
+# Render 
+container.querySelector("button#count").click();
+
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (1)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  2
+</div>
+```
+
+# Mutations
+```
+div2/#text0: "1" => "2"
+```
+
+
+# Render 
+container.querySelector("button#multiplier").click();
+
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (2)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  4
+</div>
+```
+
+# Mutations
+```
+button0/#text1: "1" => "2"
+div2/#text0: "2" => "4"
+```

--- a/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.js
@@ -1,0 +1,36 @@
+import { on as _on, queueSource as _queueSource, data as _data, intersection as _intersection, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _expr_count_multiplier = /* @__PURE__ */_intersection(2, _scope => {
+  const count = _scope["count"],
+    multiplier = _scope["multiplier"];
+  _multipliedCount(_scope, count * multiplier);
+});
+const _multipliedCount = /* @__PURE__ */_value("multipliedCount", (_scope, multipliedCount) => _data(_scope["#text/3"], multipliedCount));
+const _hydrate_multiplier = _register("packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_multiplier", _scope => _on(_scope["#button/0"], "click", function () {
+  const multiplier = _scope["multiplier"];
+  _queueSource(_scope, _multiplier, multiplier + 1);
+}));
+const _multiplier = /* @__PURE__ */_value("multiplier", (_scope, multiplier, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/1"], multiplier);
+    _queueHydrate(_scope, _hydrate_multiplier);
+  }
+  _expr_count_multiplier(_scope, _dirty);
+});
+const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_count", _scope => _on(_scope["#button/2"], "click", function () {
+  const count = _scope["count"];
+  _queueSource(_scope, _count, count + 1);
+}));
+const _count = /* @__PURE__ */_value("count", (_scope, count, _dirty) => {
+  if (_dirty) {
+    _queueHydrate(_scope, _hydrate_count);
+  }
+  _expr_count_multiplier(_scope, _dirty);
+});
+const _setup = _scope => {
+  _count(_scope, 0);
+  _multiplier(_scope, 1);
+};
+export const template = "<button id=multiplier>increase multiplier (<!>)</button><button id=count>increase count</button><div> </div>";
+export const walks = /* get, next(1), over(1), replace, out(1), get, over(1), next(1), get, out(1) */" Db%l bD l";
+export const setup = _setup;
+export default /* @__PURE__ */_createRenderFn(template, walks, setup, null, null, "packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko");

--- a/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/html.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/html.expected/template.js
@@ -1,0 +1,16 @@
+import { escapeXML as _escapeXML, markHydrateNode as _markHydrateNode, write as _write, nextScopeId as _nextScopeId, writeHydrateCall as _writeHydrateCall, writeHydrateScope as _writeHydrateScope, register as _register, createRenderer as _createRenderer } from "@marko/runtime-fluurt/src/html";
+const _renderer = _register((input, _tagVar, _scope0_) => {
+  const _scope0_id = _nextScopeId();
+  const count = 0;
+  const multiplier = 1;
+  const multipliedCount = count * multiplier;
+  _write(`<button id=multiplier>increase multiplier (<!>${_escapeXML(multiplier)}${_markHydrateNode(_scope0_id, "#text/1")})</button>${_markHydrateNode(_scope0_id, "#button/0")}<button id=count>increase count</button>${_markHydrateNode(_scope0_id, "#button/2")}<div>${_escapeXML(multipliedCount)}${_markHydrateNode(_scope0_id, "#text/3")}</div>`);
+  _writeHydrateCall(_scope0_id, "packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_count");
+  _writeHydrateCall(_scope0_id, "packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_multiplier");
+  _writeHydrateScope(_scope0_id, {
+    "count": count,
+    "multiplier": multiplier
+  }, _scope0_);
+}, "packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko");
+export default _renderer;
+export const render = /* @__PURE__ */_createRenderer(_renderer);

--- a/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/hydrate-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/hydrate-sanitized.expected.md
@@ -1,0 +1,76 @@
+# Render {}
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (1)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  0
+</div>
+```
+
+
+# Render 
+container.querySelector("button#count").click();
+
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (1)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  1
+</div>
+```
+
+
+# Render 
+container.querySelector("button#count").click();
+
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (1)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  2
+</div>
+```
+
+
+# Render 
+container.querySelector("button#multiplier").click();
+
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (2)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  4
+</div>
+```

--- a/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/hydrate.expected.md
+++ b/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/hydrate.expected.md
@@ -1,0 +1,157 @@
+# Render {}
+```html
+<html>
+  <head />
+  <body>
+    <button
+      id="multiplier"
+    >
+      increase multiplier (
+      <!---->
+      1
+      <!--M#0 #text/1-->
+      )
+    </button>
+    <!--M#0 #button/0-->
+    <button
+      id="count"
+    >
+      increase count
+    </button>
+    <!--M#0 #button/2-->
+    <div>
+      0
+      <!--M#0 #text/3-->
+    </div>
+    <script>
+      (M$h=[]).push((b,s)=&gt;({0:{count:0,multiplier:1}}),[0,"packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_count",0,"packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_multiplier",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+
+```
+
+
+# Render 
+container.querySelector("button#count").click();
+
+```html
+<html>
+  <head />
+  <body>
+    <button
+      id="multiplier"
+    >
+      increase multiplier (
+      <!---->
+      1
+      <!--M#0 #text/1-->
+      )
+    </button>
+    <!--M#0 #button/0-->
+    <button
+      id="count"
+    >
+      increase count
+    </button>
+    <!--M#0 #button/2-->
+    <div>
+      1
+      <!--M#0 #text/3-->
+    </div>
+    <script>
+      (M$h=[]).push((b,s)=&gt;({0:{count:0,multiplier:1}}),[0,"packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_count",0,"packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_multiplier",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+#document/html0/body1/div4/#text0: "0" => "1"
+```
+
+
+# Render 
+container.querySelector("button#count").click();
+
+```html
+<html>
+  <head />
+  <body>
+    <button
+      id="multiplier"
+    >
+      increase multiplier (
+      <!---->
+      1
+      <!--M#0 #text/1-->
+      )
+    </button>
+    <!--M#0 #button/0-->
+    <button
+      id="count"
+    >
+      increase count
+    </button>
+    <!--M#0 #button/2-->
+    <div>
+      2
+      <!--M#0 #text/3-->
+    </div>
+    <script>
+      (M$h=[]).push((b,s)=&gt;({0:{count:0,multiplier:1}}),[0,"packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_count",0,"packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_multiplier",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+#document/html0/body1/div4/#text0: "1" => "2"
+```
+
+
+# Render 
+container.querySelector("button#multiplier").click();
+
+```html
+<html>
+  <head />
+  <body>
+    <button
+      id="multiplier"
+    >
+      increase multiplier (
+      <!---->
+      2
+      <!--M#0 #text/1-->
+      )
+    </button>
+    <!--M#0 #button/0-->
+    <button
+      id="count"
+    >
+      increase count
+    </button>
+    <!--M#0 #button/2-->
+    <div>
+      4
+      <!--M#0 #text/3-->
+    </div>
+    <script>
+      (M$h=[]).push((b,s)=&gt;({0:{count:0,multiplier:1}}),[0,"packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_count",0,"packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_multiplier",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+#document/html0/body1/button0/#text2: "1" => "2"
+#document/html0/body1/div4/#text0: "2" => "4"
+```

--- a/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,16 @@
+# Render "End"
+```html
+<button
+  id="multiplier"
+>
+  increase multiplier (1)
+</button>
+<button
+  id="count"
+>
+  increase count
+</button>
+<div>
+  0
+</div>
+```

--- a/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/ssr.expected.md
+++ b/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/ssr.expected.md
@@ -1,0 +1,57 @@
+# Write
+  <button id=multiplier>increase multiplier (<!>1<!M#0 #text/1>)</button><!M#0 #button/0><button id=count>increase count</button><!M#0 #button/2><div>0<!M#0 #text/3></div><script>(M$h=[]).push((b,s)=>({0:{count:0,multiplier:1}}),[0,"packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_count",0,"packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_multiplier",])</script>
+
+
+# Render "End"
+```html
+<html>
+  <head />
+  <body>
+    <button
+      id="multiplier"
+    >
+      increase multiplier (
+      <!---->
+      1
+      <!--M#0 #text/1-->
+      )
+    </button>
+    <!--M#0 #button/0-->
+    <button
+      id="count"
+    >
+      increase count
+    </button>
+    <!--M#0 #button/2-->
+    <div>
+      0
+      <!--M#0 #text/3-->
+    </div>
+    <script>
+      (M$h=[]).push((b,s)=&gt;({0:{count:0,multiplier:1}}),[0,"packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_count",0,"packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_multiplier",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+inserted #document/html0
+inserted #document/html0/head0
+inserted #document/html0/body1
+inserted #document/html0/body1/button0
+inserted #document/html0/body1/button0/#text0
+inserted #document/html0/body1/button0/#comment1
+inserted #document/html0/body1/button0/#text2
+inserted #document/html0/body1/button0/#comment3
+inserted #document/html0/body1/button0/#text4
+inserted #document/html0/body1/#comment1
+inserted #document/html0/body1/button2
+inserted #document/html0/body1/button2/#text0
+inserted #document/html0/body1/#comment3
+inserted #document/html0/body1/div4
+inserted #document/html0/body1/div4/#text0
+inserted #document/html0/body1/div4/#comment1
+inserted #document/html0/body1/script5
+inserted #document/html0/body1/script5/#text0
+```

--- a/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko
+++ b/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko
@@ -1,0 +1,12 @@
+<let/count = 0/>
+<let/multiplier = 1/>
+<const/multipliedCount = count * multiplier/>
+<button id="multiplier" onClick() {
+  multiplier++
+}>increase multiplier (${multiplier})</button>
+<button id="count" onClick() {
+  count++
+}>increase count</button>
+<div>
+  ${multipliedCount}
+</div>

--- a/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/test.ts
+++ b/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/test.ts
@@ -1,0 +1,9 @@
+export const steps = [{}, count, count, multiplier];
+
+function count(container: Element) {
+  container.querySelector<HTMLButtonElement>("button#count")!.click();
+}
+
+function multiplier(container: Element) {
+  container.querySelector<HTMLButtonElement>("button#multiplier")!.click();
+}

--- a/packages/translator/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected/template.js
@@ -1,14 +1,14 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixtures/basic-counter/template.marko_0_clickCount", _scope => _on(_scope["#button/0"], "click", function () {
   const clickCount = _scope["clickCount"];
   _queueSource(_scope, _clickCount, clickCount + 1);
 }));
-const _clickCount = /* @__PURE__ */_source("clickCount", [], (_scope, clickCount) => {
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => {
   _data(_scope["#text/1"], clickCount);
   _queueHydrate(_scope, _hydrate_clickCount);
 });
 const _setup = _scope => {
-  _setSource(_scope, _clickCount, 0);
+  _clickCount(_scope, 0);
 };
 export const template = "<div><button> </button></div>";
 export const walks = /* next(1), get, next(1), get, out(2) */"D D m";

--- a/packages/translator/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/dom.expected/template.js
@@ -1,19 +1,19 @@
 import { dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _tagNameBody = /* @__PURE__ */_createRenderer("Hello World", "");
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => {
+  let _dynamicBody_attrs;
   if (_dirty) {
     _dynamicBody_attrs = () => ({
       class: ["a", "b"]
     });
   }
-  var _dynamicBody_attrs;
   _dynamicTagAttrs(_scope, "#text/0", _dynamicBody_attrs, _tagNameBody, _dirty);
 });
 const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
+  let _dynamicTagName_value;
   if (_dirty) {
     _dynamicTagName_value = tagName || _tagNameBody;
   }
-  var _dynamicTagName_value;
   _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
 });
 export const attrs = (_scope, _destructure, _dirty = true) => {

--- a/packages/translator/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/dom.expected/template.js
@@ -1,14 +1,28 @@
-import { dynamicAttrsProxy as _dynamicAttrsProxy, dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, conditional as _conditional, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _tagNameBody = /* @__PURE__ */_createRenderer("Hello World", "");
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", 1, (_scope, tagName = _scope["tagName"]) => tagName || _tagNameBody, _dynamicAttrsProxy("#text/0"), _scope => _dynamicTagAttrs(_scope, "#text/0", () => ({
-  class: ["a", "b"]
-}), _tagNameBody));
-const _tagName = /* @__PURE__ */_source("tagName", [_dynamicTagName]);
-export const attrs = /* @__PURE__ */_destructureSources([_tagName], (_scope, {
-  tagName
-}) => {
-  _setSource(_scope, _tagName, tagName);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => {
+  if (_dirty) {
+    _dynamicBody_attrs = () => ({
+      class: ["a", "b"]
+    });
+  }
+  var _dynamicBody_attrs;
+  _dynamicTagAttrs(_scope, "#text/0", _dynamicBody_attrs, _tagNameBody, _dirty);
 });
+const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
+  if (_dirty) {
+    _dynamicTagName_value = tagName || _tagNameBody;
+  }
+  var _dynamicTagName_value;
+  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
+});
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let tagName;
+  if (_dirty) ({
+    tagName
+  } = _destructure);
+  _tagName(_scope, tagName, _dirty);
+};
 export { _tagName as _apply_tagName };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.js
@@ -1,9 +1,5 @@
 import { on as _on, queueSource as _queueSource, data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, value as _value, inConditionalScope as _inConditionalScope, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _message$ifBody = /* @__PURE__ */_closure("message", (_scope, message, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/0"], message.text);
-  }
-});
+const _message$ifBody = /* @__PURE__ */_closure("message", (_scope, message) => _data(_scope["#text/0"], message.text));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-execution-order/template.marko_1_renderer", /* @__PURE__ */_createRenderer(" ", /* get */" ", null, [_message$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/1");
 const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {

--- a/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.js
@@ -1,18 +1,24 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, source as _source, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _message$ifBody = /* @__PURE__ */_closure(1, "message", [], (_scope, message) => _data(_scope["#text/0"], message.text));
+import { on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, value as _value, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _message$ifBody = /* @__PURE__ */_closure("message", (_scope, message) => _data(_scope["#text/0"], message.text));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-execution-order/template.marko_1_renderer", /* @__PURE__ */_createRenderer(" ", /* get */" ", null, [_message$ifBody]));
-const _if = /* @__PURE__ */_conditional("#text/1", 1, (_scope, show = _scope["show"]) => show ? _ifBody : null);
-const _show = /* @__PURE__ */_source("show", [_if]);
-const _message = /* @__PURE__ */_source("message", [/* @__PURE__ */_inConditionalScope(_message$ifBody, "#text/1")]);
+const _if = /* @__PURE__ */_conditional("#text/1");
+const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
+  if (_dirty) {
+    _if_value = show ? _ifBody : null;
+  }
+  var _if_value;
+  _if(_scope, _if_value, _dirty);
+});
+const _message = /* @__PURE__ */_value("message", (_scope, message, _dirty) => _inConditionalScope(_scope, _dirty, _message$ifBody, "#text/1"));
 const _hydrate_setup = _register("packages/translator/src/__tests__/fixtures/basic-execution-order/template.marko_0", _scope => _on(_scope["#button/0"], "click", function () {
   _queueSource(_scope, _message, null);
   _queueSource(_scope, _show, false);
 }));
 const _setup = _scope => {
-  _setSource(_scope, _message, {
+  _message(_scope, {
     text: "hi"
   });
-  _setSource(_scope, _show, true);
+  _show(_scope, true);
   _queueHydrate(_scope, _hydrate_setup);
 };
 export const template = "<button>hide</button><!>";

--- a/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.js
@@ -1,12 +1,16 @@
-import { on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, value as _value, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _message$ifBody = /* @__PURE__ */_closure("message", (_scope, message) => _data(_scope["#text/0"], message.text));
+import { on as _on, queueSource as _queueSource, data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, value as _value, inConditionalScope as _inConditionalScope, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _message$ifBody = /* @__PURE__ */_closure("message", (_scope, message, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/0"], message.text);
+  }
+});
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-execution-order/template.marko_1_renderer", /* @__PURE__ */_createRenderer(" ", /* get */" ", null, [_message$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/1");
 const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
+  let _if_value;
   if (_dirty) {
     _if_value = show ? _ifBody : null;
   }
-  var _if_value;
   _if(_scope, _if_value, _dirty);
 });
 const _message = /* @__PURE__ */_value("message", (_scope, message, _dirty) => _inConditionalScope(_scope, _dirty, _message$ifBody, "#text/1"));
@@ -15,11 +19,11 @@ const _hydrate_setup = _register("packages/translator/src/__tests__/fixtures/bas
   _queueSource(_scope, _show, false);
 }));
 const _setup = _scope => {
+  _queueHydrate(_scope, _hydrate_setup);
   _message(_scope, {
     text: "hi"
   });
   _show(_scope, true);
-  _queueHydrate(_scope, _hydrate_setup);
 };
 export const template = "<button>hide</button><!>";
 export const walks = /* get, over(1), replace, over(1) */" b%b";

--- a/packages/translator/src/__tests__/fixtures/basic-export/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-export/__snapshots__/dom.expected/template.js
@@ -1,11 +1,13 @@
 export const v = 123;
-import { data as _data, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _value = /* @__PURE__ */_source("value", [], (_scope, value) => _data(_scope["#text/0"], value));
-export const attrs = /* @__PURE__ */_destructureSources([_value], (_scope, {
-  value
-}) => {
-  _setSource(_scope, _value, value);
-});
+import { data as _data, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _value = /* @__PURE__ */_value2("value", (_scope, value) => _data(_scope["#text/0"], value));
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let value;
+  if (_dirty) ({
+    value
+  } = _destructure);
+  _value(_scope, value, _dirty);
+};
 export { _value as _apply_value };
 export const template = "<div> </div>";
 export const walks = /* next(1), get, out(1) */"D l";

--- a/packages/translator/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected/template.js
@@ -1,16 +1,16 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/basic-fn-with-block/template.marko_0_count", _scope => _on(_scope["#button/0"], "click", function () {
   const count = _scope["count"];
   {
     _queueSource(_scope, _count, count + 1);
   }
 }));
-const _count = /* @__PURE__ */_source("count", [], (_scope, count) => {
+const _count = /* @__PURE__ */_value("count", (_scope, count) => {
   _data(_scope["#text/1"], count);
   _queueHydrate(_scope, _hydrate_count);
 });
 const _setup = _scope => {
-  _setSource(_scope, _count, 0);
+  _count(_scope, 0);
 };
 export const template = "<button> </button>";
 export const walks = /* get, next(1), get, out(1) */" D l";

--- a/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, subscriber as _subscriber, register as _register, queueHydrate as _queueHydrate, source as _source, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueHydrate as _queueHydrate, intersection as _intersection, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_expr_a_b = _register("packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/template.marko_0_a_b", _scope => _on(_scope["#button/0"], "click", function () {
   const a = _scope["a"];
   _queueSource(_scope, _a, a.map(a => {
@@ -6,12 +6,21 @@ const _hydrate_expr_a_b = _register("packages/translator/src/__tests__/fixtures/
     return b;
   }));
 }));
-const _expr_a_b = /* @__PURE__ */_subscriber([], 2, (_scope, a = _scope["a"], b = _scope["b"]) => _queueHydrate(_scope, _hydrate_expr_a_b));
-const _b = /* @__PURE__ */_source("b", [_expr_a_b]);
-const _a = /* @__PURE__ */_source("a", [_expr_a_b], (_scope, a) => _data(_scope["#text/1"], a.join("")));
+const _expr_a_b = /* @__PURE__ */_intersection(2, _scope => {
+  const a = _scope["a"],
+    b = _scope["b"];
+  _queueHydrate(_scope, _hydrate_expr_a_b);
+});
+const _b = /* @__PURE__ */_value("b", (_scope, b, _dirty) => _expr_a_b(_scope, _dirty));
+const _a = /* @__PURE__ */_value("a", (_scope, a, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/1"], a.join(""));
+  }
+  _expr_a_b(_scope, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _a, [0]);
-  _setSource(_scope, _b, 1);
+  _a(_scope, [0]);
+  _b(_scope, 1);
 };
 export const template = "<button> </button>";
 export const walks = /* get, next(1), get, out(1) */" D l";

--- a/packages/translator/src/__tests__/fixtures/basic-handler-refless/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-refless/__snapshots__/dom.expected/template.js
@@ -4,8 +4,8 @@ const _hydrate_setup = _register("packages/translator/src/__tests__/fixtures/bas
   _queueSource(_scope, _data, 1);
 }));
 const _setup = _scope => {
-  _data(_scope, 0);
   _queueHydrate(_scope, _hydrate_setup);
+  _data(_scope, 0);
 };
 export const template = "<button> </button>";
 export const walks = /* get, next(1), get, out(1) */" D l";

--- a/packages/translator/src/__tests__/fixtures/basic-handler-refless/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-refless/__snapshots__/dom.expected/template.js
@@ -1,10 +1,10 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data2, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _data = /* @__PURE__ */_source("data", [], (_scope, data) => _data2(_scope["#text/1"], data));
+import { on as _on, queueSource as _queueSource, data as _data2, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _data = /* @__PURE__ */_value("data", (_scope, data) => _data2(_scope["#text/1"], data));
 const _hydrate_setup = _register("packages/translator/src/__tests__/fixtures/basic-handler-refless/template.marko_0", _scope => _on(_scope["#button/0"], "click", function () {
   _queueSource(_scope, _data, 1);
 }));
 const _setup = _scope => {
-  _setSource(_scope, _data, 0);
+  _data(_scope, 0);
   _queueHydrate(_scope, _hydrate_setup);
 };
 export const template = "<button> </button>";

--- a/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/components/comments.js
+++ b/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/components/comments.js
@@ -1,6 +1,7 @@
-import { attr as _attr, data as _data, on as _on, queueSource as _queueSource, intersection as _intersection, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueHydrate as _queueHydrate, value as _value, inLoopScope as _inLoopScope, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { attr as _attr, data as _data, on as _on, queueSource as _queueSource, intersection as _intersection, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueHydrate as _queueHydrate, value as _value, inConditionalScope as _inConditionalScope, loop as _loop, inLoopScope as _inLoopScope, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _comments2, attrs as _comments_attrs, template as _comments_template, walks as _comments_walks } from "./comments.marko";
 const _expr_comment_id$ifBody = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
+  let _comments_attrs_value;
   if (_dirty) {
     const comment = _scope._["comment"],
       id = _scope._["id"];
@@ -9,7 +10,6 @@ const _expr_comment_id$ifBody = /* @__PURE__ */_intersection(2, (_scope, _dirty)
       path: id
     };
   }
-  var _comments_attrs_value;
   _comments_attrs(_scope["#childScope/0"], _comments_attrs_value, _dirty);
 });
 const _id$ifBody = /* @__PURE__ */_closure("id", (_scope, id, _dirty) => _expr_comment_id$ifBody(_scope, _dirty));
@@ -19,12 +19,12 @@ const _setup$ifBody = _scope => {
 };
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko_2_renderer", /* @__PURE__ */_createRenderer(`${_comments_template}`, /* beginChild, _comments_walks, endChild */`/${_comments_walks}&`, _setup$ifBody, [_comment$ifBody, _id$ifBody]));
 const _expr_path_i$forBody = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
+  let _id$forBody_value;
   if (_dirty) {
     const path = _scope._["path"],
       i = _scope["i"];
     _id$forBody_value = `${path}-${i}`;
   }
-  var _id$forBody_value;
   _id$forBody(_scope, _id$forBody_value, _dirty);
 });
 const _if$forBody = /* @__PURE__ */_conditional("#text/4");
@@ -45,11 +45,11 @@ const _id$forBody = /* @__PURE__ */_value("id", (_scope, id, _dirty) => {
 });
 const _i$forBody = /* @__PURE__ */_value("i", (_scope, i, _dirty) => _expr_path_i$forBody(_scope, _dirty));
 const _comment$forBody = /* @__PURE__ */_value("comment", (_scope, comment, _dirty) => {
+  let _if$forBody_value;
   if (_dirty) {
     _data(_scope["#text/1"], comment.text);
     _if$forBody_value = comment.comments ? _ifBody : null;
   }
-  var _if$forBody_value;
   _if$forBody(_scope, _if$forBody_value, _dirty);
   _inConditionalScope(_scope, _dirty, _comment$ifBody, "#text/4");
 });
@@ -66,10 +66,10 @@ const _for = /* @__PURE__ */_loop("#ul/0", _forBody, (_scope, _destructure, _dir
 });
 const _path = /* @__PURE__ */_value("path", (_scope, path, _dirty) => _inLoopScope(_scope, _dirty, _path$forBody, "#ul/0"));
 const _comments = /* @__PURE__ */_value("comments", (_scope, comments, _dirty) => {
+  let _for_value;
   if (_dirty) {
     _for_value = [comments, null];
   }
-  var _for_value;
   _for(_scope, _for_value, _dirty);
 });
 export const attrs = (_scope, _destructure2, _dirty = true) => {

--- a/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/components/comments.js
+++ b/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/components/comments.js
@@ -1,46 +1,86 @@
-import { setSource as _setSource, attr as _attr, data as _data, on as _on, queueSource as _queueSource, inChild as _inChild, subscriber as _subscriber, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, source as _source, queueHydrate as _queueHydrate, derivation as _derivation, inLoopScope as _inLoopScope, loop as _loop, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { attr as _attr, data as _data, on as _on, queueSource as _queueSource, intersection as _intersection, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueHydrate as _queueHydrate, value as _value, inLoopScope as _inLoopScope, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _comments2, attrs as _comments_attrs, template as _comments_template, walks as _comments_walks } from "./comments.marko";
-const _expr_comment_id$ifBody = /* @__PURE__ */_subscriber([_inChild(_comments_attrs, "#childScope/0")], 2, (_scope, comment = _scope._["comment"], id = _scope._["id"]) => _setSource(_scope["#childScope/0"], _comments_attrs, {
-  comments: comment.comments,
-  path: id
-}));
-const _id$ifBody = /* @__PURE__ */_closure(1, "id", [_expr_comment_id$ifBody]);
-const _comment$ifBody = /* @__PURE__ */_closure(1, "comment", [_expr_comment_id$ifBody]);
+const _expr_comment_id$ifBody = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
+  if (_dirty) {
+    const comment = _scope._["comment"],
+      id = _scope._["id"];
+    _comments_attrs_value = {
+      comments: comment.comments,
+      path: id
+    };
+  }
+  var _comments_attrs_value;
+  _comments_attrs(_scope["#childScope/0"], _comments_attrs_value, _dirty);
+});
+const _id$ifBody = /* @__PURE__ */_closure("id", (_scope, id, _dirty) => _expr_comment_id$ifBody(_scope, _dirty));
+const _comment$ifBody = /* @__PURE__ */_closure("comment", (_scope, comment, _dirty) => _expr_comment_id$ifBody(_scope, _dirty));
 const _setup$ifBody = _scope => {
   _comments2(_scope["#childScope/0"]);
 };
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko_2_renderer", /* @__PURE__ */_createRenderer(`${_comments_template}`, /* beginChild, _comments_walks, endChild */`/${_comments_walks}&`, _setup$ifBody, [_comment$ifBody, _id$ifBody]));
-const _if$forBody = /* @__PURE__ */_conditional("#text/4", 1, (_scope, comment = _scope["comment"]) => comment.comments ? _ifBody : null);
+const _expr_path_i$forBody = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
+  if (_dirty) {
+    const path = _scope._["path"],
+      i = _scope["i"];
+    _id$forBody_value = `${path}-${i}`;
+  }
+  var _id$forBody_value;
+  _id$forBody(_scope, _id$forBody_value, _dirty);
+});
+const _if$forBody = /* @__PURE__ */_conditional("#text/4");
 const _hydrate_open$forBody = _register("packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko_1_open", _scope => _on(_scope["#button/2"], "click", function () {
   const open = _scope["open"];
   _queueSource(_scope, _open$forBody, !open);
 }));
-const _open$forBody = /* @__PURE__ */_source("open", [], (_scope, open) => {
+const _open$forBody = /* @__PURE__ */_value("open", (_scope, open) => {
   _attr(_scope["#li/0"], "hidden", !open);
   _data(_scope["#text/3"], open ? "[-]" : "[+]");
   _queueHydrate(_scope, _hydrate_open$forBody);
 });
-const _id$forBody = /* @__PURE__ */_derivation("id", 2, [/* @__PURE__ */_inConditionalScope(_id$ifBody, "#text/4")], (_scope, path = _scope._["path"], i = _scope["i"]) => `${path}-${i}`, (_scope, id) => _attr(_scope["#li/0"], "id", id));
-const _i$forBody = /* @__PURE__ */_source("i", [_id$forBody]);
-const _comment$forBody = /* @__PURE__ */_source("comment", [_if$forBody, /* @__PURE__ */_inConditionalScope(_comment$ifBody, "#text/4")], (_scope, comment) => _data(_scope["#text/1"], comment.text));
-const _path$forBody = /* @__PURE__ */_closure(1, "path", [_id$forBody]);
+const _id$forBody = /* @__PURE__ */_value("id", (_scope, id, _dirty) => {
+  if (_dirty) {
+    _attr(_scope["#li/0"], "id", id);
+  }
+  _inConditionalScope(_scope, _dirty, _id$ifBody, "#text/4");
+});
+const _i$forBody = /* @__PURE__ */_value("i", (_scope, i, _dirty) => _expr_path_i$forBody(_scope, _dirty));
+const _comment$forBody = /* @__PURE__ */_value("comment", (_scope, comment, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/1"], comment.text);
+    _if$forBody_value = comment.comments ? _ifBody : null;
+  }
+  var _if$forBody_value;
+  _if$forBody(_scope, _if$forBody_value, _dirty);
+  _inConditionalScope(_scope, _dirty, _comment$ifBody, "#text/4");
+});
+const _path$forBody = /* @__PURE__ */_closure("path", (_scope, path, _dirty) => _expr_path_i$forBody(_scope, _dirty));
 const _setup$forBody = _scope => {
-  _setSource(_scope, _open$forBody, true);
+  _open$forBody(_scope, true);
 };
 const _forBody = /* @__PURE__ */_createRenderer("<li><span> </span><button> </button><!></li>", /* get, next(2), get, out(1), get, next(1), get, out(1), replace */" E l D l%", _setup$forBody, [_path$forBody]);
-const _for = /* @__PURE__ */_loop("#ul/0", 1, _forBody, [_comment$forBody, _i$forBody], (_scope, [comment, i]) => {
-  _setSource(_scope, _comment$forBody, comment);
-  _setSource(_scope, _i$forBody, i);
-}, (_scope, comments = _scope["comments"]) => [comments, null]);
-const _path = /* @__PURE__ */_source("path", [/* @__PURE__ */_inLoopScope(_path$forBody, "#ul/0")]);
-const _comments = /* @__PURE__ */_source("comments", [_for]);
-export const attrs = /* @__PURE__ */_destructureSources([_comments, _path], (_scope, {
-  comments,
-  path = "c"
-}) => {
-  _setSource(_scope, _comments, comments);
-  _setSource(_scope, _path, path);
+const _for = /* @__PURE__ */_loop("#ul/0", _forBody, (_scope, _destructure, _dirty = true) => {
+  let comment, i;
+  if (_dirty) [comment, i] = _destructure;
+  _comment$forBody(_scope, comment, _dirty);
+  _i$forBody(_scope, i, _dirty);
 });
+const _path = /* @__PURE__ */_value("path", (_scope, path, _dirty) => _inLoopScope(_scope, _dirty, _path$forBody, "#ul/0"));
+const _comments = /* @__PURE__ */_value("comments", (_scope, comments, _dirty) => {
+  if (_dirty) {
+    _for_value = [comments, null];
+  }
+  var _for_value;
+  _for(_scope, _for_value, _dirty);
+});
+export const attrs = (_scope, _destructure2, _dirty = true) => {
+  let comments, path;
+  if (_dirty) ({
+    comments,
+    path = "c"
+  } = _destructure2);
+  _comments(_scope, comments, _dirty);
+  _path(_scope, path, _dirty);
+};
 export { _comments as _apply_comments, _path as _apply_path };
 export const template = "<ul></ul>";
 export const walks = /* get, over(1) */" b";

--- a/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/template.js
@@ -1,10 +1,10 @@
 import { setup as _comments, attrs as _comments_attrs, template as _comments_template, walks as _comments_walks } from "./components/comments.marko";
 import { value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _input = /* @__PURE__ */_value("input", (_scope, input, _dirty) => {
+  let _comments_attrs_value;
   if (_dirty) {
     _comments_attrs_value = input;
   }
-  var _comments_attrs_value;
   _comments_attrs(_scope["#childScope/0"], _comments_attrs_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/template.js
@@ -1,12 +1,16 @@
 import { setup as _comments, attrs as _comments_attrs, template as _comments_template, walks as _comments_walks } from "./components/comments.marko";
-import { inChild as _inChild, setSource as _setSource, source as _source, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _input = /* @__PURE__ */_source("input", [_inChild(_comments_attrs, "#childScope/0")], (_scope, input) => _setSource(_scope["#childScope/0"], _comments_attrs, input));
+import { value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _input = /* @__PURE__ */_value("input", (_scope, input, _dirty) => {
+  if (_dirty) {
+    _comments_attrs_value = input;
+  }
+  var _comments_attrs_value;
+  _comments_attrs(_scope["#childScope/0"], _comments_attrs_value, _dirty);
+});
 const _setup = _scope => {
   _comments(_scope["#childScope/0"]);
 };
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = `${_comments_template}`;
 export const walks = /* beginChild, _comments_walks, endChild */`/${_comments_walks}&`;

--- a/packages/translator/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/components/layout.js
+++ b/packages/translator/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/components/layout.js
@@ -1,11 +1,13 @@
-import { conditional as _conditional, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", 1, (_scope, renderBody = _scope["renderBody"]) => renderBody);
-const _renderBody = /* @__PURE__ */_source("renderBody", [_dynamicTagName]);
-export const attrs = /* @__PURE__ */_destructureSources([_renderBody], (_scope, {
-  renderBody
-}) => {
-  _setSource(_scope, _renderBody, renderBody);
-});
+import { conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0");
+const _renderBody = /* @__PURE__ */_value("renderBody", (_scope, renderBody) => _dynamicTagName(_scope, renderBody));
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let renderBody;
+  if (_dirty) ({
+    renderBody
+  } = _destructure);
+  _renderBody(_scope, renderBody, _dirty);
+};
 export { _renderBody as _apply_renderBody };
 export const template = "<body><!></body>";
 export const walks = /* next(1), replace, out(1) */"D%l";

--- a/packages/translator/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.js
@@ -1,6 +1,10 @@
-import { data as _data, bindRenderer as _bindRenderer, dynamicSubscribers as _dynamicSubscribers, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { data as _data, bindRenderer as _bindRenderer, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _layout, attrs as _layout_attrs, template as _layout_template, walks as _layout_walks } from "./components/layout.marko";
-const _name$layoutBody = /* @__PURE__ */_dynamicClosure("name", (_scope, name) => _data(_scope["#text/0"], name));
+const _name$layoutBody = /* @__PURE__ */_dynamicClosure("name", (_scope, name, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/0"], name);
+  }
+});
 const _layoutBody = /* @__PURE__ */_createRenderer("<h1>Hello <!></h1>", /* next(1), over(1), replace */"Db%", null, [_name$layoutBody]);
 const _name = /* @__PURE__ */_value("name", (_scope, name, _dirty) => _dynamicSubscribers(_scope["name*"], _dirty));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.js
@@ -1,10 +1,6 @@
 import { data as _data, bindRenderer as _bindRenderer, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _layout, attrs as _layout_attrs, template as _layout_template, walks as _layout_walks } from "./components/layout.marko";
-const _name$layoutBody = /* @__PURE__ */_dynamicClosure("name", (_scope, name, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/0"], name);
-  }
-});
+const _name$layoutBody = /* @__PURE__ */_dynamicClosure("name", (_scope, name) => _data(_scope["#text/0"], name));
 const _layoutBody = /* @__PURE__ */_createRenderer("<h1>Hello <!></h1>", /* next(1), over(1), replace */"Db%", null, [_name$layoutBody]);
 const _name = /* @__PURE__ */_value("name", (_scope, name, _dirty) => _dynamicSubscribers(_scope["name*"], _dirty));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.js
@@ -1,21 +1,21 @@
-import { data as _data, bindRenderer as _bindRenderer, inChild as _inChild, setSource as _setSource, dynamicSubscribers as _dynamicSubscribers, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, source as _source, notifySignal as _notifySignal, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { data as _data, bindRenderer as _bindRenderer, dynamicSubscribers as _dynamicSubscribers, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _layout, attrs as _layout_attrs, template as _layout_template, walks as _layout_walks } from "./components/layout.marko";
-const _layout_attrs_inChild = _inChild(_layout_attrs, "#childScope/0");
-const _name$layoutBody = _dynamicClosure(1, "name", [], (_scope, name) => _data(_scope["#text/0"], name));
+const _name$layoutBody = /* @__PURE__ */_dynamicClosure("name", (_scope, name) => _data(_scope["#text/0"], name));
 const _layoutBody = /* @__PURE__ */_createRenderer("<h1>Hello <!></h1>", /* next(1), over(1), replace */"Db%", null, [_name$layoutBody]);
-const _name = /* @__PURE__ */_source("name", [_dynamicSubscribers("name")]);
+const _name = /* @__PURE__ */_value("name", (_scope, name, _dirty) => _dynamicSubscribers(_scope["name*"], _dirty));
 const _setup = _scope => {
   _layout(_scope["#childScope/0"]);
-  _setSource(_scope["#childScope/0"], _layout_attrs, {
+  _layout_attrs(_scope["#childScope/0"], {
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _layoutBody)
   });
-  _notifySignal(_scope, _layout_attrs_inChild);
 };
-export const attrs = /* @__PURE__ */_destructureSources([_name], (_scope, {
-  name
-}) => {
-  _setSource(_scope, _name, name);
-});
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let name;
+  if (_dirty) ({
+    name
+  } = _destructure);
+  _name(_scope, name, _dirty);
+};
 export { _name as _apply_name };
 export const template = `${_layout_template}`;
 export const walks = /* beginChild, _layout_walks, endChild */`/${_layout_walks}&`;

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { on as _on, attr as _attr, queueSource as _queueSource, data as _data, intersection as _intersection, register as _register, queueHydrate as _queueHydrate, value as _value, inLoopScope as _inLoopScope, closure as _closure, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, attr as _attr, queueSource as _queueSource, data as _data, intersection as _intersection, register as _register, queueHydrate as _queueHydrate, value as _value, closure as _closure, createRenderer as _createRenderer, loop as _loop, inLoopScope as _inLoopScope, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _expr_selected_num$forBody = /* @__PURE__ */_intersection(2, _scope => {
   const selected = _scope._["selected"],
     num = _scope["num"];

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
@@ -1,5 +1,7 @@
-import { setSource as _setSource, on as _on, attr as _attr, queueSource as _queueSource, data as _data, subscriber as _subscriber, source as _source, register as _register, queueHydrate as _queueHydrate, inLoopScope as _inLoopScope, closure as _closure, createRenderer as _createRenderer, loop as _loop, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _expr_selected_num$forBody = /* @__PURE__ */_subscriber([], 2, (_scope, selected = _scope._["selected"], num = _scope["num"]) => {
+import { on as _on, attr as _attr, queueSource as _queueSource, data as _data, intersection as _intersection, register as _register, queueHydrate as _queueHydrate, value as _value, inLoopScope as _inLoopScope, closure as _closure, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _expr_selected_num$forBody = /* @__PURE__ */_intersection(2, _scope => {
+  const selected = _scope._["selected"],
+    num = _scope["num"];
   _attr(_scope["#button/0"], "data-selected", selected === num);
   _attr(_scope["#button/0"], "data-multiple", num % selected === 0);
 });
@@ -7,17 +9,24 @@ const _hydrate_num$forBody = _register("packages/translator/src/__tests__/fixtur
   const num = _scope["num"];
   _queueSource(_scope._, _selected, num);
 }));
-const _num$forBody = /* @__PURE__ */_source("num", [_expr_selected_num$forBody], (_scope, num) => {
-  _data(_scope["#text/1"], num);
-  _queueHydrate(_scope, _hydrate_num$forBody);
+const _num$forBody = /* @__PURE__ */_value("num", (_scope, num, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/1"], num);
+    _queueHydrate(_scope, _hydrate_num$forBody);
+  }
+  _expr_selected_num$forBody(_scope, _dirty);
 });
-const _selected$forBody = /* @__PURE__ */_closure(1, "selected", [_expr_selected_num$forBody]);
+const _selected$forBody = /* @__PURE__ */_closure("selected", (_scope, selected, _dirty) => _expr_selected_num$forBody(_scope, _dirty));
 const _forBody = /* @__PURE__ */_createRenderer("<button> </button>", /* get, next(1), get */" D ", null, [_selected$forBody]);
-const _for = /* @__PURE__ */_loop("#text/0", 1, _forBody, [_num$forBody], (_scope, [num]) => _setSource(_scope, _num$forBody, num), _scope => [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], null]);
-const _selected = /* @__PURE__ */_source("selected", [/* @__PURE__ */_inLoopScope(_selected$forBody, "#text/0")]);
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+  let num;
+  if (_dirty) [num] = _destructure;
+  _num$forBody(_scope, num, _dirty);
+});
+const _selected = /* @__PURE__ */_value("selected", (_scope, selected, _dirty) => _inLoopScope(_scope, _dirty, _selected$forBody, "#text/0"));
 const _setup = _scope => {
-  _setSource(_scope, _selected, 0);
-  _notifySignal(_scope, _for);
+  _selected(_scope, 0);
+  _for(_scope, [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], null]);
 };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
@@ -1,19 +1,27 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, queueHydrate as _queueHydrate, conditional as _conditional, source as _source, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _clickCount$elseBody = /* @__PURE__ */_closure(1, "clickCount", [], (_scope, clickCount) => _data(_scope["#text/0"], clickCount));
+import { on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, queueHydrate as _queueHydrate, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _clickCount$elseBody = /* @__PURE__ */_closure("clickCount", (_scope, clickCount) => _data(_scope["#text/0"], clickCount));
 const _elseBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_2_renderer", /* @__PURE__ */_createRenderer("<span>The button was clicked <!> times.</span>", /* next(1), over(1), replace */"Db%", null, [_clickCount$elseBody]));
 const _hydrate_clickCount$ifBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_1_clickCount", _scope => _on(_scope["#button/0"], "click", function () {
   const clickCount = _scope._["clickCount"];
   _queueSource(_scope._, _clickCount, clickCount + 1);
 }));
-const _clickCount$ifBody = /* @__PURE__ */_closure(1, "clickCount", [], (_scope, clickCount) => {
+const _clickCount$ifBody = /* @__PURE__ */_closure("clickCount", (_scope, clickCount) => {
   _data(_scope["#text/1"], clickCount);
   _queueHydrate(_scope, _hydrate_clickCount$ifBody);
 });
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<button> </button>", /* get, next(1), get */" D ", null, [_clickCount$ifBody]));
-const _if = /* @__PURE__ */_conditional("#text/0", 1, (_scope, clickCount = _scope["clickCount"]) => clickCount < 3 ? _ifBody : _elseBody);
-const _clickCount = /* @__PURE__ */_source("clickCount", [_if, /* @__PURE__ */_inConditionalScope(_clickCount$elseBody, "#text/0"), /* @__PURE__ */_inConditionalScope(_clickCount$ifBody, "#text/0")]);
+const _if = /* @__PURE__ */_conditional("#text/0");
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount, _dirty) => {
+  if (_dirty) {
+    _if_value = clickCount < 3 ? _ifBody : _elseBody;
+  }
+  var _if_value;
+  _if(_scope, _if_value, _dirty);
+  _inConditionalScope(_scope, _dirty, _clickCount$elseBody, "#text/0");
+  _inConditionalScope(_scope, _dirty, _clickCount$ifBody, "#text/0");
+});
 const _setup = _scope => {
-  _setSource(_scope, _clickCount, 0);
+  _clickCount(_scope, 0);
 };
 export const template = "<div><!></div>";
 export const walks = /* next(1), replace, out(1) */"D%l";

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
@@ -1,24 +1,30 @@
-import { on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, queueHydrate as _queueHydrate, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _clickCount$elseBody = /* @__PURE__ */_closure("clickCount", (_scope, clickCount) => _data(_scope["#text/0"], clickCount));
+import { on as _on, queueSource as _queueSource, data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, queueHydrate as _queueHydrate, conditional as _conditional, inConditionalScope as _inConditionalScope, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _clickCount$elseBody = /* @__PURE__ */_closure("clickCount", (_scope, clickCount, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/0"], clickCount);
+  }
+});
 const _elseBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_2_renderer", /* @__PURE__ */_createRenderer("<span>The button was clicked <!> times.</span>", /* next(1), over(1), replace */"Db%", null, [_clickCount$elseBody]));
 const _hydrate_clickCount$ifBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_1_clickCount", _scope => _on(_scope["#button/0"], "click", function () {
   const clickCount = _scope._["clickCount"];
   _queueSource(_scope._, _clickCount, clickCount + 1);
 }));
-const _clickCount$ifBody = /* @__PURE__ */_closure("clickCount", (_scope, clickCount) => {
-  _data(_scope["#text/1"], clickCount);
-  _queueHydrate(_scope, _hydrate_clickCount$ifBody);
+const _clickCount$ifBody = /* @__PURE__ */_closure("clickCount", (_scope, clickCount, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/1"], clickCount);
+    _queueHydrate(_scope, _hydrate_clickCount$ifBody);
+  }
 });
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<button> </button>", /* get, next(1), get */" D ", null, [_clickCount$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/0");
 const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount, _dirty) => {
+  let _if_value;
   if (_dirty) {
     _if_value = clickCount < 3 ? _ifBody : _elseBody;
   }
-  var _if_value;
   _if(_scope, _if_value, _dirty);
-  _inConditionalScope(_scope, _dirty, _clickCount$elseBody, "#text/0");
   _inConditionalScope(_scope, _dirty, _clickCount$ifBody, "#text/0");
+  _inConditionalScope(_scope, _dirty, _clickCount$elseBody, "#text/0");
 });
 const _setup = _scope => {
   _clickCount(_scope, 0);

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
@@ -1,19 +1,13 @@
 import { on as _on, queueSource as _queueSource, data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, queueHydrate as _queueHydrate, conditional as _conditional, inConditionalScope as _inConditionalScope, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _clickCount$elseBody = /* @__PURE__ */_closure("clickCount", (_scope, clickCount, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/0"], clickCount);
-  }
-});
+const _clickCount$elseBody = /* @__PURE__ */_closure("clickCount", (_scope, clickCount) => _data(_scope["#text/0"], clickCount));
 const _elseBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_2_renderer", /* @__PURE__ */_createRenderer("<span>The button was clicked <!> times.</span>", /* next(1), over(1), replace */"Db%", null, [_clickCount$elseBody]));
 const _hydrate_clickCount$ifBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_1_clickCount", _scope => _on(_scope["#button/0"], "click", function () {
   const clickCount = _scope._["clickCount"];
   _queueSource(_scope._, _clickCount, clickCount + 1);
 }));
-const _clickCount$ifBody = /* @__PURE__ */_closure("clickCount", (_scope, clickCount, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/1"], clickCount);
-    _queueHydrate(_scope, _hydrate_clickCount$ifBody);
-  }
+const _clickCount$ifBody = /* @__PURE__ */_closure("clickCount", (_scope, clickCount) => {
+  _data(_scope["#text/1"], clickCount);
+  _queueHydrate(_scope, _hydrate_clickCount$ifBody);
 });
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<button> </button>", /* get, next(1), get */" D ", null, [_clickCount$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/0");

--- a/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
@@ -1,5 +1,5 @@
-import { setSource as _setSource, data as _data, on as _on, queueSource as _queueSource, source as _source, createRenderer as _createRenderer, subscriber as _subscriber, register as _register, queueHydrate as _queueHydrate, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _item$forBody = /* @__PURE__ */_source("item", [], (_scope, item) => _data(_scope["#text/0"], item));
+import { data as _data, on as _on, queueSource as _queueSource, value as _value, createRenderer as _createRenderer, register as _register, queueHydrate as _queueHydrate, intersection as _intersection, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _item$forBody = /* @__PURE__ */_value("item", (_scope, item) => _data(_scope["#text/0"], item));
 const _forBody = /* @__PURE__ */_createRenderer(" ", /* get */" ");
 const _hydrate_expr_id_items = _register("packages/translator/src/__tests__/fixtures/basic-push-pop-list/template.marko_0_id_items", _scope => _on(_scope["#button/1"], "click", function () {
   const id = _scope["id"],
@@ -9,17 +9,31 @@ const _hydrate_expr_id_items = _register("packages/translator/src/__tests__/fixt
   _queueSource(_scope, _id, nextId);
   _queueSource(_scope, _items, [...items, nextId]);
 }));
-const _expr_id_items = /* @__PURE__ */_subscriber([], 2, (_scope, id = _scope["id"], items = _scope["items"]) => _queueHydrate(_scope, _hydrate_expr_id_items));
-const _for = /* @__PURE__ */_loop("#text/0", 1, _forBody, [_item$forBody], (_scope, [item]) => _setSource(_scope, _item$forBody, item), (_scope, items = _scope["items"]) => [items, null]);
+const _expr_id_items = /* @__PURE__ */_intersection(2, _scope => {
+  const id = _scope["id"],
+    items = _scope["items"];
+  _queueHydrate(_scope, _hydrate_expr_id_items);
+});
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+  let item;
+  if (_dirty) [item] = _destructure;
+  _item$forBody(_scope, item, _dirty);
+});
 const _hydrate_items = _register("packages/translator/src/__tests__/fixtures/basic-push-pop-list/template.marko_0_items", _scope => _on(_scope["#button/2"], "click", function () {
   const items = _scope["items"];
   _queueSource(_scope, _items, items.slice(0, -1));
 }));
-const _items = /* @__PURE__ */_source("items", [_for, _expr_id_items], (_scope, items) => _queueHydrate(_scope, _hydrate_items));
-const _id = /* @__PURE__ */_source("id", [_expr_id_items]);
+const _items = /* @__PURE__ */_value("items", (_scope, items, _dirty) => {
+  if (_dirty) {
+    _for(_scope, [items, null]);
+    _queueHydrate(_scope, _hydrate_items);
+  }
+  _expr_id_items(_scope, _dirty);
+});
+const _id = /* @__PURE__ */_value("id", (_scope, id, _dirty) => _expr_id_items(_scope, _dirty));
 const _setup = _scope => {
-  _setSource(_scope, _id, 0);
-  _setSource(_scope, _items, []);
+  _id(_scope, 0);
+  _items(_scope, []);
 };
 export const template = "<div><!><button id=add>Add</button><button id=remove>Remove</button></div>";
 export const walks = /* next(1), replace, over(1), get, over(1), get, out(1) */"D%b b l";

--- a/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
@@ -25,8 +25,8 @@ const _hydrate_items = _register("packages/translator/src/__tests__/fixtures/bas
 }));
 const _items = /* @__PURE__ */_value("items", (_scope, items, _dirty) => {
   if (_dirty) {
-    _for(_scope, [items, null]);
     _queueHydrate(_scope, _hydrate_items);
+    _for(_scope, [items, null]);
   }
   _expr_id_items(_scope, _dirty);
 });

--- a/packages/translator/src/__tests__/fixtures/basic-scriptlet/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-scriptlet/__snapshots__/dom.expected/template.js
@@ -1,15 +1,15 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixtures/basic-scriptlet/template.marko_0_clickCount", _scope => _on(_scope["#button/0"], "click", function () {
   const clickCount = _scope["clickCount"];
   _queueSource(_scope, _clickCount, clickCount + 1);
 }));
-const _clickCount = /* @__PURE__ */_source("clickCount", [], (_scope, clickCount) => {
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => {
   const doubleCount = clickCount * 2;
   _queueHydrate(_scope, _hydrate_clickCount);
 });
 const _setup = _scope => {
-  _setSource(_scope, _clickCount, 0);
   _data(_scope["#text/1"], doubleCount);
+  _clickCount(_scope, 0);
 };
 export const template = "<div><button> </button></div>";
 export const walks = /* next(1), get, next(1), get, out(2) */"D D m";

--- a/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
@@ -11,10 +11,10 @@ const _hydrate_list = _register("packages/translator/src/__tests__/fixtures/basi
   _queueSource(_scope, _list, [].concat(list).reverse());
 }));
 const _list = /* @__PURE__ */_value("list", (_scope, list) => {
+  _queueHydrate(_scope, _hydrate_list);
   _ul_for(_scope, [list, function (x) {
     return x;
   }]);
-  _queueHydrate(_scope, _hydrate_list);
 });
 const _hydrate_open = _register("packages/translator/src/__tests__/fixtures/basic-shared-node-ref/template.marko_0_open", _scope => _on(_scope["#button/1"], "click", function () {
   const open = _scope["open"];

--- a/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
@@ -1,25 +1,32 @@
-import { setSource as _setSource, attr as _attr, data as _data, on as _on, queueSource as _queueSource, source as _source, createRenderer as _createRenderer, loop as _loop, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _x$forBody = /* @__PURE__ */_source("x", [], (_scope, x) => _data(_scope["#text/0"], x));
+import { attr as _attr, data as _data, on as _on, queueSource as _queueSource, value as _value, createRenderer as _createRenderer, loop as _loop, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _x$forBody = /* @__PURE__ */_value("x", (_scope, x) => _data(_scope["#text/0"], x));
 const _forBody = /* @__PURE__ */_createRenderer("<li> </li>", /* next(1), get */"D ");
-const _ul_for = /* @__PURE__ */_loop("#ul/0", 1, _forBody, [_x$forBody], (_scope, [x]) => _setSource(_scope, _x$forBody, x), (_scope, list = _scope["list"]) => [list, function (x) {
-  return x;
-}]);
+const _ul_for = /* @__PURE__ */_loop("#ul/0", _forBody, (_scope, _destructure, _dirty = true) => {
+  let x;
+  if (_dirty) [x] = _destructure;
+  _x$forBody(_scope, x, _dirty);
+});
 const _hydrate_list = _register("packages/translator/src/__tests__/fixtures/basic-shared-node-ref/template.marko_0_list", _scope => _on(_scope["#button/2"], "click", function () {
   const list = _scope["list"];
   _queueSource(_scope, _list, [].concat(list).reverse());
 }));
-const _list = /* @__PURE__ */_source("list", [_ul_for], (_scope, list) => _queueHydrate(_scope, _hydrate_list));
+const _list = /* @__PURE__ */_value("list", (_scope, list) => {
+  _ul_for(_scope, [list, function (x) {
+    return x;
+  }]);
+  _queueHydrate(_scope, _hydrate_list);
+});
 const _hydrate_open = _register("packages/translator/src/__tests__/fixtures/basic-shared-node-ref/template.marko_0_open", _scope => _on(_scope["#button/1"], "click", function () {
   const open = _scope["open"];
   _queueSource(_scope, _open, !open);
 }));
-const _open = /* @__PURE__ */_source("open", [], (_scope, open) => {
+const _open = /* @__PURE__ */_value("open", (_scope, open) => {
   _attr(_scope["#ul/0"], "hidden", !open);
   _queueHydrate(_scope, _hydrate_open);
 });
 const _setup = _scope => {
-  _setSource(_scope, _open, true);
-  _setSource(_scope, _list, [1, 2, 3]);
+  _open(_scope, true);
+  _list(_scope, [1, 2, 3]);
 };
 export const template = "<ul></ul><button id=toggle>Toggle</button><button id=reverse>Reverse</button>";
 export const walks = /* get, over(1), get, over(1), get, over(1) */" b b b";

--- a/packages/translator/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.js
@@ -1,13 +1,16 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, register as _register, conditional as _conditional, source as _source, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-toggle-show/template.marko_1_renderer", /* @__PURE__ */_createRenderer("Hello!", ""));
-const _if = /* @__PURE__ */_conditional("#text/0", 1, (_scope, show = _scope["show"]) => show ? _ifBody : null);
+const _if = /* @__PURE__ */_conditional("#text/0");
 const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/basic-toggle-show/template.marko_0_show", _scope => _on(_scope["#button/1"], "click", function () {
   const show = _scope["show"];
   _queueSource(_scope, _show, !show);
 }));
-const _show = /* @__PURE__ */_source("show", [_if], (_scope, show) => _queueHydrate(_scope, _hydrate_show));
+const _show = /* @__PURE__ */_value("show", (_scope, show) => {
+  _if(_scope, show ? _ifBody : null);
+  _queueHydrate(_scope, _hydrate_show);
+});
 const _setup = _scope => {
-  _setSource(_scope, _show, true);
+  _show(_scope, true);
 };
 export const template = "<div><!><button>Toggle</button></div>";
 export const walks = /* next(1), replace, over(1), get, out(1) */"D%b l";

--- a/packages/translator/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.js
@@ -6,8 +6,8 @@ const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/basi
   _queueSource(_scope, _show, !show);
 }));
 const _show = /* @__PURE__ */_value("show", (_scope, show) => {
-  _if(_scope, show ? _ifBody : null);
   _queueHydrate(_scope, _hydrate_show);
+  _if(_scope, show ? _ifBody : null);
 });
 const _setup = _scope => {
   _show(_scope, true);

--- a/packages/translator/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.js
@@ -1,18 +1,18 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, derivation as _derivation, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixtures/basic-unused-ref/template.marko_0_clickCount", _scope => _on(_scope["#button/0"], "click", function () {
   const clickCount = _scope["clickCount"];
   _queueSource(_scope, _clickCount, clickCount + 1);
 }));
-const _clickCount = /* @__PURE__ */_source("clickCount", [], (_scope, clickCount) => {
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => {
   _data(_scope["#text/1"], clickCount);
   _queueHydrate(_scope, _hydrate_clickCount);
 });
-const _unused_2 = /* @__PURE__ */_derivation("unused_2", 1, [], _scope => 456);
-const _unused_ = /* @__PURE__ */_source("unused_1", []);
+const _unused_2 = (_scope, unused_2) => {};
+const _unused_ = (_scope, unused_1) => {};
 const _setup = _scope => {
-  _setSource(_scope, _unused_, 123);
-  _setSource(_scope, _clickCount, 0);
-  _notifySignal(_scope, _unused_2);
+  _unused_(_scope, 123);
+  _unused_2(_scope, 456);
+  _clickCount(_scope, 0);
 };
 export const template = "<div><button> </button></div>";
 export const walks = /* next(1), get, next(1), get, out(2) */"D D m";

--- a/packages/translator/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
@@ -1,17 +1,24 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, source as _source, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _message$ifBody = /* @__PURE__ */_closure(1, "message", [], (_scope, message) => _data(_scope["#text/0"], message));
+import { on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, value as _value, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _message$ifBody = /* @__PURE__ */_closure("message", (_scope, message) => _data(_scope["#text/0"], message));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/batched-updates-cleanup/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_message$ifBody]));
-const _if = /* @__PURE__ */_conditional("#text/1", 1, (_scope, show = _scope["show"]) => show ? _ifBody : null);
-const _message = /* @__PURE__ */_source("message", [/* @__PURE__ */_inConditionalScope(_message$ifBody, "#text/1")]);
+const _if = /* @__PURE__ */_conditional("#text/1");
+const _message = /* @__PURE__ */_value("message", (_scope, message, _dirty) => _inConditionalScope(_scope, _dirty, _message$ifBody, "#text/1"));
 const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/batched-updates-cleanup/template.marko_0_show", _scope => _on(_scope["#button/0"], "click", function () {
   const show = _scope["show"];
   _queueSource(_scope, _message, "bye");
   _queueSource(_scope, _show, !show);
 }));
-const _show = /* @__PURE__ */_source("show", [_if], (_scope, show) => _queueHydrate(_scope, _hydrate_show));
+const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
+  if (_dirty) {
+    _if_value = show ? _ifBody : null;
+    _queueHydrate(_scope, _hydrate_show);
+  }
+  var _if_value;
+  _if(_scope, _if_value, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _show, true);
-  _setSource(_scope, _message, "hi");
+  _show(_scope, true);
+  _message(_scope, "hi");
 };
 export const template = "<button></button><!>";
 export const walks = /* get, over(1), replace, over(1) */" b%b";

--- a/packages/translator/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
@@ -1,5 +1,9 @@
-import { on as _on, queueSource as _queueSource, data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, value as _value, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _message$ifBody = /* @__PURE__ */_closure("message", (_scope, message) => _data(_scope["#text/0"], message));
+import { on as _on, queueSource as _queueSource, data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, inConditionalScope as _inConditionalScope, value as _value, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _message$ifBody = /* @__PURE__ */_closure("message", (_scope, message, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/0"], message);
+  }
+});
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/batched-updates-cleanup/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_message$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/1");
 const _message = /* @__PURE__ */_value("message", (_scope, message, _dirty) => _inConditionalScope(_scope, _dirty, _message$ifBody, "#text/1"));
@@ -9,11 +13,11 @@ const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/batc
   _queueSource(_scope, _show, !show);
 }));
 const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
+  let _if_value;
   if (_dirty) {
-    _if_value = show ? _ifBody : null;
     _queueHydrate(_scope, _hydrate_show);
+    _if_value = show ? _ifBody : null;
   }
-  var _if_value;
   _if(_scope, _if_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
@@ -1,9 +1,5 @@
 import { on as _on, queueSource as _queueSource, data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, inConditionalScope as _inConditionalScope, value as _value, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _message$ifBody = /* @__PURE__ */_closure("message", (_scope, message, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/0"], message);
-  }
-});
+const _message$ifBody = /* @__PURE__ */_closure("message", (_scope, message) => _data(_scope["#text/0"], message));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/batched-updates-cleanup/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_message$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/1");
 const _message = /* @__PURE__ */_value("message", (_scope, message, _dirty) => _inConditionalScope(_scope, _dirty, _message$ifBody, "#text/1"));

--- a/packages/translator/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.js
@@ -1,19 +1,21 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, subscriber as _subscriber, register as _register, queueHydrate as _queueHydrate, source as _source, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueHydrate as _queueHydrate, intersection as _intersection, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_expr_a_b = _register("packages/translator/src/__tests__/fixtures/batched-updates/template.marko_0_a_b", _scope => _on(_scope["#button/0"], "click", function () {
   const a = _scope["a"],
     b = _scope["b"];
   _queueSource(_scope, _a, a + 1);
   _queueSource(_scope, _b, b + 1);
 }));
-const _expr_a_b = /* @__PURE__ */_subscriber([], 2, (_scope, a = _scope["a"], b = _scope["b"]) => {
+const _expr_a_b = /* @__PURE__ */_intersection(2, _scope => {
+  const a = _scope["a"],
+    b = _scope["b"];
   _data(_scope["#text/1"], a + b);
   _queueHydrate(_scope, _hydrate_expr_a_b);
 });
-const _b = /* @__PURE__ */_source("b", [_expr_a_b]);
-const _a = /* @__PURE__ */_source("a", [_expr_a_b]);
+const _b = /* @__PURE__ */_value("b", (_scope, b, _dirty) => _expr_a_b(_scope, _dirty));
+const _a = /* @__PURE__ */_value("a", (_scope, a, _dirty) => _expr_a_b(_scope, _dirty));
 const _setup = _scope => {
-  _setSource(_scope, _a, 0);
-  _setSource(_scope, _b, 0);
+  _a(_scope, 0);
+  _b(_scope, 0);
 };
 export const template = "<button> </button>";
 export const walks = /* get, next(1), get, out(1) */" D l";

--- a/packages/translator/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/components/display-intersection.js
+++ b/packages/translator/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/components/display-intersection.js
@@ -1,15 +1,21 @@
-import { setSource as _setSource, data as _data, subscriber as _subscriber, source as _source, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _expr_value_dummy = /* @__PURE__ */_subscriber([], 2, (_scope, value = _scope["value"], dummy = _scope["dummy"]) => _data(_scope["#text/0"], (dummy, value)));
-const _dummy = /* @__PURE__ */_source("dummy", [_expr_value_dummy]);
-const _value = /* @__PURE__ */_source("value", [_expr_value_dummy]);
-const _setup = _scope => {
-  _setSource(_scope, _dummy, {});
-};
-export const attrs = /* @__PURE__ */_destructureSources([_value], (_scope, {
-  value
-}) => {
-  _setSource(_scope, _value, value);
+import { data as _data, intersection as _intersection, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _expr_value_dummy = /* @__PURE__ */_intersection(2, _scope => {
+  const value = _scope["value"],
+    dummy = _scope["dummy"];
+  _data(_scope["#text/0"], (dummy, value));
 });
+const _dummy = /* @__PURE__ */_value2("dummy", (_scope, dummy, _dirty) => _expr_value_dummy(_scope, _dirty));
+const _value = /* @__PURE__ */_value2("value", (_scope, value, _dirty) => _expr_value_dummy(_scope, _dirty));
+const _setup = _scope => {
+  _dummy(_scope, {});
+};
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let value;
+  if (_dirty) ({
+    value
+  } = _destructure);
+  _value(_scope, value, _dirty);
+};
 export { _value as _apply_value };
 export const template = "<div> </div>";
 export const walks = /* next(1), get, out(1) */"D l";

--- a/packages/translator/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.js
@@ -5,13 +5,13 @@ const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/com
   _queueSource(_scope, _count, count + 1);
 }));
 const _count = /* @__PURE__ */_value("count", (_scope, count, _dirty) => {
+  let _displayIntersection_attrs_value;
   if (_dirty) {
+    _queueHydrate(_scope, _hydrate_count);
     _displayIntersection_attrs_value = {
       value: count
     };
-    _queueHydrate(_scope, _hydrate_count);
   }
-  var _displayIntersection_attrs_value;
   _displayIntersection_attrs(_scope["#childScope/0"], _displayIntersection_attrs_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.js
@@ -1,18 +1,22 @@
-import { setSource as _setSource, inChild as _inChild, on as _on, queueSource as _queueSource, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _displayIntersection, attrs as _displayIntersection_attrs, template as _displayIntersection_template, walks as _displayIntersection_walks } from "./components/display-intersection.marko";
+import { on as _on, queueSource as _queueSource, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/component-attrs-intersection/template.marko_0_count", _scope => _on(_scope["#button/1"], "click", function () {
   const count = _scope["count"];
   _queueSource(_scope, _count, count + 1);
 }));
-const _count = /* @__PURE__ */_source("count", [_inChild(_displayIntersection_attrs, "#childScope/0")], (_scope, count) => {
-  _setSource(_scope["#childScope/0"], _displayIntersection_attrs, {
-    value: count
-  });
-  _queueHydrate(_scope, _hydrate_count);
+const _count = /* @__PURE__ */_value("count", (_scope, count, _dirty) => {
+  if (_dirty) {
+    _displayIntersection_attrs_value = {
+      value: count
+    };
+    _queueHydrate(_scope, _hydrate_count);
+  }
+  var _displayIntersection_attrs_value;
+  _displayIntersection_attrs(_scope["#childScope/0"], _displayIntersection_attrs_value, _dirty);
 });
 const _setup = _scope => {
-  _setSource(_scope, _count, 0);
   _displayIntersection(_scope["#childScope/0"]);
+  _count(_scope, 0);
 };
 export const template = `${_displayIntersection_template}<button></button>`;
 export const walks = /* beginChild, _displayIntersection_walks, endChild, get, over(1) */`/${_displayIntersection_walks}& b`;

--- a/packages/translator/src/__tests__/fixtures/const-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/const-tag/__snapshots__/dom.expected/template.js
@@ -1,9 +1,9 @@
-import { data as _data, derivation as _derivation, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _y = /* @__PURE__ */_derivation("y", 1, [], _scope => 1, (_scope, y) => _data(_scope["#text/1"], y));
-const _x = /* @__PURE__ */_derivation("x", 1, [], _scope => 1, (_scope, x) => _data(_scope["#text/0"], x));
+import { data as _data, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _y = /* @__PURE__ */_value("y", (_scope, y) => _data(_scope["#text/1"], y));
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _data(_scope["#text/0"], x));
 const _setup = _scope => {
-  _notifySignal(_scope, _x);
-  _notifySignal(_scope, _y);
+  _x(_scope, 1);
+  _y(_scope, 1);
 };
 export const template = "<div> </div><!>";
 export const walks = /* next(1), get, out(1), replace, over(1) */"D l%b";

--- a/packages/translator/src/__tests__/fixtures/context-tag-derivation/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-derivation/__snapshots__/dom.expected/components/child.js
@@ -1,6 +1,6 @@
-import { data as _data, derivation as _derivation, contextClosure as _contextClosure, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _y = /* @__PURE__ */_derivation("y", 1, [], (_scope, x = _scope["x"]) => x, (_scope, y) => _data(_scope["#text/0"], y));
-const _x = _contextClosure("x", "packages/translator/src/__tests__/fixtures/context-tag-derivation/template.marko", [_y]);
+import { data as _data, value as _value, contextClosure as _contextClosure, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _y = /* @__PURE__ */_value("y", (_scope, y) => _data(_scope["#text/0"], y));
+const _x = /* @__PURE__ */_contextClosure("x", "packages/translator/src/__tests__/fixtures/context-tag-derivation/template.marko", (_scope, x) => _y(_scope, x));
 export const template = "<div> </div>";
 export const walks = /* next(1), get, out(1) */"D l";
 export const setup = function () {};

--- a/packages/translator/src/__tests__/fixtures/context-tag-derivation/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-derivation/__snapshots__/dom.expected/template.js
@@ -1,13 +1,13 @@
-import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, inChildMany as _inChildMany, createRenderer as _createRenderer, derivation as _derivation, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, childClosures as _childClosures, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _child, template as _child_template, walks as _child_walks, closures as _child_closures } from "./components/child.marko";
 const _setup$putBody = _scope => {
   _child(_scope["#childScope/0"]);
 };
-const _putBody = /* @__PURE__ */_createRenderer(`${_child_template}`, /* beginChild, _child_walks, endChild */`/${_child_walks}&`, _setup$putBody, [_inChildMany(_child_closures, "#childScope/0")]);
-const _put = /* @__PURE__ */_derivation("0:", 1, [_dynamicSubscribers("0:")], _scope => 123);
+const _putBody = /* @__PURE__ */_createRenderer(`${_child_template}`, /* beginChild, _child_walks, endChild */`/${_child_walks}&`, _setup$putBody, [_childClosures(_child_closures, "#childScope/0")]);
+const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
 const _setup = _scope => {
   _initContextProvider(_scope, "#text/0", "0:", "packages/translator/src/__tests__/fixtures/context-tag-derivation/template.marko", _putBody);
-  _notifySignal(_scope, _put);
+  _put(_scope, 123);
 };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-global/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-global/__snapshots__/dom.expected/template.js
@@ -1,5 +1,5 @@
 import { data as _data, contextClosure as _contextClosure, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _x = _contextClosure("x", "$", [], (_scope, x) => _data(_scope["#text/0"], x));
+const _x = /* @__PURE__ */_contextClosure("x", "$", (_scope, x) => _data(_scope["#text/0"], x));
 export const template = "<div><span> </span></div>";
 export const walks = /* next(2), get, out(2) */"E m";
 export const setup = function () {};

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-relative-path/__snapshots__/dom.expected/other.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-relative-path/__snapshots__/dom.expected/other.js
@@ -1,9 +1,7 @@
-import { conditional as _conditional, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", 1, (_scope, input = _scope["input"]) => input.renderBody);
-const _input = /* @__PURE__ */_source("input", [_dynamicTagName]);
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+import { conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0");
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.renderBody));
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<set value=hello><!></set>";
 export const walks = /* next(1), replace, out(1) */"D%l";

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-self/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-self/__snapshots__/dom.expected/template.js
@@ -1,10 +1,10 @@
-import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, data as _data, contextClosure as _contextClosure, createRenderer as _createRenderer, derivation as _derivation, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _x$putBody = _contextClosure("x", "packages/translator/src/__tests__/fixtures/context-tag-from-self/template.marko", [], (_scope, x) => _data(_scope["#text/0"], x));
+import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, data as _data, contextClosure as _contextClosure, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _x$putBody = /* @__PURE__ */_contextClosure("x", "packages/translator/src/__tests__/fixtures/context-tag-from-self/template.marko", (_scope, x) => _data(_scope["#text/0"], x));
 const _putBody = /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_x$putBody]);
-const _put = /* @__PURE__ */_derivation("0:", 1, [_dynamicSubscribers("0:")], _scope => 1);
+const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
 const _setup = _scope => {
   _initContextProvider(_scope, "#text/0", "0:", "packages/translator/src/__tests__/fixtures/context-tag-from-self/template.marko", _putBody);
-  _notifySignal(_scope, _put);
+  _put(_scope, 1);
 };
 export const template = "<div><!></div>";
 export const walks = /* next(1), replace, out(1) */"D%l";

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected/components/other.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected/components/other.js
@@ -1,16 +1,14 @@
-import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, conditional as _conditional, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, derivation as _derivation, source as _source, notifySignal as _notifySignal, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _dynamicTagName$putBody = /* @__PURE__ */_conditional("#text/0", 1, (_scope, input = _scope._["input"]) => input.renderBody);
-const _input$putBody = _dynamicClosure(1, "input", [_dynamicTagName$putBody]);
+import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, conditional as _conditional, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _dynamicTagName$putBody = /* @__PURE__ */_conditional("#text/0");
+const _input$putBody = /* @__PURE__ */_dynamicClosure("input", (_scope, input) => _dynamicTagName$putBody(_scope, input.renderBody));
 const _putBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_input$putBody]);
-const _put = /* @__PURE__ */_derivation("0:", 1, [_dynamicSubscribers("0:")], _scope => "Hello");
-const _input = /* @__PURE__ */_source("input", [_dynamicSubscribers("input")]);
+const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
+const _input = /* @__PURE__ */_value("input", (_scope, input, _dirty) => _dynamicSubscribers(_scope["input*"], _dirty));
 const _setup = _scope => {
   _initContextProvider(_scope, "#text/0", "0:", "packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/components/other.marko", _putBody);
-  _notifySignal(_scope, _put);
+  _put(_scope, "Hello");
 };
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected/components/other.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected/components/other.js
@@ -1,10 +1,6 @@
 import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, conditional as _conditional, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _dynamicTagName$putBody = /* @__PURE__ */_conditional("#text/0");
-const _input$putBody = /* @__PURE__ */_dynamicClosure("input", (_scope, input, _dirty) => {
-  if (_dirty) {
-    _dynamicTagName$putBody(_scope, input.renderBody);
-  }
-});
+const _input$putBody = /* @__PURE__ */_dynamicClosure("input", (_scope, input) => _dynamicTagName$putBody(_scope, input.renderBody));
 const _putBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_input$putBody]);
 const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
 const _input = /* @__PURE__ */_value("input", (_scope, input, _dirty) => _dynamicSubscribers(_scope["input*"], _dirty));

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected/components/other.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected/components/other.js
@@ -1,6 +1,10 @@
 import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, conditional as _conditional, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _dynamicTagName$putBody = /* @__PURE__ */_conditional("#text/0");
-const _input$putBody = /* @__PURE__ */_dynamicClosure("input", (_scope, input) => _dynamicTagName$putBody(_scope, input.renderBody));
+const _input$putBody = /* @__PURE__ */_dynamicClosure("input", (_scope, input, _dirty) => {
+  if (_dirty) {
+    _dynamicTagName$putBody(_scope, input.renderBody);
+  }
+});
 const _putBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_input$putBody]);
 const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
 const _input = /* @__PURE__ */_value("input", (_scope, input, _dirty) => _dynamicSubscribers(_scope["input*"], _dirty));

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected/template.js
@@ -1,14 +1,12 @@
-import { data as _data, bindRenderer as _bindRenderer, inChild as _inChild, setSource as _setSource, contextClosure as _contextClosure, createRenderer as _createRenderer, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { data as _data, bindRenderer as _bindRenderer, contextClosure as _contextClosure, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _other, attrs as _other_attrs, template as _other_template, walks as _other_walks } from "./components/other.marko";
-const _other_attrs_inChild = _inChild(_other_attrs, "#childScope/0");
-const _message$otherBody = _contextClosure("message", "packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/components/other.marko", [], (_scope, message) => _data(_scope["#text/0"], message));
+const _message$otherBody = /* @__PURE__ */_contextClosure("message", "packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/components/other.marko", (_scope, message) => _data(_scope["#text/0"], message));
 const _otherBody = /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_message$otherBody]);
 const _setup = _scope => {
   _other(_scope["#childScope/0"]);
-  _setSource(_scope["#childScope/0"], _other_attrs, {
+  _other_attrs(_scope["#childScope/0"], {
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _otherBody)
   });
-  _notifySignal(_scope, _other_attrs_inChild);
 };
 export const template = `${_other_template}`;
 export const walks = /* beginChild, _other_walks, endChild */`/${_other_walks}&`;

--- a/packages/translator/src/__tests__/fixtures/context-tag-in-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-in-if/__snapshots__/dom.expected/template.js
@@ -3,10 +3,10 @@ const _x$ifBody = /* @__PURE__ */_contextClosure("x", "packages/translator/src/_
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/context-tag-in-if/template.marko_2_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_x$ifBody]));
 const _if$putBody = /* @__PURE__ */_conditional("#text/0");
 const _show$putBody = /* @__PURE__ */_dynamicClosure("show", (_scope, show, _dirty) => {
+  let _if$putBody_value;
   if (_dirty) {
     _if$putBody_value = show ? _ifBody : null;
   }
-  var _if$putBody_value;
   _if$putBody(_scope, _if$putBody_value, _dirty);
 });
 const _putBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_show$putBody]);

--- a/packages/translator/src/__tests__/fixtures/context-tag-in-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-in-if/__snapshots__/dom.expected/template.js
@@ -1,19 +1,30 @@
-import { setSource as _setSource, dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, data as _data, on as _on, queueSource as _queueSource, contextClosure as _contextClosure, createRenderer as _createRenderer, register as _register, conditional as _conditional, dynamicClosure as _dynamicClosure, derivation as _derivation, source as _source, queueHydrate as _queueHydrate, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _x$ifBody = _contextClosure("x", "packages/translator/src/__tests__/fixtures/context-tag-in-if/template.marko", [], (_scope, x) => _data(_scope["#text/0"], x));
+import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, data as _data, on as _on, queueSource as _queueSource, contextClosure as _contextClosure, createRenderer as _createRenderer, register as _register, conditional as _conditional, dynamicClosure as _dynamicClosure, value as _value, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _x$ifBody = /* @__PURE__ */_contextClosure("x", "packages/translator/src/__tests__/fixtures/context-tag-in-if/template.marko", (_scope, x) => _data(_scope["#text/0"], x));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/context-tag-in-if/template.marko_2_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_x$ifBody]));
-const _if$putBody = /* @__PURE__ */_conditional("#text/0", 1, (_scope, show = _scope._["show"]) => show ? _ifBody : null);
-const _show$putBody = _dynamicClosure(1, "show", [_if$putBody]);
+const _if$putBody = /* @__PURE__ */_conditional("#text/0");
+const _show$putBody = /* @__PURE__ */_dynamicClosure("show", (_scope, show, _dirty) => {
+  if (_dirty) {
+    _if$putBody_value = show ? _ifBody : null;
+  }
+  var _if$putBody_value;
+  _if$putBody(_scope, _if$putBody_value, _dirty);
+});
 const _putBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_show$putBody]);
-const _put = /* @__PURE__ */_derivation("0:", 1, [_dynamicSubscribers("0:")], _scope => 123);
+const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
 const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/context-tag-in-if/template.marko_0_show", _scope => _on(_scope["#button/1"], "click", function () {
   const show = _scope["show"];
   _queueSource(_scope, _show, !show);
 }));
-const _show = /* @__PURE__ */_source("show", [_dynamicSubscribers("show")], (_scope, show) => _queueHydrate(_scope, _hydrate_show));
+const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
+  if (_dirty) {
+    _queueHydrate(_scope, _hydrate_show);
+  }
+  _dynamicSubscribers(_scope["show*"], _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _show, true);
   _initContextProvider(_scope, "#text/0", "0:", "packages/translator/src/__tests__/fixtures/context-tag-in-if/template.marko", _putBody);
-  _notifySignal(_scope, _put);
+  _show(_scope, true);
+  _put(_scope, 123);
 };
 export const template = "<div><!><button id=toggle>Toggle</button></div>";
 export const walks = /* next(1), replace, over(1), get, out(1) */"D%b l";

--- a/packages/translator/src/__tests__/fixtures/context-tag-reactive/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-reactive/__snapshots__/dom.expected/components/child.js
@@ -1,5 +1,5 @@
 import { data as _data, contextClosure as _contextClosure, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _x = _contextClosure("x", "packages/translator/src/__tests__/fixtures/context-tag-reactive/template.marko", [], (_scope, x) => _data(_scope["#text/0"], x));
+const _x = /* @__PURE__ */_contextClosure("x", "packages/translator/src/__tests__/fixtures/context-tag-reactive/template.marko", (_scope, x) => _data(_scope["#text/0"], x));
 export const template = "<div> </div>";
 export const walks = /* next(1), get, out(1) */"D l";
 export const setup = function () {};

--- a/packages/translator/src/__tests__/fixtures/context-tag-reactive/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-reactive/__snapshots__/dom.expected/template.js
@@ -1,21 +1,26 @@
-import { setSource as _setSource, dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, inChildMany as _inChildMany, on as _on, queueSource as _queueSource, data as _data, createRenderer as _createRenderer, derivation as _derivation, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, childClosures as _childClosures, on as _on, queueSource as _queueSource, data as _data, createRenderer as _createRenderer, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _child, template as _child_template, walks as _child_walks, closures as _child_closures } from "./components/child.marko";
 const _setup$putBody = _scope => {
   _child(_scope["#childScope/0"]);
 };
-const _putBody = /* @__PURE__ */_createRenderer(`${_child_template}`, /* beginChild, _child_walks, endChild */`/${_child_walks}&`, _setup$putBody, [_inChildMany(_child_closures, "#childScope/0")]);
-const _put = /* @__PURE__ */_derivation("0:", 1, [_dynamicSubscribers("0:")], (_scope, x = _scope["x"]) => x);
+const _putBody = /* @__PURE__ */_createRenderer(`${_child_template}`, /* beginChild, _child_walks, endChild */`/${_child_walks}&`, _setup$putBody, [_childClosures(_child_closures, "#childScope/0")]);
+const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
 const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/context-tag-reactive/template.marko_0_x", _scope => _on(_scope["#button/1"], "click", function () {
   const x = _scope["x"];
   _queueSource(_scope, _x, x + 1);
 }));
-const _x = /* @__PURE__ */_source("x", [_put], (_scope, x) => {
-  _data(_scope["#text/2"], x);
-  _queueHydrate(_scope, _hydrate_x);
+const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/2"], x);
+    _put_value = x;
+    _queueHydrate(_scope, _hydrate_x);
+  }
+  var _put_value;
+  _put(_scope, _put_value, _dirty);
 });
 const _setup = _scope => {
-  _setSource(_scope, _x, 123);
   _initContextProvider(_scope, "#text/0", "0:", "packages/translator/src/__tests__/fixtures/context-tag-reactive/template.marko", _putBody);
+  _x(_scope, 123);
 };
 export const template = "<!><button id=increment> </button>";
 export const walks = /* replace, over(1), get, next(1), get, out(1) */"%b D l";

--- a/packages/translator/src/__tests__/fixtures/context-tag-reactive/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-reactive/__snapshots__/dom.expected/template.js
@@ -10,12 +10,12 @@ const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/context
   _queueSource(_scope, _x, x + 1);
 }));
 const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  let _put_value;
   if (_dirty) {
     _data(_scope["#text/2"], x);
-    _put_value = x;
     _queueHydrate(_scope, _hydrate_x);
+    _put_value = x;
   }
-  var _put_value;
   _put(_scope, _put_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/context-tag-static/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-static/__snapshots__/dom.expected/components/child.js
@@ -1,5 +1,5 @@
 import { data as _data, contextClosure as _contextClosure, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _x = _contextClosure("x", "packages/translator/src/__tests__/fixtures/context-tag-static/template.marko", [], (_scope, x) => _data(_scope["#text/0"], x));
+const _x = /* @__PURE__ */_contextClosure("x", "packages/translator/src/__tests__/fixtures/context-tag-static/template.marko", (_scope, x) => _data(_scope["#text/0"], x));
 export const template = "<div> </div>";
 export const walks = /* next(1), get, out(1) */"D l";
 export const setup = function () {};

--- a/packages/translator/src/__tests__/fixtures/context-tag-static/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-static/__snapshots__/dom.expected/template.js
@@ -1,13 +1,13 @@
-import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, inChildMany as _inChildMany, createRenderer as _createRenderer, derivation as _derivation, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, childClosures as _childClosures, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _child, template as _child_template, walks as _child_walks, closures as _child_closures } from "./components/child.marko";
 const _setup$putBody = _scope => {
   _child(_scope["#childScope/0"]);
 };
-const _putBody = /* @__PURE__ */_createRenderer(`${_child_template}`, /* beginChild, _child_walks, endChild */`/${_child_walks}&`, _setup$putBody, [_inChildMany(_child_closures, "#childScope/0")]);
-const _put = /* @__PURE__ */_derivation("0:", 1, [_dynamicSubscribers("0:")], _scope => 123);
+const _putBody = /* @__PURE__ */_createRenderer(`${_child_template}`, /* beginChild, _child_walks, endChild */`/${_child_walks}&`, _setup$putBody, [_childClosures(_child_closures, "#childScope/0")]);
+const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
 const _setup = _scope => {
   _initContextProvider(_scope, "#text/0", "0:", "packages/translator/src/__tests__/fixtures/context-tag-static/template.marko", _putBody);
-  _notifySignal(_scope, _put);
+  _put(_scope, 123);
 };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator/src/__tests__/fixtures/counter-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/counter-intersection/__snapshots__/dom.expected/template.js
@@ -25,9 +25,9 @@ const _hydrate_setup = _register("packages/translator/src/__tests__/fixtures/cou
   });
 });
 const _setup = _scope => {
+  _queueHydrate(_scope, _hydrate_setup);
   _a(_scope, 0);
   _b(_scope, 0);
-  _queueHydrate(_scope, _hydrate_setup);
 };
 export const template = "<div><button class=a> </button> + <button class=b> </button> = <!></div>";
 export const walks = /* next(1), get, next(1), get, out(1), over(1), get, next(1), get, out(1), over(1), replace, out(1) */"D D lb D lb%l";

--- a/packages/translator/src/__tests__/fixtures/counter-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/counter-intersection/__snapshots__/dom.expected/template.js
@@ -1,7 +1,21 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, subscriber as _subscriber, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _expr_a_b = /* @__PURE__ */_subscriber([], 2, (_scope, a = _scope["a"], b = _scope["b"]) => _data(_scope["#text/4"], a + b));
-const _b = /* @__PURE__ */_source("b", [_expr_a_b], (_scope, b) => _data(_scope["#text/3"], b));
-const _a = /* @__PURE__ */_source("a", [_expr_a_b], (_scope, a) => _data(_scope["#text/1"], a));
+import { on as _on, queueSource as _queueSource, data as _data, intersection as _intersection, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _expr_a_b = /* @__PURE__ */_intersection(2, _scope => {
+  const a = _scope["a"],
+    b = _scope["b"];
+  _data(_scope["#text/4"], a + b);
+});
+const _b = /* @__PURE__ */_value("b", (_scope, b, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/3"], b);
+  }
+  _expr_a_b(_scope, _dirty);
+});
+const _a = /* @__PURE__ */_value("a", (_scope, a, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/1"], a);
+  }
+  _expr_a_b(_scope, _dirty);
+});
 const _hydrate_setup = _register("packages/translator/src/__tests__/fixtures/counter-intersection/template.marko_0", _scope => {
   _on(_scope["#button/0"], "click", function () {
     _queueSource(_scope, _a, 10);
@@ -11,8 +25,8 @@ const _hydrate_setup = _register("packages/translator/src/__tests__/fixtures/cou
   });
 });
 const _setup = _scope => {
-  _setSource(_scope, _a, 0);
-  _setSource(_scope, _b, 0);
+  _a(_scope, 0);
+  _b(_scope, 0);
   _queueHydrate(_scope, _hydrate_setup);
 };
 export const template = "<div><button class=a> </button> + <button class=b> </button> = <!></div>";

--- a/packages/translator/src/__tests__/fixtures/create-and-clear-rows-loop-from/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/create-and-clear-rows-loop-from/__snapshots__/dom.expected/template.js
@@ -1,11 +1,13 @@
-import { data as _data, computeLoopToFrom as _computeLoopToFrom, source as _source, createRenderer as _createRenderer, setSource as _setSource, loop as _loop, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _n$forBody = /* @__PURE__ */_source("n", [], (_scope, n) => _data(_scope["#text/0"], n));
+import { data as _data, computeLoopToFrom as _computeLoopToFrom, value as _value, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _n$forBody = /* @__PURE__ */_value("n", (_scope, n) => _data(_scope["#text/0"], n));
 const _forBody = /* @__PURE__ */_createRenderer("<!>, ", /* replace */"%");
-const _for = /* @__PURE__ */_loop("#div/0", 1, _forBody, [_n$forBody], (_scope, [n]) => _setSource(_scope, _n$forBody, n), (_scope, input = _scope["input"]) => _computeLoopToFrom(input.to, input.from, input.step));
-const _input = /* @__PURE__ */_source("input", [_for]);
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
+const _for = /* @__PURE__ */_loop("#div/0", _forBody, (_scope, _destructure, _dirty = true) => {
+  let n;
+  if (_dirty) [n] = _destructure;
+  _n$forBody(_scope, n, _dirty);
 });
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _for(_scope, _computeLoopToFrom(input.to, input.from, input.step)));
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<div></div>";
 export const walks = /* get, over(1) */" b";

--- a/packages/translator/src/__tests__/fixtures/create-and-clear-rows-loop-in/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/create-and-clear-rows-loop-in/__snapshots__/dom.expected/template.js
@@ -1,18 +1,25 @@
-import { data as _data, computeLoopIn as _computeLoopIn, source as _source, createRenderer as _createRenderer, setSource as _setSource, loop as _loop, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _key$forBody2 = /* @__PURE__ */_source("key", [], (_scope, key) => _data(_scope["#text/0"], key));
+import { data as _data, computeLoopIn as _computeLoopIn, value as _value, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _key$forBody2 = /* @__PURE__ */_value("key", (_scope, key) => _data(_scope["#text/0"], key));
 const _forBody2 = /* @__PURE__ */_createRenderer("<p> </p>", /* next(1), get */"D ");
-const _text$forBody = /* @__PURE__ */_source("text", [], (_scope, text) => _data(_scope["#text/1"], text));
-const _key$forBody = /* @__PURE__ */_source("key", [], (_scope, key) => _data(_scope["#text/0"], key));
+const _text$forBody = /* @__PURE__ */_value("text", (_scope, text) => _data(_scope["#text/1"], text));
+const _key$forBody = /* @__PURE__ */_value("key", (_scope, key) => _data(_scope["#text/0"], key));
 const _forBody = /* @__PURE__ */_createRenderer("<p><!>: <!></p>", /* next(1), replace, over(2), replace */"D%c%");
-const _for2 = /* @__PURE__ */_loop("#text/1", 1, _forBody2, [_key$forBody2], (_scope, [[key]]) => _setSource(_scope, _key$forBody2, key), (_scope, input = _scope["input"]) => _computeLoopIn(input.children));
-const _for = /* @__PURE__ */_loop("#text/0", 1, _forBody, [_key$forBody, _text$forBody], (_scope, [[key, text]]) => {
-  _setSource(_scope, _key$forBody, key);
-  _setSource(_scope, _text$forBody, text);
-}, (_scope, input = _scope["input"]) => _computeLoopIn(input.children));
-const _input = /* @__PURE__ */_source("input", [_for, _for2]);
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
+const _for2 = /* @__PURE__ */_loop("#text/1", _forBody2, (_scope, _destructure2, _dirty = true) => {
+  let key;
+  if (_dirty) [[key]] = _destructure2;
+  _key$forBody2(_scope, key, _dirty);
 });
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+  let key, text;
+  if (_dirty) [[key, text]] = _destructure;
+  _key$forBody(_scope, key, _dirty);
+  _text$forBody(_scope, text, _dirty);
+});
+const _input = /* @__PURE__ */_value("input", (_scope, input) => {
+  _for(_scope, _computeLoopIn(input.children));
+  _for2(_scope, _computeLoopIn(input.children));
+});
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<div><!><!></div>";
 export const walks = /* next(1), replace, over(1), replace, out(1) */"D%b%l";

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/components/child.js
@@ -1,9 +1,7 @@
-import { data as _data, derivation as _derivation, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _value = /* @__PURE__ */_derivation("value", 1, [], (_scope, input = _scope["input"]) => input.value, (_scope, value) => _data(_scope["#text/0"], value));
-const _input = /* @__PURE__ */_source("input", [_value]);
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+import { data as _data, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _value = /* @__PURE__ */_value2("value", (_scope, value) => _data(_scope["#text/0"], value));
+const _input = /* @__PURE__ */_value2("input", (_scope, input) => _value(_scope, input.value));
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<!> ";
 export const walks = /* replace, over(2) */"%c";

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/template.js
@@ -1,17 +1,21 @@
-import { setSource as _setSource, inChild as _inChild, source as _source, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _child, attrs as _child_attrs, template as _child_template, walks as _child_walks } from "./components/child.marko";
-const _child_attrs_inChild = _inChild(_child_attrs, "#childScope/0");
-const _x = /* @__PURE__ */_source("x", [_inChild(_child_attrs, "#childScope/1")], (_scope, x) => _setSource(_scope["#childScope/1"], _child_attrs, {
-  value: x
-}));
+import { value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  if (_dirty) {
+    _child_attrs_value = {
+      value: x
+    };
+  }
+  var _child_attrs_value;
+  _child_attrs(_scope["#childScope/1"], _child_attrs_value, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _x, "y");
   _child(_scope["#childScope/0"]);
-  _setSource(_scope["#childScope/0"], _child_attrs, {
+  _child(_scope["#childScope/1"]);
+  _x(_scope, "y");
+  _child_attrs(_scope["#childScope/0"], {
     value: 3
   });
-  _child(_scope["#childScope/1"]);
-  _notifySignal(_scope, _child_attrs_inChild);
 };
 export const template = `${_child_template}${_child_template}`;
 export const walks = /* beginChild, _child_walks, endChild, beginChild, _child_walks, endChild */`/${_child_walks}&/${_child_walks}&`;

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/template.js
@@ -1,12 +1,12 @@
 import { setup as _child, attrs as _child_attrs, template as _child_template, walks as _child_walks } from "./components/child.marko";
 import { value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  let _child_attrs_value;
   if (_dirty) {
     _child_attrs_value = {
       value: x
     };
   }
-  var _child_attrs_value;
   _child_attrs(_scope["#childScope/1"], _child_attrs_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/components/child/index.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/components/child/index.js
@@ -1,9 +1,7 @@
-import { conditional as _conditional, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", 1, (_scope, input = _scope["input"]) => input.renderBody);
-const _input = /* @__PURE__ */_source("input", [_dynamicTagName]);
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+import { conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0");
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.renderBody));
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/template.js
@@ -1,14 +1,12 @@
 import { setup as _child, attrs as _child_attrs, template as _child_template, walks as _child_walks } from "./components/child/index.marko";
-import { bindRenderer as _bindRenderer, inChild as _inChild, setSource as _setSource, createRenderer as _createRenderer, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _child_attrs_inChild = _inChild(_child_attrs, "#childScope/0");
+import { bindRenderer as _bindRenderer, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _childBody = /* @__PURE__ */_createRenderer("This is the body content", "");
 const _setup = _scope => {
   _child(_scope["#childScope/0"]);
-  _setSource(_scope["#childScope/0"], _child_attrs, {
+  _child_attrs(_scope["#childScope/0"], {
     name: "World",
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _childBody)
   });
-  _notifySignal(_scope, _child_attrs_inChild);
 };
 export const template = `${_child_template}`;
 export const walks = /* beginChild, _child_walks, endChild */`/${_child_walks}&`;

--- a/packages/translator/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.expected/hello.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.expected/hello.js
@@ -1,8 +1,6 @@
-import { data as _data, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _input = /* @__PURE__ */_source("input", [], (_scope, input) => _data(_scope["#text/0"], input.name));
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+import { data as _data, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _data(_scope["#text/0"], input.name));
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "Hello <!>!";
 export const walks = /* over(1), replace, over(2) */"b%c";

--- a/packages/translator/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.expected/template.js
@@ -1,14 +1,12 @@
 import { setup as _hello, attrs as _hello_attrs, template as _hello_template, walks as _hello_walks } from "./hello.marko";
-import { inChild as _inChild, setSource as _setSource, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _hello_attrs_inChild = _inChild(_hello_attrs, "#childScope/0");
 const _setup = _scope => {
   _hello(_scope["#childScope/0"]);
-  _setSource(_scope["#childScope/0"], _hello_attrs, {
+  _hello_attrs(_scope["#childScope/0"], {
     name: "Frank"
   });
-  _notifySignal(_scope, _hello_attrs_inChild);
 };
 export const template = `${_hello_template}`;
 export const walks = /* beginChild, _hello_walks, endChild */`/${_hello_walks}&`;
 export const setup = _setup;
+import { createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 export default /* @__PURE__ */_createRenderFn(template, walks, setup, null, null, "packages/translator/src/__tests__/fixtures/custom-tag-template/template.marko");

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/components/child.js
@@ -1,9 +1,9 @@
 import { tagVarSignal as _tagVarSignal, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  let _tagVarSignal_value;
   if (_dirty) {
     _tagVarSignal_value = x + 3;
   }
-  var _tagVarSignal_value;
   _tagVarSignal(_scope, _tagVarSignal_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/components/child.js
@@ -1,7 +1,13 @@
-import { setSource as _setSource, tagVarSignal as _tagVarSignal, source as _source, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _x = /* @__PURE__ */_source("x", [_tagVarSignal], (_scope, x) => _setSource(_scope, _tagVarSignal, x + 3));
+import { tagVarSignal as _tagVarSignal, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  if (_dirty) {
+    _tagVarSignal_value = x + 3;
+  }
+  var _tagVarSignal_value;
+  _tagVarSignal(_scope, _tagVarSignal_value, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _x, 1);
+  _x(_scope, 1);
 };
 export const template = "<span>child</span>";
 export const walks = /* over(1) */"b";

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/template.js
@@ -1,6 +1,6 @@
 import { setup as _child, template as _child_template, walks as _child_walks } from "./components/child.marko";
-import { setTagVar as _setTagVar, data as _data2, source as _source, register as _register, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _data = _register("packages/translator/src/__tests__/fixtures/custom-tag-var-expression/template.marko_0_data", /* @__PURE__ */_source("data", [], (_scope, data) => {
+import { setTagVar as _setTagVar, data as _data2, value as _value, register as _register, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _data = _register("packages/translator/src/__tests__/fixtures/custom-tag-var-expression/template.marko_0_data", /* @__PURE__ */_value("data", (_scope, data) => {
   _data2(_scope["#text/1"], data);
 }));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/components/child.js
@@ -1,11 +1,11 @@
 import { tagVarSignal as _tagVarSignal, intersection as _intersection, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _expr_x_y = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
+  let _tagVarSignal_value;
   if (_dirty) {
     const x = _scope["x"],
       y = _scope["y"];
     _tagVarSignal_value = x + y;
   }
-  var _tagVarSignal_value;
   _tagVarSignal(_scope, _tagVarSignal_value, _dirty);
 });
 const _y = /* @__PURE__ */_value("y", (_scope, y, _dirty) => _expr_x_y(_scope, _dirty));

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/components/child.js
@@ -1,10 +1,18 @@
-import { setSource as _setSource, tagVarSignal as _tagVarSignal, subscriber as _subscriber, source as _source, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _expr_x_y = /* @__PURE__ */_subscriber([_tagVarSignal], 2, (_scope, x = _scope["x"], y = _scope["y"]) => _setSource(_scope, _tagVarSignal, x + y));
-const _y = /* @__PURE__ */_source("y", [_expr_x_y]);
-const _x = /* @__PURE__ */_source("x", [_expr_x_y]);
+import { tagVarSignal as _tagVarSignal, intersection as _intersection, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _expr_x_y = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
+  if (_dirty) {
+    const x = _scope["x"],
+      y = _scope["y"];
+    _tagVarSignal_value = x + y;
+  }
+  var _tagVarSignal_value;
+  _tagVarSignal(_scope, _tagVarSignal_value, _dirty);
+});
+const _y = /* @__PURE__ */_value("y", (_scope, y, _dirty) => _expr_x_y(_scope, _dirty));
+const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => _expr_x_y(_scope, _dirty));
 const _setup = _scope => {
-  _setSource(_scope, _x, 1);
-  _setSource(_scope, _y, 2);
+  _x(_scope, 1);
+  _y(_scope, 2);
 };
 export const template = "<span>child</span>";
 export const walks = /* over(1) */"b";

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/template.js
@@ -1,6 +1,6 @@
 import { setup as _child, template as _child_template, walks as _child_walks } from "./components/child.marko";
-import { setTagVar as _setTagVar, data as _data2, source as _source, register as _register, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _data = _register("packages/translator/src/__tests__/fixtures/custom-tag-var-multiple/template.marko_0_data", /* @__PURE__ */_source("data", [], (_scope, data) => {
+import { setTagVar as _setTagVar, data as _data2, value as _value, register as _register, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _data = _register("packages/translator/src/__tests__/fixtures/custom-tag-var-multiple/template.marko_0_data", /* @__PURE__ */_value("data", (_scope, data) => {
   _data2(_scope["#text/1"], data);
 }));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/components/child.js
@@ -1,15 +1,19 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, tagVarSignal as _tagVarSignal, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, tagVarSignal as _tagVarSignal, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/custom-tag-var/components/child.marko_0_x", _scope => _on(_scope["#button/0"], "click", function () {
   const x = _scope["x"];
   _queueSource(_scope, _x, x + 1);
 }));
-const _x = /* @__PURE__ */_source("x", [_tagVarSignal], (_scope, x) => {
-  _data(_scope["#text/1"], x);
-  _setSource(_scope, _tagVarSignal, x);
-  _queueHydrate(_scope, _hydrate_x);
+const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/1"], x);
+    _tagVarSignal_value = x;
+    _queueHydrate(_scope, _hydrate_x);
+  }
+  var _tagVarSignal_value;
+  _tagVarSignal(_scope, _tagVarSignal_value, _dirty);
 });
 const _setup = _scope => {
-  _setSource(_scope, _x, 1);
+  _x(_scope, 1);
 };
 export const template = "<button class=inc> </button>";
 export const walks = /* get, next(1), get, out(1) */" D l";

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/components/child.js
@@ -4,12 +4,12 @@ const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/custom-
   _queueSource(_scope, _x, x + 1);
 }));
 const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  let _tagVarSignal_value;
   if (_dirty) {
     _data(_scope["#text/1"], x);
-    _tagVarSignal_value = x;
     _queueHydrate(_scope, _hydrate_x);
+    _tagVarSignal_value = x;
   }
-  var _tagVarSignal_value;
   _tagVarSignal(_scope, _tagVarSignal_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/template.js
@@ -1,6 +1,6 @@
 import { setup as _child, template as _child_template, walks as _child_walks } from "./components/child.marko";
-import { setTagVar as _setTagVar, data as _data2, source as _source, register as _register, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _data = _register("packages/translator/src/__tests__/fixtures/custom-tag-var/template.marko_0_data", /* @__PURE__ */_source("data", [], (_scope, data) => {
+import { setTagVar as _setTagVar, data as _data2, value as _value, register as _register, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _data = _register("packages/translator/src/__tests__/fixtures/custom-tag-var/template.marko_0_data", /* @__PURE__ */_value("data", (_scope, data) => {
   _data2(_scope["#text/1"], data);
 }));
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixtures/dynamic-event-handlers/template.marko_0_clickCount", _scope => {
   const clickCount = _scope["clickCount"];
   _on(_scope["#button/0"], "click", clickCount <= 1 ? () => {
@@ -6,12 +6,12 @@ const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixture
     _queueSource(_scope, _clickCount, clickCount + 1);
   } : false);
 });
-const _clickCount = /* @__PURE__ */_source("clickCount", [], (_scope, clickCount) => {
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => {
   _data(_scope["#text/1"], clickCount);
   _queueHydrate(_scope, _hydrate_clickCount);
 });
 const _setup = _scope => {
-  _setSource(_scope, _clickCount, 0);
+  _clickCount(_scope, 0);
 };
 export const template = "<button> </button>";
 export const walks = /* get, next(1), get, out(1) */" D l";

--- a/packages/translator/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
@@ -1,6 +1,7 @@
 import { dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, intersection as _intersection, conditional as _conditional, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _tagNameBody = /* @__PURE__ */_createRenderer("body content", "");
 const _expr_dynamicTagName_className = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
+  let _dynamicBody_attrs;
   if (_dirty) {
     const dynamicTagName = _scope["#text/0"],
       className = _scope["className"];
@@ -8,7 +9,6 @@ const _expr_dynamicTagName_className = /* @__PURE__ */_intersection(2, (_scope, 
       class: className
     });
   }
-  var _dynamicBody_attrs;
   _dynamicTagAttrs(_scope, "#text/0", _dynamicBody_attrs, _tagNameBody, _dirty);
 });
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => _expr_dynamicTagName_className(_scope, _dirty));
@@ -18,11 +18,11 @@ const _hydrate_tagName = _register("packages/translator/src/__tests__/fixtures/d
   _queueSource(_scope, _tagName, tagName === "span" ? "div" : "span");
 }));
 const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
+  let _dynamicTagName_value;
   if (_dirty) {
-    _dynamicTagName_value = tagName || _tagNameBody;
     _queueHydrate(_scope, _hydrate_tagName);
+    _dynamicTagName_value = tagName || _tagNameBody;
   }
-  var _dynamicTagName_value;
   _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
@@ -1,18 +1,33 @@
-import { setSource as _setSource, dynamicAttrsProxy as _dynamicAttrsProxy, dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, subscriber as _subscriber, conditional as _conditional, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, intersection as _intersection, conditional as _conditional, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _tagNameBody = /* @__PURE__ */_createRenderer("body content", "");
-const _expr_dynamicTagName_className = /* @__PURE__ */_subscriber([_dynamicAttrsProxy("#text/0")], 2, (_scope, dynamicTagName = _scope["#text/0"], className = _scope["className"]) => _dynamicTagAttrs(_scope, "#text/0", () => ({
-  class: className
-}), _tagNameBody));
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", 1, (_scope, tagName = _scope["tagName"]) => tagName || _tagNameBody, _expr_dynamicTagName_className);
-const _className = /* @__PURE__ */_source("className", [_expr_dynamicTagName_className]);
+const _expr_dynamicTagName_className = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
+  if (_dirty) {
+    const dynamicTagName = _scope["#text/0"],
+      className = _scope["className"];
+    _dynamicBody_attrs = () => ({
+      class: className
+    });
+  }
+  var _dynamicBody_attrs;
+  _dynamicTagAttrs(_scope, "#text/0", _dynamicBody_attrs, _tagNameBody, _dirty);
+});
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => _expr_dynamicTagName_className(_scope, _dirty));
+const _className = /* @__PURE__ */_value("className", (_scope, className, _dirty) => _expr_dynamicTagName_className(_scope, _dirty));
 const _hydrate_tagName = _register("packages/translator/src/__tests__/fixtures/dynamic-native-dynamic-tag/template.marko_0_tagName", _scope => _on(_scope["#button/1"], "click", function () {
   const tagName = _scope["tagName"];
   _queueSource(_scope, _tagName, tagName === "span" ? "div" : "span");
 }));
-const _tagName = /* @__PURE__ */_source("tagName", [_dynamicTagName], (_scope, tagName) => _queueHydrate(_scope, _hydrate_tagName));
+const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
+  if (_dirty) {
+    _dynamicTagName_value = tagName || _tagNameBody;
+    _queueHydrate(_scope, _hydrate_tagName);
+  }
+  var _dynamicTagName_value;
+  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _tagName, "span");
-  _setSource(_scope, _className, "A");
+  _tagName(_scope, "span");
+  _className(_scope, "A");
 };
 export const template = "<!><button></button>";
 export const walks = /* replace, over(1), get, over(1) */"%b b";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-attr-signal/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-attr-signal/__snapshots__/dom.expected/template.js
@@ -1,14 +1,14 @@
-import { setSource as _setSource, classAttr as _classAttr, on as _on, queueSource as _queueSource, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { classAttr as _classAttr, on as _on, queueSource as _queueSource, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_className = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-attr-signal/template.marko_0_className", _scope => _on(_scope["#button/1"], "click", function () {
   const className = _scope["className"];
   _queueSource(_scope, _className, className === "A" ? "B" : "A");
 }));
-const _className = /* @__PURE__ */_source("className", [], (_scope, className) => {
+const _className = /* @__PURE__ */_value("className", (_scope, className) => {
   _classAttr(_scope["#p/0"], className);
   _queueHydrate(_scope, _hydrate_className);
 });
 const _setup = _scope => {
-  _setSource(_scope, _className, "A");
+  _className(_scope, "A");
 };
 export const template = "<p>paragraph</p><button></button>";
 export const walks = /* get, over(1), get, over(1) */" b b";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/components/child.js
@@ -1,10 +1,12 @@
-import { data as _data, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _id = /* @__PURE__ */_source("id", [], (_scope, id) => _data(_scope["#text/0"], id));
-export const attrs = /* @__PURE__ */_destructureSources([_id], (_scope, {
-  id
-}) => {
-  _setSource(_scope, _id, id);
-});
+import { data as _data, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _id = /* @__PURE__ */_value("id", (_scope, id) => _data(_scope["#text/0"], id));
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let id;
+  if (_dirty) ({
+    id
+  } = _destructure);
+  _id(_scope, id, _dirty);
+};
 export { _id as _apply_id };
 export const template = "<div>Id is <!></div>";
 export const walks = /* next(1), over(1), replace, out(1) */"Db%l";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.js
@@ -1,15 +1,28 @@
 import child from "./components/child.marko";
-import { setSource as _setSource, on as _on, queueSource as _queueSource, dynamicAttrsProxy as _dynamicAttrsProxy, dynamicTagAttrs as _dynamicTagAttrs, conditional as _conditional, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/1", 1, (_scope, tagName = _scope["tagName"]) => tagName, _dynamicAttrsProxy("#text/1"), _scope => _dynamicTagAttrs(_scope, "#text/1", () => ({
-  id: "dynamic"
-})));
+import { on as _on, queueSource as _queueSource, dynamicTagAttrs as _dynamicTagAttrs, conditional as _conditional, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/1", (_scope, _dirty) => {
+  if (_dirty) {
+    _dynamicBody_attrs = () => ({
+      id: "dynamic"
+    });
+  }
+  var _dynamicBody_attrs;
+  _dynamicTagAttrs(_scope, "#text/1", _dynamicBody_attrs, null, _dirty);
+});
 const _hydrate_tagName = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/template.marko_0_tagName", _scope => _on(_scope["#button/0"], "click", function () {
   const tagName = _scope["tagName"];
   _queueSource(_scope, _tagName, tagName === child ? "div" : child);
 }));
-const _tagName = /* @__PURE__ */_source("tagName", [_dynamicTagName], (_scope, tagName) => _queueHydrate(_scope, _hydrate_tagName));
+const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
+  if (_dirty) {
+    _dynamicTagName_value = tagName;
+    _queueHydrate(_scope, _hydrate_tagName);
+  }
+  var _dynamicTagName_value;
+  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _tagName, child);
+  _tagName(_scope, child);
 };
 export const template = "<button></button><!>";
 export const walks = /* get, over(1), replace, over(1) */" b%b";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.js
@@ -1,12 +1,12 @@
 import child from "./components/child.marko";
 import { on as _on, queueSource as _queueSource, dynamicTagAttrs as _dynamicTagAttrs, conditional as _conditional, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/1", (_scope, _dirty) => {
+  let _dynamicBody_attrs;
   if (_dirty) {
     _dynamicBody_attrs = () => ({
       id: "dynamic"
     });
   }
-  var _dynamicBody_attrs;
   _dynamicTagAttrs(_scope, "#text/1", _dynamicBody_attrs, null, _dirty);
 });
 const _hydrate_tagName = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/template.marko_0_tagName", _scope => _on(_scope["#button/0"], "click", function () {
@@ -14,11 +14,11 @@ const _hydrate_tagName = _register("packages/translator/src/__tests__/fixtures/d
   _queueSource(_scope, _tagName, tagName === child ? "div" : child);
 }));
 const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
+  let _dynamicTagName_value;
   if (_dirty) {
-    _dynamicTagName_value = tagName;
     _queueHydrate(_scope, _hydrate_tagName);
+    _dynamicTagName_value = tagName;
   }
-  var _dynamicTagName_value;
   _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/components/child1.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/components/child1.js
@@ -1,10 +1,12 @@
-import { data as _data, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _value = /* @__PURE__ */_source("value", [], (_scope, value) => _data(_scope["#text/0"], value));
-export const attrs = /* @__PURE__ */_destructureSources([_value], (_scope, {
-  value
-}) => {
-  _setSource(_scope, _value, value);
-});
+import { data as _data, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _value = /* @__PURE__ */_value2("value", (_scope, value) => _data(_scope["#text/0"], value));
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let value;
+  if (_dirty) ({
+    value
+  } = _destructure);
+  _value(_scope, value, _dirty);
+};
 export { _value as _apply_value };
 export const template = "<div>Child 1 has <!></div>";
 export const walks = /* next(1), over(1), replace, out(1) */"Db%l";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/components/child2.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/components/child2.js
@@ -1,10 +1,12 @@
-import { data as _data, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _value = /* @__PURE__ */_source("value", [], (_scope, value) => _data(_scope["#text/0"], value));
-export const attrs = /* @__PURE__ */_destructureSources([_value], (_scope, {
-  value
-}) => {
-  _setSource(_scope, _value, value);
-});
+import { data as _data, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _value = /* @__PURE__ */_value2("value", (_scope, value) => _data(_scope["#text/0"], value));
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let value;
+  if (_dirty) ({
+    value
+  } = _destructure);
+  _value(_scope, value, _dirty);
+};
 export { _value as _apply_value };
 export const template = "<div>Child 2 has <!></div>";
 export const walks = /* next(1), over(1), replace, out(1) */"Db%l";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
@@ -1,19 +1,34 @@
 import child1 from "./components/child1.marko";
 import child2 from "./components/child2.marko";
-import { setSource as _setSource, dynamicAttrsProxy as _dynamicAttrsProxy, dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, subscriber as _subscriber, conditional as _conditional, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _expr_dynamicTagName_val = /* @__PURE__ */_subscriber([_dynamicAttrsProxy("#text/0")], 2, (_scope, dynamicTagName = _scope["#text/0"], val = _scope["val"]) => _dynamicTagAttrs(_scope, "#text/0", () => ({
-  value: val
-})));
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", 1, (_scope, tagName = _scope["tagName"]) => tagName, _expr_dynamicTagName_val);
-const _val = /* @__PURE__ */_source("val", [_expr_dynamicTagName_val]);
+import { dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, intersection as _intersection, conditional as _conditional, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _expr_dynamicTagName_val = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
+  if (_dirty) {
+    const dynamicTagName = _scope["#text/0"],
+      val = _scope["val"];
+    _dynamicBody_attrs = () => ({
+      value: val
+    });
+  }
+  var _dynamicBody_attrs;
+  _dynamicTagAttrs(_scope, "#text/0", _dynamicBody_attrs, null, _dirty);
+});
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => _expr_dynamicTagName_val(_scope, _dirty));
+const _val = /* @__PURE__ */_value("val", (_scope, val, _dirty) => _expr_dynamicTagName_val(_scope, _dirty));
 const _hydrate_tagName = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/template.marko_0_tagName", _scope => _on(_scope["#button/1"], "click", function () {
   const tagName = _scope["tagName"];
   _queueSource(_scope, _tagName, tagName === child1 ? child2 : child1);
 }));
-const _tagName = /* @__PURE__ */_source("tagName", [_dynamicTagName], (_scope, tagName) => _queueHydrate(_scope, _hydrate_tagName));
+const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
+  if (_dirty) {
+    _dynamicTagName_value = tagName;
+    _queueHydrate(_scope, _hydrate_tagName);
+  }
+  var _dynamicTagName_value;
+  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _tagName, child1);
-  _setSource(_scope, _val, 3);
+  _tagName(_scope, child1);
+  _val(_scope, 3);
 };
 export const template = "<!><button></button>";
 export const walks = /* replace, over(1), get, over(1) */"%b b";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
@@ -2,6 +2,7 @@ import child1 from "./components/child1.marko";
 import child2 from "./components/child2.marko";
 import { dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, intersection as _intersection, conditional as _conditional, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _expr_dynamicTagName_val = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
+  let _dynamicBody_attrs;
   if (_dirty) {
     const dynamicTagName = _scope["#text/0"],
       val = _scope["val"];
@@ -9,7 +10,6 @@ const _expr_dynamicTagName_val = /* @__PURE__ */_intersection(2, (_scope, _dirty
       value: val
     });
   }
-  var _dynamicBody_attrs;
   _dynamicTagAttrs(_scope, "#text/0", _dynamicBody_attrs, null, _dirty);
 });
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => _expr_dynamicTagName_val(_scope, _dirty));
@@ -19,11 +19,11 @@ const _hydrate_tagName = _register("packages/translator/src/__tests__/fixtures/d
   _queueSource(_scope, _tagName, tagName === child1 ? child2 : child1);
 }));
 const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
+  let _dynamicTagName_value;
   if (_dirty) {
-    _dynamicTagName_value = tagName;
     _queueHydrate(_scope, _hydrate_tagName);
+    _dynamicTagName_value = tagName;
   }
-  var _dynamicTagName_value;
   _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.js
@@ -1,13 +1,26 @@
-import { setSource as _setSource, dynamicAttrsProxy as _dynamicAttrsProxy, dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, conditional as _conditional, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, conditional as _conditional, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _xBody = /* @__PURE__ */_createRenderer("Body Content", "");
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", 1, (_scope, x = _scope["x"]) => x || _xBody, _dynamicAttrsProxy("#text/0"), _scope => _dynamicTagAttrs(_scope, "#text/0", () => ({}), _xBody));
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => {
+  if (_dirty) {
+    _dynamicBody_attrs = () => ({});
+  }
+  var _dynamicBody_attrs;
+  _dynamicTagAttrs(_scope, "#text/0", _dynamicBody_attrs, _xBody, _dirty);
+});
 const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-sometimes-null/template.marko_0_x", _scope => _on(_scope["#button/1"], "click", function () {
   const x = _scope["x"];
   _queueSource(_scope, _x, x ? null : "div");
 }));
-const _x = /* @__PURE__ */_source("x", [_dynamicTagName], (_scope, x) => _queueHydrate(_scope, _hydrate_x));
+const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  if (_dirty) {
+    _dynamicTagName_value = x || _xBody;
+    _queueHydrate(_scope, _hydrate_x);
+  }
+  var _dynamicTagName_value;
+  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _x, null);
+  _x(_scope, null);
 };
 export const template = "<!><button></button>";
 export const walks = /* replace, over(1), get, over(1) */"%b b";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.js
@@ -1,10 +1,10 @@
 import { dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, conditional as _conditional, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _xBody = /* @__PURE__ */_createRenderer("Body Content", "");
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => {
+  let _dynamicBody_attrs;
   if (_dirty) {
     _dynamicBody_attrs = () => ({});
   }
-  var _dynamicBody_attrs;
   _dynamicTagAttrs(_scope, "#text/0", _dynamicBody_attrs, _xBody, _dirty);
 });
 const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-sometimes-null/template.marko_0_x", _scope => _on(_scope["#button/1"], "click", function () {
@@ -12,11 +12,11 @@ const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/dynamic
   _queueSource(_scope, _x, x ? null : "div");
 }));
 const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  let _dynamicTagName_value;
   if (_dirty) {
-    _dynamicTagName_value = x || _xBody;
     _queueHydrate(_scope, _hydrate_x);
+    _dynamicTagName_value = x || _xBody;
   }
-  var _dynamicTagName_value;
   _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-var/__snapshots__/dom.expected/components/child/index.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-var/__snapshots__/dom.expected/components/child/index.js
@@ -1,7 +1,6 @@
-import { tagVarSignal as _tagVarSignal, setSource as _setSource, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { tagVarSignal as _tagVarSignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _setup = _scope => {
-  _setSource(_scope, _tagVarSignal, 1);
-  _notifySignal(_scope, _tagVarSignal);
+  _tagVarSignal(_scope, 1);
 };
 export const template = "";
 export const walks = "";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/components/counter.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/components/counter.js
@@ -1,14 +1,14 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-with-updating-body/components/counter.marko_0_count", _scope => _on(_scope["#button/0"], "click", function () {
   const count = _scope["count"];
   _queueSource(_scope, _count, count + 1);
 }));
-const _count = /* @__PURE__ */_source("count", [], (_scope, count) => {
+const _count = /* @__PURE__ */_value("count", (_scope, count) => {
   _data(_scope["#text/1"], count);
   _queueHydrate(_scope, _hydrate_count);
 });
 const _setup = _scope => {
-  _setSource(_scope, _count, 0);
+  _count(_scope, 0);
 };
 export const template = "<button id=count> </button>";
 export const walks = /* get, next(1), get, out(1) */" D l";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.js
@@ -5,10 +5,10 @@ const _setup$tagNameBody = _scope => {
 };
 const _tagNameBody = /* @__PURE__ */_createRenderer(`${_counter_template}`, /* beginChild, _counter_walks, endChild */`/${_counter_walks}&`, _setup$tagNameBody);
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => {
+  let _dynamicBody_attrs;
   if (_dirty) {
     _dynamicBody_attrs = () => ({});
   }
-  var _dynamicBody_attrs;
   _dynamicTagAttrs(_scope, "#text/0", _dynamicBody_attrs, _tagNameBody, _dirty);
 });
 const _hydrate_tagName = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-with-updating-body/template.marko_0_tagName", _scope => _on(_scope["#button/1"], "click", function () {
@@ -16,11 +16,11 @@ const _hydrate_tagName = _register("packages/translator/src/__tests__/fixtures/d
   _queueSource(_scope, _tagName, tagName === "span" ? "div" : "span");
 }));
 const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
+  let _dynamicTagName_value;
   if (_dirty) {
-    _dynamicTagName_value = tagName || _tagNameBody;
     _queueHydrate(_scope, _hydrate_tagName);
+    _dynamicTagName_value = tagName || _tagNameBody;
   }
-  var _dynamicTagName_value;
   _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.js
@@ -1,17 +1,30 @@
-import { setSource as _setSource, dynamicAttrsProxy as _dynamicAttrsProxy, dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, conditional as _conditional, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _counter, template as _counter_template, walks as _counter_walks } from "./components/counter.marko";
+import { dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, conditional as _conditional, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _setup$tagNameBody = _scope => {
   _counter(_scope["#childScope/0"]);
 };
 const _tagNameBody = /* @__PURE__ */_createRenderer(`${_counter_template}`, /* beginChild, _counter_walks, endChild */`/${_counter_walks}&`, _setup$tagNameBody);
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", 1, (_scope, tagName = _scope["tagName"]) => tagName || _tagNameBody, _dynamicAttrsProxy("#text/0"), _scope => _dynamicTagAttrs(_scope, "#text/0", () => ({}), _tagNameBody));
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => {
+  if (_dirty) {
+    _dynamicBody_attrs = () => ({});
+  }
+  var _dynamicBody_attrs;
+  _dynamicTagAttrs(_scope, "#text/0", _dynamicBody_attrs, _tagNameBody, _dirty);
+});
 const _hydrate_tagName = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-with-updating-body/template.marko_0_tagName", _scope => _on(_scope["#button/1"], "click", function () {
   const tagName = _scope["tagName"];
   _queueSource(_scope, _tagName, tagName === "span" ? "div" : "span");
 }));
-const _tagName = /* @__PURE__ */_source("tagName", [_dynamicTagName], (_scope, tagName) => _queueHydrate(_scope, _hydrate_tagName));
+const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
+  if (_dirty) {
+    _dynamicTagName_value = tagName || _tagNameBody;
+    _queueHydrate(_scope, _hydrate_tagName);
+  }
+  var _dynamicTagName_value;
+  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _tagName, "div");
+  _tagName(_scope, "div");
 };
 export const template = "<!><button id=changeTag></button>";
 export const walks = /* replace, over(1), get, over(1) */"%b b";

--- a/packages/translator/src/__tests__/fixtures/effect-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/effect-counter/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixtures/effect-counter/template.marko_0_clickCount", _scope => {
   const clickCount = _scope["clickCount"];
   document.getElementById("button").textContent = clickCount;
@@ -7,9 +7,9 @@ const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixture
     _queueSource(_scope, _clickCount, clickCount + 1);
   });
 });
-const _clickCount = /* @__PURE__ */_source("clickCount", [], (_scope, clickCount) => _queueHydrate(_scope, _hydrate_clickCount));
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => _queueHydrate(_scope, _hydrate_clickCount));
 const _setup = _scope => {
-  _setSource(_scope, _clickCount, 0);
+  _clickCount(_scope, 0);
 };
 export const template = "<div><button id=button>0</button></div>";
 export const walks = /* next(1), get, out(1) */"D l";

--- a/packages/translator/src/__tests__/fixtures/effect-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/effect-tag/__snapshots__/dom.expected/template.js
@@ -1,11 +1,11 @@
-import { setSource as _setSource, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/effect-tag/template.marko_0_x", _scope => {
   const x = _scope["x"];
   document.getElementById("ref").textContent = x;
 });
-const _x = /* @__PURE__ */_source("x", [], (_scope, x) => _queueHydrate(_scope, _hydrate_x));
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _queueHydrate(_scope, _hydrate_x));
 const _setup = _scope => {
-  _setSource(_scope, _x, 1);
+  _x(_scope, 1);
 };
 export const template = "<div id=ref>0</div>";
 export const walks = /* over(1) */"b";

--- a/packages/translator/src/__tests__/fixtures/for-tag-siblings/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag-siblings/__snapshots__/dom.expected/template.js
@@ -1,13 +1,24 @@
-import { data as _data, source as _source, createRenderer as _createRenderer, setSource as _setSource, loop as _loop, derivation as _derivation, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _val$forBody2 = /* @__PURE__ */_source("val", [], (_scope, val) => _data(_scope["#text/0"], val));
+import { data as _data, value as _value, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _val$forBody2 = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope["#text/0"], val));
 const _forBody2 = /* @__PURE__ */_createRenderer("<div> </div>", /* next(1), get */"D ");
-const _val$forBody = /* @__PURE__ */_source("val", [], (_scope, val) => _data(_scope["#text/0"], val));
+const _val$forBody = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope["#text/0"], val));
 const _forBody = /* @__PURE__ */_createRenderer("<div> </div>", /* next(1), get */"D ");
-const _for2 = /* @__PURE__ */_loop("#text/1", 1, _forBody2, [_val$forBody2], (_scope, [val]) => _setSource(_scope, _val$forBody2, val), (_scope, arrA = _scope["arrA"]) => [arrA, null]);
-const _for = /* @__PURE__ */_loop("#div/0", 1, _forBody, [_val$forBody], (_scope, [val]) => _setSource(_scope, _val$forBody, val), (_scope, arrA = _scope["arrA"]) => [arrA, null]);
-const _arrA = /* @__PURE__ */_derivation("arrA", 1, [_for, _for2], _scope => [1, 2, 3]);
+const _for2 = /* @__PURE__ */_loop("#text/1", _forBody2, (_scope, _destructure2, _dirty = true) => {
+  let val;
+  if (_dirty) [val] = _destructure2;
+  _val$forBody2(_scope, val, _dirty);
+});
+const _for = /* @__PURE__ */_loop("#div/0", _forBody, (_scope, _destructure, _dirty = true) => {
+  let val;
+  if (_dirty) [val] = _destructure;
+  _val$forBody(_scope, val, _dirty);
+});
+const _arrA = /* @__PURE__ */_value("arrA", (_scope, arrA) => {
+  _for(_scope, [arrA, null]);
+  _for2(_scope, [arrA, null]);
+});
 const _setup = _scope => {
-  _notifySignal(_scope, _arrA);
+  _arrA(_scope, [1, 2, 3]);
 };
 export const template = "<div></div><div><!><div></div></div>";
 export const walks = /* get, over(1), next(1), replace, out(1) */" bD%l";

--- a/packages/translator/src/__tests__/fixtures/for-tag-with-state/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag-with-state/__snapshots__/dom.expected/template.js
@@ -1,23 +1,27 @@
-import { data as _data, setSource as _setSource, source as _source, createRenderer as _createRenderer, loop as _loop, derivation as _derivation, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _i$forBody2 = /* @__PURE__ */_source("i", [], (_scope, i) => _data(_scope["#text/0"], i));
-const _val$forBody2 = /* @__PURE__ */_source("val", [], (_scope, val) => _data(_scope["#text/1"], val));
+import { data as _data, value as _value, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _i$forBody2 = /* @__PURE__ */_value("i", (_scope, i) => _data(_scope["#text/0"], i));
+const _val$forBody2 = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope["#text/1"], val));
 const _forBody2 = /* @__PURE__ */_createRenderer("<div><!>: <!></div>", /* next(1), replace, over(2), replace */"D%c%");
-const _i$forBody = /* @__PURE__ */_source("i", [], (_scope, i) => _data(_scope["#text/0"], i));
-const _val$forBody = /* @__PURE__ */_source("val", [], (_scope, val) => _data(_scope["#text/1"], val));
+const _i$forBody = /* @__PURE__ */_value("i", (_scope, i) => _data(_scope["#text/0"], i));
+const _val$forBody = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope["#text/1"], val));
 const _forBody = /* @__PURE__ */_createRenderer("<div><!>: <!></div>", /* next(1), replace, over(2), replace */"D%c%");
-const _for2 = /* @__PURE__ */_loop("#text/1", 1, _forBody2, [_val$forBody2, _i$forBody2], (_scope, [val, i]) => {
-  _setSource(_scope, _val$forBody2, val);
-  _setSource(_scope, _i$forBody2, i);
-}, (_scope, arrB = _scope["arrB"]) => [arrB, null]);
-const _for = /* @__PURE__ */_loop("#text/0", 1, _forBody, [_val$forBody, _i$forBody], (_scope, [val, i]) => {
-  _setSource(_scope, _val$forBody, val);
-  _setSource(_scope, _i$forBody, i);
-}, (_scope, arrA = _scope["arrA"]) => [arrA, null]);
-const _arrB = /* @__PURE__ */_source("arrB", [_for2]);
-const _arrA = /* @__PURE__ */_derivation("arrA", 1, [_for], _scope => [1, 2, 3]);
+const _for2 = /* @__PURE__ */_loop("#text/1", _forBody2, (_scope, _destructure2, _dirty = true) => {
+  let val, i;
+  if (_dirty) [val, i] = _destructure2;
+  _val$forBody2(_scope, val, _dirty);
+  _i$forBody2(_scope, i, _dirty);
+});
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+  let val, i;
+  if (_dirty) [val, i] = _destructure;
+  _val$forBody(_scope, val, _dirty);
+  _i$forBody(_scope, i, _dirty);
+});
+const _arrB = /* @__PURE__ */_value("arrB", (_scope, arrB) => _for2(_scope, [arrB, null]));
+const _arrA = /* @__PURE__ */_value("arrA", (_scope, arrA) => _for(_scope, [arrA, null]));
 const _setup = _scope => {
-  _setSource(_scope, _arrB, [1, 2, 3]);
-  _notifySignal(_scope, _arrA);
+  _arrA(_scope, [1, 2, 3]);
+  _arrB(_scope, [1, 2, 3]);
 };
 export const template = "<!><!>";
 export const walks = /* replace, over(1), replace, over(1) */"%b%b";

--- a/packages/translator/src/__tests__/fixtures/for-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag/__snapshots__/dom.expected/template.js
@@ -1,94 +1,127 @@
-import { data as _data, computeLoopIn as _computeLoopIn, computeLoopToFrom as _computeLoopToFrom, attr as _attr, createRenderer as _createRenderer, source as _source, setSource as _setSource, loop as _loop, notifySignal as _notifySignal, derivation as _derivation, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { data as _data, computeLoopIn as _computeLoopIn, computeLoopToFrom as _computeLoopToFrom, attr as _attr, createRenderer as _createRenderer, value as _value, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _forBody11 = /* @__PURE__ */_createRenderer("Hello", "");
 const _forBody10 = /* @__PURE__ */_createRenderer("Hello", "");
-const _i$forBody7 = /* @__PURE__ */_source("i", [], (_scope, i) => {
+const _i$forBody7 = /* @__PURE__ */_value("i", (_scope, i) => {
   _attr(_scope["#div/0"], "key", i);
   _data(_scope["#text/1"], i);
   _attr(_scope["#div/2"], "key", `other-${i}`);
 });
 const _forBody9 = /* @__PURE__ */_createRenderer("<div> </div><div></div><div></div>", /* get, next(1), get, out(1), over(1), get */" D lb ");
-const _i$forBody6 = /* @__PURE__ */_source("i", [], (_scope, i) => {
+const _i$forBody6 = /* @__PURE__ */_value("i", (_scope, i) => {
   _attr(_scope["#div/0"], "key", i);
   _data(_scope["#text/1"], i);
   _attr(_scope["#div/2"], "key", `other-${i}`);
 });
 const _forBody8 = /* @__PURE__ */_createRenderer("<div> </div><div></div><div></div>", /* get, next(1), get, out(1), over(1), get */" D lb ");
-const _for$forBody = /* @__PURE__ */_loop("#text/3", 1, _forBody8, [_i$forBody6], (_scope, [i]) => _setSource(_scope, _i$forBody6, i), _scope => _computeLoopToFrom(10, 0, 2));
-const _i$forBody5 = /* @__PURE__ */_source("i", [], (_scope, i) => {
+const _for$forBody = /* @__PURE__ */_loop("#text/3", _forBody8, (_scope, _destructure7, _dirty = true) => {
+  let i;
+  if (_dirty) [i] = _destructure7;
+  _i$forBody6(_scope, i, _dirty);
+});
+const _i$forBody5 = /* @__PURE__ */_value("i", (_scope, i) => {
   _attr(_scope["#div/0"], "key", i);
   _data(_scope["#text/1"], i);
   _attr(_scope["#div/2"], "key", `other-${i}`);
 });
 const _setup$forBody = _scope => {
-  _notifySignal(_scope, _for$forBody);
+  _for$forBody(_scope, _computeLoopToFrom(10, 0, 2));
 };
 const _forBody7 = /* @__PURE__ */_createRenderer("<div> </div><div></div><div></div><!>", /* get, next(1), get, out(1), over(1), get, over(1), replace */" D lb b%", _setup$forBody);
-const _val$forBody5 = /* @__PURE__ */_source("val", [], (_scope, val) => _data(_scope["#text/2"], val));
-const _key$forBody2 = /* @__PURE__ */_source("key", [], (_scope, key) => {
+const _val$forBody5 = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope["#text/2"], val));
+const _key$forBody2 = /* @__PURE__ */_value("key", (_scope, key) => {
   _attr(_scope["#div/0"], "key", key);
   _data(_scope["#text/1"], key);
   _attr(_scope["#div/3"], "key", `other-${key}`);
 });
 const _forBody6 = /* @__PURE__ */_createRenderer("<div><!>: <!></div><div></div><div></div>", /* get, next(1), replace, over(2), replace, out(1), over(1), get */" D%c%lb ");
-const _list$forBody = /* @__PURE__ */_source("list", [], (_scope, list) => _data(_scope["#text/1"], list.length));
-const _i$forBody4 = /* @__PURE__ */_source("i", [], (_scope, i) => _attr(_scope["#div/0"], "key", i));
-const _val$forBody4 = /* @__PURE__ */_source("val", [], (_scope, val) => _data(_scope["#text/2"], val));
+const _list$forBody = /* @__PURE__ */_value("list", (_scope, list) => _data(_scope["#text/1"], list.length));
+const _i$forBody4 = /* @__PURE__ */_value("i", (_scope, i) => _attr(_scope["#div/0"], "key", i));
+const _val$forBody4 = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope["#text/2"], val));
 const _forBody5 = /* @__PURE__ */_createRenderer("<div><!>: <!></div>", /* get, next(1), replace, over(2), replace */" D%c%");
-const _i$forBody3 = /* @__PURE__ */_source("i", [], (_scope, i) => {
+const _i$forBody3 = /* @__PURE__ */_value("i", (_scope, i) => {
   _attr(_scope["#div/0"], "key", i);
   _data(_scope["#text/1"], i);
   _attr(_scope["#div/3"], "key", `other-${i}`);
 });
-const _val$forBody3 = /* @__PURE__ */_source("val", [], (_scope, val) => _data(_scope["#text/2"], val));
+const _val$forBody3 = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope["#text/2"], val));
 const _forBody4 = /* @__PURE__ */_createRenderer("<div><!>: <!></div><div></div><div></div>", /* get, next(1), replace, over(2), replace, out(1), over(1), get */" D%c%lb ");
-const _i$forBody2 = /* @__PURE__ */_source("i", [], (_scope, i) => _data(_scope["#text/0"], i));
+const _i$forBody2 = /* @__PURE__ */_value("i", (_scope, i) => _data(_scope["#text/0"], i));
 const _forBody3 = /* @__PURE__ */_createRenderer("<div> </div><div></div><div></div>", /* next(1), get */"D ");
-const _val$forBody2 = /* @__PURE__ */_source("val", [], (_scope, val) => _data(_scope["#text/1"], val));
-const _key$forBody = /* @__PURE__ */_source("key", [], (_scope, key) => _data(_scope["#text/0"], key));
+const _val$forBody2 = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope["#text/1"], val));
+const _key$forBody = /* @__PURE__ */_value("key", (_scope, key) => _data(_scope["#text/0"], key));
 const _forBody2 = /* @__PURE__ */_createRenderer("<div><!>: <!></div><div></div><div></div>", /* next(1), replace, over(2), replace */"D%c%");
-const _i$forBody = /* @__PURE__ */_source("i", [], (_scope, i) => _data(_scope["#text/0"], i));
-const _val$forBody = /* @__PURE__ */_source("val", [], (_scope, val) => _data(_scope["#text/1"], val));
+const _i$forBody = /* @__PURE__ */_value("i", (_scope, i) => _data(_scope["#text/0"], i));
+const _val$forBody = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope["#text/1"], val));
 const _forBody = /* @__PURE__ */_createRenderer("<div><!>: <!></div><div></div><div></div>", /* next(1), replace, over(2), replace */"D%c%");
-const _for10 = /* @__PURE__ */_loop("#text/9", 1, _forBody11, [], null, _scope => _computeLoopToFrom(10, 0, 1));
-const _for9 = /* @__PURE__ */_loop("#text/8", 1, _forBody10, [], null, _scope => _computeLoopToFrom(10, 0, 1));
-const _for8 = /* @__PURE__ */_loop("#text/7", 1, _forBody9, [_i$forBody7], (_scope, [i]) => _setSource(_scope, _i$forBody7, i), _scope => _computeLoopToFrom(0, 10, -2));
-const _for7 = /* @__PURE__ */_loop("#text/6", 1, _forBody7, [_i$forBody5], (_scope, [i]) => _setSource(_scope, _i$forBody5, i), _scope => _computeLoopToFrom(10, 0, 2));
-const _for6 = /* @__PURE__ */_loop("#text/5", 1, _forBody6, [_key$forBody2, _val$forBody5], (_scope, [[key, val]]) => {
-  _setSource(_scope, _key$forBody2, key);
-  _setSource(_scope, _val$forBody5, val);
-}, (_scope, obj = _scope["obj"]) => _computeLoopIn(obj));
-const _for5 = /* @__PURE__ */_loop("#text/4", 1, _forBody5, [_val$forBody4, _i$forBody4, _list$forBody], (_scope, [val, i, list]) => {
-  _setSource(_scope, _val$forBody4, val);
-  _setSource(_scope, _i$forBody4, i);
-  _setSource(_scope, _list$forBody, list);
-}, (_scope, arr = _scope["arr"]) => [arr, null]);
-const _for4 = /* @__PURE__ */_loop("#text/3", 1, _forBody4, [_val$forBody3, _i$forBody3], (_scope, [val, i]) => {
-  _setSource(_scope, _val$forBody3, val);
-  _setSource(_scope, _i$forBody3, i);
-}, (_scope, arr = _scope["arr"]) => [arr, null]);
-const _for3 = /* @__PURE__ */_loop("#text/2", 1, _forBody3, [_i$forBody2], (_scope, [i]) => _setSource(_scope, _i$forBody2, i), _scope => _computeLoopToFrom(10, 0, 2));
-const _for2 = /* @__PURE__ */_loop("#text/1", 1, _forBody2, [_key$forBody, _val$forBody2], (_scope, [[key, val]]) => {
-  _setSource(_scope, _key$forBody, key);
-  _setSource(_scope, _val$forBody2, val);
-}, (_scope, obj = _scope["obj"]) => _computeLoopIn(obj));
-const _for = /* @__PURE__ */_loop("#text/0", 1, _forBody, [_val$forBody, _i$forBody], (_scope, [val, i]) => {
-  _setSource(_scope, _val$forBody, val);
-  _setSource(_scope, _i$forBody, i);
-}, (_scope, arr = _scope["arr"]) => [arr, null]);
-const _obj = /* @__PURE__ */_derivation("obj", 1, [_for2, _for6], _scope => ({
-  a: 1,
-  b: 1,
-  c: 1
-}));
-const _arr = /* @__PURE__ */_derivation("arr", 1, [_for, _for4, _for5], _scope => [1, 2, 3]);
+const _for10 = /* @__PURE__ */_loop("#text/9", _forBody11);
+const _for9 = /* @__PURE__ */_loop("#text/8", _forBody10);
+const _for8 = /* @__PURE__ */_loop("#text/7", _forBody9, (_scope, _destructure9, _dirty = true) => {
+  let i;
+  if (_dirty) [i] = _destructure9;
+  _i$forBody7(_scope, i, _dirty);
+});
+const _for7 = /* @__PURE__ */_loop("#text/6", _forBody7, (_scope, _destructure8, _dirty = true) => {
+  let i;
+  if (_dirty) [i] = _destructure8;
+  _i$forBody5(_scope, i, _dirty);
+});
+const _for6 = /* @__PURE__ */_loop("#text/5", _forBody6, (_scope, _destructure6, _dirty = true) => {
+  let key, val;
+  if (_dirty) [[key, val]] = _destructure6;
+  _key$forBody2(_scope, key, _dirty);
+  _val$forBody5(_scope, val, _dirty);
+});
+const _for5 = /* @__PURE__ */_loop("#text/4", _forBody5, (_scope, _destructure5, _dirty = true) => {
+  let val, i, list;
+  if (_dirty) [val, i, list] = _destructure5;
+  _val$forBody4(_scope, val, _dirty);
+  _i$forBody4(_scope, i, _dirty);
+  _list$forBody(_scope, list, _dirty);
+});
+const _for4 = /* @__PURE__ */_loop("#text/3", _forBody4, (_scope, _destructure4, _dirty = true) => {
+  let val, i;
+  if (_dirty) [val, i] = _destructure4;
+  _val$forBody3(_scope, val, _dirty);
+  _i$forBody3(_scope, i, _dirty);
+});
+const _for3 = /* @__PURE__ */_loop("#text/2", _forBody3, (_scope, _destructure3, _dirty = true) => {
+  let i;
+  if (_dirty) [i] = _destructure3;
+  _i$forBody2(_scope, i, _dirty);
+});
+const _for2 = /* @__PURE__ */_loop("#text/1", _forBody2, (_scope, _destructure2, _dirty = true) => {
+  let key, val;
+  if (_dirty) [[key, val]] = _destructure2;
+  _key$forBody(_scope, key, _dirty);
+  _val$forBody2(_scope, val, _dirty);
+});
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+  let val, i;
+  if (_dirty) [val, i] = _destructure;
+  _val$forBody(_scope, val, _dirty);
+  _i$forBody(_scope, i, _dirty);
+});
+const _obj = /* @__PURE__ */_value("obj", (_scope, obj) => {
+  _for2(_scope, _computeLoopIn(obj));
+  _for6(_scope, _computeLoopIn(obj));
+});
+const _arr = /* @__PURE__ */_value("arr", (_scope, arr) => {
+  _for(_scope, [arr, null]);
+  _for4(_scope, [arr, null]);
+  _for5(_scope, [arr, null]);
+});
 const _setup = _scope => {
-  _notifySignal(_scope, _arr);
-  _notifySignal(_scope, _obj);
-  _notifySignal(_scope, _for3);
-  _notifySignal(_scope, _for7);
-  _notifySignal(_scope, _for8);
-  _notifySignal(_scope, _for9);
-  _notifySignal(_scope, _for10);
+  _arr(_scope, [1, 2, 3]);
+  _obj(_scope, {
+    a: 1,
+    b: 1,
+    c: 1
+  });
+  _for3(_scope, _computeLoopToFrom(10, 0, 2));
+  _for7(_scope, _computeLoopToFrom(10, 0, 2));
+  _for8(_scope, _computeLoopToFrom(0, 10, -2));
+  _for9(_scope, _computeLoopToFrom(10, 0, 1));
+  _for10(_scope, _computeLoopToFrom(10, 0, 1));
 };
 export const template = "<!><!><!><!><!><!><!><!><!><!>";
 export const walks = /* replace, over(1), replace, over(1), replace, over(1), replace, over(1), replace, over(1), replace, over(1), replace, over(1), replace, over(1), replace, over(1), replace, over(1) */"%b%b%b%b%b%b%b%b%b%b";

--- a/packages/translator/src/__tests__/fixtures/hello-dynamic/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/hello-dynamic/__snapshots__/dom.expected/template.js
@@ -1,12 +1,10 @@
-import { data as _data, html as _html, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _input = /* @__PURE__ */_source("input", [], (_scope, input) => {
+import { data as _data, html as _html, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _input = /* @__PURE__ */_value("input", (_scope, input) => {
   _data(_scope["#text/0"], input.name);
   _html(_scope, input.name, "#text/1");
   _html(_scope, input.missing, "#text/2");
 });
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "Hello <!>! Hello <!>! Hello <!>!";
 export const walks = /* over(1), replace, over(2), replace, over(2), replace, over(2) */"b%c%c%c";

--- a/packages/translator/src/__tests__/fixtures/id-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/id-tag/__snapshots__/dom.expected/template.js
@@ -1,9 +1,9 @@
-import { nextTagId as _nextTagId, data as _data, derivation as _derivation, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _y = /* @__PURE__ */_derivation("y", 1, [], _scope => _nextTagId(), (_scope, y) => _data(_scope["#text/1"], y));
-const _x = /* @__PURE__ */_derivation("x", 1, [], _scope => _nextTagId(), (_scope, x) => _data(_scope["#text/0"], x));
+import { nextTagId as _nextTagId, data as _data, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _y = /* @__PURE__ */_value("y", (_scope, y) => _data(_scope["#text/1"], y));
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _data(_scope["#text/0"], x));
 const _setup = _scope => {
-  _notifySignal(_scope, _x);
-  _notifySignal(_scope, _y);
+  _x(_scope, _nextTagId());
+  _y(_scope, _nextTagId());
 };
 export const template = "<div> </div><!>";
 export const walks = /* next(1), get, out(1), replace, over(1) */"D l%b";

--- a/packages/translator/src/__tests__/fixtures/if-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/if-tag/__snapshots__/dom.expected/template.js
@@ -1,16 +1,18 @@
-import { createRenderer as _createRenderer, register as _register, conditional as _conditional, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { createRenderer as _createRenderer, register as _register, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _elseBody = _register("packages/translator/src/__tests__/fixtures/if-tag/template.marko_5_renderer", /* @__PURE__ */_createRenderer("C", ""));
 const _elseIfBody = _register("packages/translator/src/__tests__/fixtures/if-tag/template.marko_4_renderer", /* @__PURE__ */_createRenderer("B", ""));
 const _ifBody3 = _register("packages/translator/src/__tests__/fixtures/if-tag/template.marko_3_renderer", /* @__PURE__ */_createRenderer("A", ""));
 const _ifBody2 = _register("packages/translator/src/__tests__/fixtures/if-tag/template.marko_2_renderer", /* @__PURE__ */_createRenderer("World", ""));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/if-tag/template.marko_1_renderer", /* @__PURE__ */_createRenderer("Hello", ""));
-const _if3 = /* @__PURE__ */_conditional("#text/2", 1, (_scope, input = _scope["input"]) => input.x ? _ifBody3 : input.y ? _elseIfBody : _elseBody);
-const _if2 = /* @__PURE__ */_conditional("#text/1", 1, (_scope, input = _scope["input"]) => (input.a, input.b) ? _ifBody2 : null);
-const _if = /* @__PURE__ */_conditional("#text/0", 1, (_scope, input = _scope["input"]) => input.a + input.b ? _ifBody : null);
-const _input = /* @__PURE__ */_source("input", [_if, _if2, _if3]);
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
+const _if3 = /* @__PURE__ */_conditional("#text/2");
+const _if2 = /* @__PURE__ */_conditional("#text/1");
+const _if = /* @__PURE__ */_conditional("#text/0");
+const _input = /* @__PURE__ */_value("input", (_scope, input) => {
+  _if(_scope, input.a + input.b ? _ifBody : null);
+  _if2(_scope, (input.a, input.b) ? _ifBody2 : null);
+  _if3(_scope, input.x ? _ifBody3 : input.y ? _elseIfBody : _elseBody);
 });
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<!><!><div><!></div>";
 export const walks = /* replace, over(1), replace, over(1), next(1), replace, out(1) */"%b%bD%l";

--- a/packages/translator/src/__tests__/fixtures/input-destructure/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/input-destructure/__snapshots__/dom.expected/template.js
@@ -1,10 +1,8 @@
-import { data as _data, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { data as _data, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _b = "SIGNAL NOT INITIALIZED";
 const _a = "SIGNAL NOT INITIALIZED";
-const _input = /* @__PURE__ */_source("input", []);
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+const _input = (_scope, input) => {};
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<!> <!>";
 export const walks = /* replace, over(2), replace, over(1) */"%c%b";

--- a/packages/translator/src/__tests__/fixtures/let-tag-set-in-effect/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/let-tag-set-in-effect/__snapshots__/dom.expected/template.js
@@ -1,17 +1,17 @@
-import { setSource as _setSource, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _y = /* @__PURE__ */_source("y", [], (_scope, y) => _data(_scope["#text/1"], y));
+import { queueSource as _queueSource, data as _data, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _y = /* @__PURE__ */_value("y", (_scope, y) => _data(_scope["#text/1"], y));
 const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/let-tag-set-in-effect/template.marko_0_x", _scope => {
   const x = _scope["x"];
   _queueSource(_scope, _y, x);
   _queueSource(_scope, _x, 2);
 });
-const _x = /* @__PURE__ */_source("x", [], (_scope, x) => {
+const _x = /* @__PURE__ */_value("x", (_scope, x) => {
   _data(_scope["#text/0"], x);
   _queueHydrate(_scope, _hydrate_x);
 });
 const _setup = _scope => {
-  _setSource(_scope, _x, 1);
-  _setSource(_scope, _y, 0);
+  _x(_scope, 1);
+  _y(_scope, 0);
 };
 export const template = "<span> </span><span> </span>";
 export const walks = /* next(1), get, out(1), next(1), get, out(1) */"D lD l";

--- a/packages/translator/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.js
@@ -1,15 +1,29 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, subscriber as _subscriber, register as _register, queueHydrate as _queueHydrate, source as _source, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueHydrate as _queueHydrate, intersection as _intersection, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_expr_x_y = _register("packages/translator/src/__tests__/fixtures/let-tag/template.marko_0_x_y", _scope => _on(_scope["#button/0"], "click", () => {
   const x = _scope["x"],
     y = _scope["y"];
   return _queueSource(_scope, _x, _queueSource(_scope, _y, x + y));
 }));
-const _expr_x_y = /* @__PURE__ */_subscriber([], 2, (_scope, x = _scope["x"], y = _scope["y"]) => _queueHydrate(_scope, _hydrate_expr_x_y));
-const _y = /* @__PURE__ */_source("y", [_expr_x_y], (_scope, y) => _data(_scope["#text/2"], y));
-const _x = /* @__PURE__ */_source("x", [_expr_x_y], (_scope, x) => _data(_scope["#text/1"], x));
+const _expr_x_y = /* @__PURE__ */_intersection(2, _scope => {
+  const x = _scope["x"],
+    y = _scope["y"];
+  _queueHydrate(_scope, _hydrate_expr_x_y);
+});
+const _y = /* @__PURE__ */_value("y", (_scope, y, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/2"], y);
+  }
+  _expr_x_y(_scope, _dirty);
+});
+const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/1"], x);
+  }
+  _expr_x_y(_scope, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _x, 1);
-  _setSource(_scope, _y, 1);
+  _x(_scope, 1);
+  _y(_scope, 1);
 };
 export const template = "<button> </button><!>";
 export const walks = /* get, next(1), get, out(1), replace, over(1) */" D l%b";

--- a/packages/translator/src/__tests__/fixtures/let-undefined-until-dom/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/let-undefined-until-dom/__snapshots__/dom.expected/template.js
@@ -1,8 +1,8 @@
-import { setSource as _setSource, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _x = /* @__PURE__ */_source("x", [], (_scope, x) => _data(_scope["#text/0"], x));
+import { queueSource as _queueSource, data as _data, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _data(_scope["#text/0"], x));
 const _hydrate_setup = _register("packages/translator/src/__tests__/fixtures/let-undefined-until-dom/template.marko_0", _scope => _queueSource(_scope, _x, "Client Only"));
 const _setup = _scope => {
-  _setSource(_scope, _x, undefined);
+  _x(_scope, undefined);
   _queueHydrate(_scope, _hydrate_setup);
 };
 export const template = "<div> </div>";

--- a/packages/translator/src/__tests__/fixtures/let-undefined-until-dom/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/let-undefined-until-dom/__snapshots__/dom.expected/template.js
@@ -2,8 +2,8 @@ import { queueSource as _queueSource, data as _data, value as _value, register a
 const _x = /* @__PURE__ */_value("x", (_scope, x) => _data(_scope["#text/0"], x));
 const _hydrate_setup = _register("packages/translator/src/__tests__/fixtures/let-undefined-until-dom/template.marko_0", _scope => _queueSource(_scope, _x, "Client Only"));
 const _setup = _scope => {
-  _x(_scope, undefined);
   _queueHydrate(_scope, _hydrate_setup);
+  _x(_scope, undefined);
 };
 export const template = "<div> </div>";
 export const walks = /* next(1), get, out(1) */"D l";

--- a/packages/translator/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/dom.expected/template.js
@@ -1,5 +1,5 @@
-import { setSource as _setSource, queueSource as _queueSource, lifecycle as _lifecycle, data as _data, on as _on, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _prev = /* @__PURE__ */_source("prev", [], (_scope, prev) => _data(_scope["#text/1"], prev));
+import { queueSource as _queueSource, lifecycle as _lifecycle, data as _data, on as _on, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _prev = /* @__PURE__ */_value("prev", (_scope, prev) => _data(_scope["#text/1"], prev));
 const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-assignment/template.marko_0_x", _scope => {
   _lifecycle(_scope, "cleanup", {
     onMount: function () {
@@ -17,13 +17,13 @@ const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/lifecyc
     _queueSource(_scope, _x, x + 1);
   });
 });
-const _x = /* @__PURE__ */_source("x", [], (_scope, x) => {
+const _x = /* @__PURE__ */_value("x", (_scope, x) => {
   _data(_scope["#text/0"], x);
   _queueHydrate(_scope, _hydrate_x);
 });
 const _setup = _scope => {
-  _setSource(_scope, _x, 0);
-  _setSource(_scope, _prev, false);
+  _x(_scope, 0);
+  _prev(_scope, false);
 };
 export const template = "<div>x=<span> </span>, was=<!></div><button id=increment>Increment</button>";
 export const walks = /* next(1), over(1), next(1), get, out(1), over(1), replace, out(1), get, over(1) */"DbD lb%l b";

--- a/packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { lifecycle as _lifecycle, on as _on, queueSource as _queueSource, register as _register, queueHydrate as _queueHydrate, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { lifecycle as _lifecycle, on as _on, queueSource as _queueSource, register as _register, queueHydrate as _queueHydrate, closure as _closure, createRenderer as _createRenderer, conditional as _conditional, value as _value, inConditionalScope as _inConditionalScope, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_x$ifBody = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_1_x", _scope => _lifecycle(_scope, "cleanup", {
   onMount: function () {
     const x = _scope._["x"];
@@ -12,7 +12,11 @@ const _hydrate_x$ifBody = _register("packages/translator/src/__tests__/fixtures/
     document.getElementById("ref").textContent = "Destroy";
   }
 }));
-const _x$ifBody = /* @__PURE__ */_closure("x", (_scope, x) => _queueHydrate(_scope, _hydrate_x$ifBody));
+const _x$ifBody = /* @__PURE__ */_closure("x", (_scope, x, _dirty) => {
+  if (_dirty) {
+    _queueHydrate(_scope, _hydrate_x$ifBody);
+  }
+});
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_1_renderer", /* @__PURE__ */_createRenderer("", "", null, [_x$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/0");
 const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_0_show", _scope => _on(_scope["#button/2"], "click", function () {
@@ -20,11 +24,11 @@ const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/life
   _queueSource(_scope, _show, !show);
 }));
 const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
+  let _if_value;
   if (_dirty) {
-    _if_value = show ? _ifBody : null;
     _queueHydrate(_scope, _hydrate_show);
+    _if_value = show ? _ifBody : null;
   }
-  var _if_value;
   _if(_scope, _if_value, _dirty);
 });
 const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_0_x", _scope => _on(_scope["#button/1"], "click", function () {

--- a/packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { setSource as _setSource, lifecycle as _lifecycle, on as _on, queueSource as _queueSource, inConditionalScope as _inConditionalScope, closure as _closure, register as _register, queueHydrate as _queueHydrate, createRenderer as _createRenderer, conditional as _conditional, source as _source, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { lifecycle as _lifecycle, on as _on, queueSource as _queueSource, register as _register, queueHydrate as _queueHydrate, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_x$ifBody = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_1_x", _scope => _lifecycle(_scope, "cleanup", {
   onMount: function () {
     const x = _scope._["x"];
@@ -12,22 +12,34 @@ const _hydrate_x$ifBody = _register("packages/translator/src/__tests__/fixtures/
     document.getElementById("ref").textContent = "Destroy";
   }
 }));
-const _x$ifBody = /* @__PURE__ */_closure(1, "x", [], (_scope, x) => _queueHydrate(_scope, _hydrate_x$ifBody));
+const _x$ifBody = /* @__PURE__ */_closure("x", (_scope, x) => _queueHydrate(_scope, _hydrate_x$ifBody));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_1_renderer", /* @__PURE__ */_createRenderer("", "", null, [_x$ifBody]));
-const _if = /* @__PURE__ */_conditional("#text/0", 1, (_scope, show = _scope["show"]) => show ? _ifBody : null);
+const _if = /* @__PURE__ */_conditional("#text/0");
 const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_0_show", _scope => _on(_scope["#button/2"], "click", function () {
   const show = _scope["show"];
   _queueSource(_scope, _show, !show);
 }));
-const _show = /* @__PURE__ */_source("show", [_if], (_scope, show) => _queueHydrate(_scope, _hydrate_show));
+const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
+  if (_dirty) {
+    _if_value = show ? _ifBody : null;
+    _queueHydrate(_scope, _hydrate_show);
+  }
+  var _if_value;
+  _if(_scope, _if_value, _dirty);
+});
 const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_0_x", _scope => _on(_scope["#button/1"], "click", function () {
   const x = _scope["x"];
   _queueSource(_scope, _x, x + 1);
 }));
-const _x = /* @__PURE__ */_source("x", [/* @__PURE__ */_inConditionalScope(_x$ifBody, "#text/0")], (_scope, x) => _queueHydrate(_scope, _hydrate_x));
+const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  if (_dirty) {
+    _queueHydrate(_scope, _hydrate_x);
+  }
+  _inConditionalScope(_scope, _dirty, _x$ifBody, "#text/0");
+});
 const _setup = _scope => {
-  _setSource(_scope, _x, 0);
-  _setSource(_scope, _show, true);
+  _x(_scope, 0);
+  _show(_scope, true);
 };
 export const template = "<!><div id=ref></div><button id=increment>Increment</button><button id=toggle>Toggle</button>";
 export const walks = /* replace, over(2), get, over(1), get, over(1) */"%c b b";

--- a/packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
@@ -12,11 +12,7 @@ const _hydrate_x$ifBody = _register("packages/translator/src/__tests__/fixtures/
     document.getElementById("ref").textContent = "Destroy";
   }
 }));
-const _x$ifBody = /* @__PURE__ */_closure("x", (_scope, x, _dirty) => {
-  if (_dirty) {
-    _queueHydrate(_scope, _hydrate_x$ifBody);
-  }
-});
+const _x$ifBody = /* @__PURE__ */_closure("x", (_scope, x) => _queueHydrate(_scope, _hydrate_x$ifBody));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_1_renderer", /* @__PURE__ */_createRenderer("", "", null, [_x$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/0");
 const _hydrate_show = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_0_show", _scope => _on(_scope["#button/2"], "click", function () {

--- a/packages/translator/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { setSource as _setSource, lifecycle as _lifecycle, on as _on, queueSource as _queueSource, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { lifecycle as _lifecycle, on as _on, queueSource as _queueSource, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-this/template.marko_0_x", _scope => {
   _lifecycle(_scope, "cleanup", {
     onMount: function () {
@@ -15,9 +15,9 @@ const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/lifecyc
     _queueSource(_scope, _x, x + 1);
   });
 });
-const _x = /* @__PURE__ */_source("x", [], (_scope, x) => _queueHydrate(_scope, _hydrate_x));
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _queueHydrate(_scope, _hydrate_x));
 const _setup = _scope => {
-  _setSource(_scope, _x, 0);
+  _x(_scope, 0);
 };
 export const template = "<div id=ref></div><button id=increment>Increment</button>";
 export const walks = /* over(1), get, over(1) */"b b";

--- a/packages/translator/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { setSource as _setSource, lifecycle as _lifecycle, on as _on, queueSource as _queueSource, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { lifecycle as _lifecycle, on as _on, queueSource as _queueSource, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag/template.marko_0_x", _scope => {
   _lifecycle(_scope, "cleanup", {
     onMount: function () {
@@ -15,9 +15,9 @@ const _hydrate_x = _register("packages/translator/src/__tests__/fixtures/lifecyc
     _queueSource(_scope, _x, x + 1);
   });
 });
-const _x = /* @__PURE__ */_source("x", [], (_scope, x) => _queueHydrate(_scope, _hydrate_x));
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _queueHydrate(_scope, _hydrate_x));
 const _setup = _scope => {
-  _setSource(_scope, _x, 0);
+  _x(_scope, 0);
 };
 export const template = "<div id=ref></div><button id=increment>Increment</button>";
 export const walks = /* over(1), get, over(1) */"b b";

--- a/packages/translator/src/__tests__/fixtures/migrate-input/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/migrate-input/__snapshots__/dom.expected/template.js
@@ -1,8 +1,6 @@
-import { data as _data, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _input = /* @__PURE__ */_source("input", [], (_scope, input) => _data(_scope["#text/0"], input.x));
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+import { data as _data, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _data(_scope["#text/0"], input.x));
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<div><span> </span></div>";
 export const walks = /* next(2), get, out(2) */"E m";

--- a/packages/translator/src/__tests__/fixtures/migrate-out-global/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/migrate-out-global/__snapshots__/dom.expected/template.js
@@ -1,5 +1,5 @@
 import { data as _data, contextClosure as _contextClosure, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _$global2 = _contextClosure("_$global", "$", [], (_scope, _$global) => _data(_scope["#text/0"], _$global.x));
+const _$global2 = /* @__PURE__ */_contextClosure("_$global", "$", (_scope, _$global) => _data(_scope["#text/0"], _$global.x));
 export const template = "<div><span> </span></div>";
 export const walks = /* next(2), get, out(2) */"E m";
 export const setup = function () {};

--- a/packages/translator/src/__tests__/fixtures/move-and-clear-children/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/move-and-clear-children/__snapshots__/dom.expected/template.js
@@ -1,15 +1,21 @@
-import { data as _data, source as _source, createRenderer as _createRenderer, setSource as _setSource, loop as _loop, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _child$forBody = /* @__PURE__ */_source("child", [], (_scope, child) => _data(_scope["#text/0"], child.text));
+import { data as _data, value as _value, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _child$forBody = /* @__PURE__ */_value("child", (_scope, child) => _data(_scope["#text/0"], child.text));
 const _forBody = /* @__PURE__ */_createRenderer(" ", /* get */" ");
-const _for = /* @__PURE__ */_loop("#div/0", 1, _forBody, [_child$forBody], (_scope, [child]) => _setSource(_scope, _child$forBody, child), (_scope, children = _scope["children"]) => [children, function (c) {
-  return c.id;
-}]);
-const _children = /* @__PURE__ */_source("children", [_for]);
-export const attrs = /* @__PURE__ */_destructureSources([_children], (_scope, {
-  children
-}) => {
-  _setSource(_scope, _children, children);
+const _for = /* @__PURE__ */_loop("#div/0", _forBody, (_scope, _destructure, _dirty = true) => {
+  let child;
+  if (_dirty) [child] = _destructure;
+  _child$forBody(_scope, child, _dirty);
 });
+const _children = /* @__PURE__ */_value("children", (_scope, children) => _for(_scope, [children, function (c) {
+  return c.id;
+}]));
+export const attrs = (_scope, _destructure2, _dirty = true) => {
+  let children;
+  if (_dirty) ({
+    children
+  } = _destructure2);
+  _children(_scope, children, _dirty);
+};
 export { _children as _apply_children };
 export const template = "<div></div>";
 export const walks = /* get, over(1) */" b";

--- a/packages/translator/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/dom.expected/template.js
@@ -1,13 +1,15 @@
-import { data as _data, source as _source, createRenderer as _createRenderer, setSource as _setSource, loop as _loop, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _child$forBody = /* @__PURE__ */_source("child", [], (_scope, child) => _data(_scope["#text/0"], child.text));
+import { data as _data, value as _value, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _child$forBody = /* @__PURE__ */_value("child", (_scope, child) => _data(_scope["#text/0"], child.text));
 const _forBody = /* @__PURE__ */_createRenderer(" ", /* get */" ");
-const _for = /* @__PURE__ */_loop("#text/0", 1, _forBody, [_child$forBody], (_scope, [child]) => _setSource(_scope, _child$forBody, child), (_scope, input = _scope["input"]) => [input.children, function (c) {
-  return c.id;
-}]);
-const _input = /* @__PURE__ */_source("input", [_for]);
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+  let child;
+  if (_dirty) [child] = _destructure;
+  _child$forBody(_scope, child, _dirty);
 });
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _for(_scope, [input.children, function (c) {
+  return c.id;
+}]));
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator/src/__tests__/fixtures/native-tag-ref-downstream-effect/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/native-tag-ref-downstream-effect/__snapshots__/dom.expected/template.js
@@ -1,12 +1,12 @@
-import { register as _register, queueHydrate as _queueHydrate, createRenderer as _createRenderer, conditional as _conditional, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { register as _register, queueHydrate as _queueHydrate, createRenderer as _createRenderer, conditional as _conditional, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_setup$ifBody = _register("packages/translator/src/__tests__/fixtures/native-tag-ref-downstream-effect/template.marko_1", _scope => _scope._["#div/0"].textContent = "hello");
 const _setup$ifBody = _scope => {
   _queueHydrate(_scope, _hydrate_setup$ifBody);
 };
 const _ifBody = /* @__PURE__ */_createRenderer("", "", _setup$ifBody);
-const _if = /* @__PURE__ */_conditional("#text/1", 1, _scope => true ? _ifBody : null);
+const _if = /* @__PURE__ */_conditional("#text/1");
 const _setup = _scope => {
-  _notifySignal(_scope, _if);
+  _if(_scope, true ? _ifBody : null);
 };
 export const template = "<div></div><!>";
 export const walks = /* get, over(1), replace, over(1) */" b%b";

--- a/packages/translator/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/components/hello-setter.js
+++ b/packages/translator/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/components/hello-setter.js
@@ -1,14 +1,16 @@
-import { source as _source, register as _register, queueHydrate as _queueHydrate, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_el = _register("packages/translator/src/__tests__/fixtures/native-tag-ref-effect-child/components/hello-setter.marko_0_el", _scope => {
   const el = _scope["el"];
   el().textContent = "hello";
 });
-const _el = /* @__PURE__ */_source("el", [], (_scope, el) => _queueHydrate(_scope, _hydrate_el));
-export const attrs = /* @__PURE__ */_destructureSources([_el], (_scope, {
-  el
-}) => {
-  _setSource(_scope, _el, el);
-});
+const _el = /* @__PURE__ */_value("el", (_scope, el) => _queueHydrate(_scope, _hydrate_el));
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let el;
+  if (_dirty) ({
+    el
+  } = _destructure);
+  _el(_scope, el, _dirty);
+};
 export { _el as _apply_el };
 export const template = "";
 export const walks = "";

--- a/packages/translator/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/template.js
@@ -1,13 +1,11 @@
-import { bind as _bind, inChild as _inChild, setSource as _setSource, notifySignal as _notifySignal, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { bindFunction as _bindFunction, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const el_getter = _scope => _scope["#div/0"];
 import { setup as _helloSetter, attrs as _helloSetter_attrs, template as _helloSetter_template, walks as _helloSetter_walks } from "./components/hello-setter.marko";
-const _helloSetter_attrs_inChild = _inChild(_helloSetter_attrs, "#childScope/1");
 const _setup = _scope => {
   _helloSetter(_scope["#childScope/1"]);
-  _setSource(_scope["#childScope/1"], _helloSetter_attrs, {
-    el: /* @__PURE__ */_bind(_scope, el_getter)
+  _helloSetter_attrs(_scope["#childScope/1"], {
+    el: /* @__PURE__ */_bindFunction(_scope, el_getter)
   });
-  _notifySignal(_scope, _helloSetter_attrs_inChild);
 };
 export const template = `<div></div>${_helloSetter_template}`;
 export const walks = /* get, over(1), beginChild, _helloSetter_walks, endChild */` b/${_helloSetter_walks}&`;

--- a/packages/translator/src/__tests__/fixtures/native-tag-ref-hoisting/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/native-tag-ref-hoisting/__snapshots__/dom.expected/template.js
@@ -1,9 +1,9 @@
-import { createRenderer as _createRenderer, conditional as _conditional, notifySignal as _notifySignal, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { createRenderer as _createRenderer, conditional as _conditional, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _ifBody = /* @__PURE__ */_createRenderer("<div></div>", /* get */" ");
-const _if = /* @__PURE__ */_conditional("#text/0", 1, _scope => true ? _ifBody : null);
+const _if = /* @__PURE__ */_conditional("#text/0");
 const _hydrate_setup = _register("packages/translator/src/__tests__/fixtures/native-tag-ref-hoisting/template.marko_0", _scope => _scope._["#div/0"].textContent = "hello");
 const _setup = _scope => {
-  _notifySignal(_scope, _if);
+  _if(_scope, true ? _ifBody : null);
   _queueHydrate(_scope, _hydrate_setup);
 };
 export const template = "<!>";

--- a/packages/translator/src/__tests__/fixtures/native-tag-ref-hoisting/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/native-tag-ref-hoisting/__snapshots__/dom.expected/template.js
@@ -3,8 +3,8 @@ const _ifBody = /* @__PURE__ */_createRenderer("<div></div>", /* get */" ");
 const _if = /* @__PURE__ */_conditional("#text/0");
 const _hydrate_setup = _register("packages/translator/src/__tests__/fixtures/native-tag-ref-hoisting/template.marko_0", _scope => _scope._["#div/0"].textContent = "hello");
 const _setup = _scope => {
-  _if(_scope, true ? _ifBody : null);
   _queueHydrate(_scope, _hydrate_setup);
+  _if(_scope, true ? _ifBody : null);
 };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator/src/__tests__/fixtures/nested-assignment-expression/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/nested-assignment-expression/__snapshots__/dom.expected/template.js
@@ -1,19 +1,19 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _lastCount2 = /* @__PURE__ */_source("lastCount2", [], (_scope, lastCount2) => _data(_scope["#text/3"], lastCount2));
-const _lastCount = /* @__PURE__ */_source("lastCount", [], (_scope, lastCount) => _data(_scope["#text/2"], lastCount));
+import { on as _on, queueSource as _queueSource, data as _data, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _lastCount2 = /* @__PURE__ */_value("lastCount2", (_scope, lastCount2) => _data(_scope["#text/3"], lastCount2));
+const _lastCount = /* @__PURE__ */_value("lastCount", (_scope, lastCount) => _data(_scope["#text/2"], lastCount));
 const _hydrate_clickCount = _register("packages/translator/src/__tests__/fixtures/nested-assignment-expression/template.marko_0_clickCount", _scope => _on(_scope["#button/0"], "click", function () {
   const clickCount = _scope["clickCount"];
   const last = _queueSource(_scope, _lastCount, (_queueSource(_scope, _clickCount, clickCount + 1), clickCount));
   _queueSource(_scope, _lastCount2, last);
 }));
-const _clickCount = /* @__PURE__ */_source("clickCount", [], (_scope, clickCount) => {
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => {
   _data(_scope["#text/1"], clickCount);
   _queueHydrate(_scope, _hydrate_clickCount);
 });
 const _setup = _scope => {
-  _setSource(_scope, _clickCount, 0);
-  _setSource(_scope, _lastCount, 0);
-  _setSource(_scope, _lastCount2, 0);
+  _clickCount(_scope, 0);
+  _lastCount(_scope, 0);
+  _lastCount2(_scope, 0);
 };
 export const template = "<button> </button>used to be <span> </span> which should be the same as <span> </span>";
 export const walks = /* get, next(1), get, out(1), over(1), next(1), get, out(1), over(1), next(1), get, out(1) */" D lbD lbD l";

--- a/packages/translator/src/__tests__/fixtures/placeholders/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/placeholders/__snapshots__/dom.expected/template.js
@@ -1,5 +1,5 @@
-import { data as _data, html as _html, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _input = /* @__PURE__ */_source("input", [], (_scope, input) => {
+import { data as _data, html as _html, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _input = /* @__PURE__ */_value("input", (_scope, input) => {
   _data(_scope["#text/0"], input.x);
   _data(_scope["#text/1"], input.x);
   _data(_scope["#text/2"], input.x);
@@ -8,9 +8,7 @@ const _input = /* @__PURE__ */_source("input", [], (_scope, input) => {
 const _setup = _scope => {
   _html(_scope, "Hello HTML <a/>", "#text/4");
 };
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<!><span> <div></div></span><div><div>a</div><!>Hello Text &lt;a/><!><!><script>\n    Hello &lt;b> &lt;/script>\n  </script></div>";
 export const walks = /* replace, over(1), next(1), get, out(1), next(1), over(1), replace, over(2), replace, over(2), replace, out(1) */"%bD lDb%c%c%l";

--- a/packages/translator/src/__tests__/fixtures/reassignment-expression-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/reassignment-expression-counter/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { setSource as _setSource, on as _on, queueSource as _queueSource, data as _data, source as _source, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueHydrate as _queueHydrate, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/reassignment-expression-counter/template.marko_0_count", _scope => {
   _on(_scope["#button/0"], "click", function () {
     const count = _scope["count"];
@@ -13,14 +13,14 @@ const _hydrate_count = _register("packages/translator/src/__tests__/fixtures/rea
     _queueSource(_scope, _count, count ** 3);
   });
 });
-const _count = /* @__PURE__ */_source("count", [], (_scope, count) => {
+const _count = /* @__PURE__ */_value("count", (_scope, count) => {
   _data(_scope["#text/1"], count);
   _data(_scope["#text/3"], count);
   _data(_scope["#text/5"], count);
   _queueHydrate(_scope, _hydrate_count);
 });
 const _setup = _scope => {
-  _setSource(_scope, _count, 0);
+  _count(_scope, 0);
 };
 export const template = "<button id=addTwo> </button><button id=triple> </button><button id=cube> </button>";
 export const walks = /* get, next(1), get, out(1), get, next(1), get, out(1), get, next(1), get, out(1) */" D l D l D l";

--- a/packages/translator/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/dom.expected/template.js
@@ -1,15 +1,21 @@
-import { data as _data, source as _source, createRenderer as _createRenderer, setSource as _setSource, loop as _loop, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _child$forBody = /* @__PURE__ */_source("child", [], (_scope, child) => _data(_scope["#text/0"], child.text));
+import { data as _data, value as _value, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _child$forBody = /* @__PURE__ */_value("child", (_scope, child) => _data(_scope["#text/0"], child.text));
 const _forBody = /* @__PURE__ */_createRenderer(" ", /* get */" ");
-const _for = /* @__PURE__ */_loop("#div/0", 1, _forBody, [_child$forBody], (_scope, [child]) => _setSource(_scope, _child$forBody, child), (_scope, children = _scope["children"]) => [children, function (c) {
-  return c.id;
-}]);
-const _children = /* @__PURE__ */_source("children", [_for]);
-export const attrs = /* @__PURE__ */_destructureSources([_children], (_scope, {
-  children
-}) => {
-  _setSource(_scope, _children, children);
+const _for = /* @__PURE__ */_loop("#div/0", _forBody, (_scope, _destructure, _dirty = true) => {
+  let child;
+  if (_dirty) [child] = _destructure;
+  _child$forBody(_scope, child, _dirty);
 });
+const _children = /* @__PURE__ */_value("children", (_scope, children) => _for(_scope, [children, function (c) {
+  return c.id;
+}]));
+export const attrs = (_scope, _destructure2, _dirty = true) => {
+  let children;
+  if (_dirty) ({
+    children
+  } = _destructure2);
+  _children(_scope, children, _dirty);
+};
 export { _children as _apply_children };
 export const template = "<div></div>";
 export const walks = /* get, over(1) */" b";

--- a/packages/translator/src/__tests__/fixtures/return-tag-no-var/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/return-tag-no-var/__snapshots__/dom.expected/components/child.js
@@ -1,9 +1,9 @@
 import { tagVarSignal as _tagVarSignal, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  let _tagVarSignal_value;
   if (_dirty) {
     _tagVarSignal_value = x;
   }
-  var _tagVarSignal_value;
   _tagVarSignal(_scope, _tagVarSignal_value, _dirty);
 });
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/return-tag-no-var/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/return-tag-no-var/__snapshots__/dom.expected/components/child.js
@@ -1,7 +1,13 @@
-import { setSource as _setSource, tagVarSignal as _tagVarSignal, source as _source, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _x = /* @__PURE__ */_source("x", [_tagVarSignal], (_scope, x) => _setSource(_scope, _tagVarSignal, x));
+import { tagVarSignal as _tagVarSignal, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
+  if (_dirty) {
+    _tagVarSignal_value = x;
+  }
+  var _tagVarSignal_value;
+  _tagVarSignal(_scope, _tagVarSignal_value, _dirty);
+});
 const _setup = _scope => {
-  _setSource(_scope, _x, 1);
+  _x(_scope, 1);
 };
 export const template = "<span>child</span>";
 export const walks = /* over(1) */"b";

--- a/packages/translator/src/__tests__/fixtures/return-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/return-tag/__snapshots__/dom.expected/template.js
@@ -1,19 +1,15 @@
-import { tagVarSignal as _tagVarSignal, setSource as _setSource, notifySignal as _notifySignal, createRenderer as _createRenderer, register as _register, conditional as _conditional, source as _source, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { tagVarSignal as _tagVarSignal, createRenderer as _createRenderer, register as _register, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _setup$elseBody = _scope => {
-  _setSource(_scope, _tagVarSignal, 2);
-  _notifySignal(_scope, _tagVarSignal);
+  _tagVarSignal(_scope, 2);
 };
 const _elseBody = _register("packages/translator/src/__tests__/fixtures/return-tag/template.marko_2_renderer", /* @__PURE__ */_createRenderer("", "", _setup$elseBody));
 const _setup$ifBody = _scope => {
-  _setSource(_scope, _tagVarSignal, 1);
-  _notifySignal(_scope, _tagVarSignal);
+  _tagVarSignal(_scope, 1);
 };
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/return-tag/template.marko_1_renderer", /* @__PURE__ */_createRenderer("", "", _setup$ifBody));
-const _if = /* @__PURE__ */_conditional("#text/0", 1, (_scope, input = _scope["input"]) => input.show ? _ifBody : _elseBody);
-const _input = /* @__PURE__ */_source("input", [_if]);
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+const _if = /* @__PURE__ */_conditional("#text/0");
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _if(_scope, input.show ? _ifBody : _elseBody));
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.expected/template.js
@@ -1,9 +1,5 @@
 import { data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, inConditionalScope as _inConditionalScope, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _value$ifBody = /* @__PURE__ */_closure("value", (_scope, value, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/0"], value);
-  }
-});
+const _value$ifBody = /* @__PURE__ */_closure("value", (_scope, value) => _data(_scope["#text/0"], value));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/toggle-first-child/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_value$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/0");
 const _value = /* @__PURE__ */_value2("value", (_scope, value, _dirty) => {

--- a/packages/translator/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.expected/template.js
@@ -1,12 +1,16 @@
-import { data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _value$ifBody = /* @__PURE__ */_closure("value", (_scope, value) => _data(_scope["#text/0"], value));
+import { data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, inConditionalScope as _inConditionalScope, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _value$ifBody = /* @__PURE__ */_closure("value", (_scope, value, _dirty) => {
+  if (_dirty) {
+    _data(_scope["#text/0"], value);
+  }
+});
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/toggle-first-child/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_value$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/0");
 const _value = /* @__PURE__ */_value2("value", (_scope, value, _dirty) => {
+  let _if_value;
   if (_dirty) {
     _if_value = value ? _ifBody : null;
   }
-  var _if_value;
   _if(_scope, _if_value, _dirty);
   _inConditionalScope(_scope, _dirty, _value$ifBody, "#text/0");
 });

--- a/packages/translator/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.expected/template.js
@@ -1,13 +1,22 @@
-import { data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _value$ifBody = /* @__PURE__ */_closure(1, "value", [], (_scope, value) => _data(_scope["#text/0"], value));
+import { data as _data, inConditionalScope as _inConditionalScope, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _value$ifBody = /* @__PURE__ */_closure("value", (_scope, value) => _data(_scope["#text/0"], value));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/toggle-first-child/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_value$ifBody]));
-const _if = /* @__PURE__ */_conditional("#text/0", 1, (_scope, value = _scope["value"]) => value ? _ifBody : null);
-const _value = /* @__PURE__ */_source("value", [_if, /* @__PURE__ */_inConditionalScope(_value$ifBody, "#text/0")]);
-export const attrs = /* @__PURE__ */_destructureSources([_value], (_scope, {
-  value
-}) => {
-  _setSource(_scope, _value, value);
+const _if = /* @__PURE__ */_conditional("#text/0");
+const _value = /* @__PURE__ */_value2("value", (_scope, value, _dirty) => {
+  if (_dirty) {
+    _if_value = value ? _ifBody : null;
+  }
+  var _if_value;
+  _if(_scope, _if_value, _dirty);
+  _inConditionalScope(_scope, _dirty, _value$ifBody, "#text/0");
 });
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let value;
+  if (_dirty) ({
+    value
+  } = _destructure);
+  _value(_scope, value, _dirty);
+};
 export { _value as _apply_value };
 export const template = "<div><!><span></span><span></span></div>";
 export const walks = /* next(1), replace, out(1) */"D%l";

--- a/packages/translator/src/__tests__/fixtures/toggle-nested/browser.ts
+++ b/packages/translator/src/__tests__/fixtures/toggle-nested/browser.ts
@@ -8,9 +8,7 @@ import {
   dynamicFragment,
   closure,
   Scope,
-  destructureSources,
-  source,
-  setSource,
+  value,
 } from "@marko/runtime-fluurt/src/dom";
 import { next, over, get } from "../../utils/walks";
 import type { steps } from "./test";
@@ -62,10 +60,10 @@ const enum INDEX_IF2 {
   text = "#text/0",
 }
 
-type If2Scope = Scope<{
-  _: If0Scope;
-  [INDEX_IF2.text]: Text;
-}>;
+// type If2Scope = Scope<{
+//   _: If0Scope;
+//   [INDEX_IF2.text]: Text;
+// }>;
 
 // <attrs/{show, value1, value2}/>
 // <div>
@@ -78,68 +76,59 @@ type If2Scope = Scope<{
 export const template = `<div></div>`;
 export const walks = get + over(1);
 
-const value2$if2 = closure(
-  2,
-  INDEX.value2,
-  [],
-  (scope: If2Scope, value: string) => {
-    data(scope[INDEX_IF2.text], value);
+export const attrs = (scope: Scope, input: Input, dirty?: null | boolean) => {
+  let show, value1, value2;
+  if (dirty) {
+    ({ show, value1, value2 } = input);
   }
-);
+  _show(scope, show, dirty);
+  _value1(scope, value1, dirty);
+  _value2(scope, value2, dirty);
+};
 
-const value1$if1 = closure(
-  2,
-  INDEX.value1,
-  [],
-  (scope: If1Scope, value: string) => {
-    data(scope[INDEX_IF1.text], value);
-  }
-);
-
-const _if2 = conditional(INDEX_IF0.conditional1, 1, (scope: If0Scope) => {
-  return scope._[INDEX.value2] ? ifBody2 : undefined;
+const _show = value(INDEX.show, (scope, value, dirty) => {
+  _if0(scope, value ? ifBody0 : undefined, dirty);
+});
+const _value1 = value(INDEX.value1, (scope, _value, dirty) => {
+  inConditionalScope(scope, dirty!, value1$if0, INDEX.conditional);
+});
+const _value2 = value(INDEX.value2, (scope, _value, dirty) => {
+  inConditionalScope(scope, dirty!, value2$if0, INDEX.conditional);
 });
 
-const _if1 = conditional(INDEX_IF0.conditional0, 1, (scope: If0Scope) =>
-  scope._[INDEX.value1] ? ifBody1 : undefined
+const _if0 = conditionalOnlyChild(INDEX.conditional);
+
+const value1$if0 = closure(INDEX.value1, (scope, value, dirty) => {
+  _if1(scope, value ? ifBody1 : undefined, dirty);
+  inConditionalScope(scope, dirty!, value1$if1, INDEX_IF0.conditional0);
+});
+
+const value2$if0 = closure(INDEX.value2, (scope, value, dirty) => {
+  _if2(scope, value ? ifBody2 : undefined, dirty);
+  inConditionalScope(scope, dirty!, value2$if2, INDEX_IF0.conditional1);
+});
+
+const _if1 = conditional(INDEX_IF0.conditional0);
+
+const value1$if1 = closure(
+  INDEX.value1,
+  (scope, value: string) => {
+    data(scope[INDEX_IF1.text], value);
+  },
+  (scope) => {
+    return (scope as If1Scope)._._;
+  }
 );
 
-const value2$if0 = closure(1, INDEX.value2, [
-  _if2,
-  inConditionalScope(value2$if2, INDEX_IF0.conditional1),
-]);
+const _if2 = conditional(INDEX_IF0.conditional1);
 
-const value1$if0 = closure(1, INDEX.value1, [
-  _if1,
-  inConditionalScope(value1$if1, INDEX_IF0.conditional0),
-]);
-
-const _if0 = conditionalOnlyChild(
-  INDEX.conditional,
-  1,
-  (scope: ComponentScope) => (scope[INDEX.show] ? ifBody0 : undefined)
-);
-
-export const value2_subscribers = [
-  inConditionalScope(value2$if0, INDEX.conditional),
-];
-
-export const value1_subscribers = [
-  inConditionalScope(value1$if0, INDEX.conditional),
-];
-
-export const show_subscribers = [_if0];
-
-const _show = source(INDEX.show, show_subscribers);
-const _value1 = source(INDEX.value1, value1_subscribers);
-const _value2 = source(INDEX.value2, value2_subscribers);
-
-export const attrs = destructureSources(
-  [_show, _value1, _value2],
-  (scope: ComponentScope, { show, value1, value2 }: Input) => {
-    setSource(scope, _show, show);
-    setSource(scope, _value1, value1);
-    setSource(scope, _value2, value2);
+const value2$if2 = closure(
+  INDEX.value2,
+  (scope, value: string) => {
+    data(scope[INDEX_IF2.text], value);
+  },
+  (scope) => {
+    return (scope as If1Scope)._._;
   }
 );
 

--- a/packages/translator/src/__tests__/fixtures/update-attr/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/update-attr/__snapshots__/dom.expected/template.js
@@ -1,8 +1,6 @@
-import { attr as _attr, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _input = /* @__PURE__ */_source("input", [], (_scope, input) => _attr(_scope["#div/0"], "b", input.value));
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+import { attr as _attr, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _attr(_scope["#div/0"], "b", input.value));
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<div a=0></div>";
 export const walks = /* get, over(1) */" b";

--- a/packages/translator/src/__tests__/fixtures/update-dynamic-attrs/browser.ts
+++ b/packages/translator/src/__tests__/fixtures/update-dynamic-attrs/browser.ts
@@ -2,9 +2,7 @@ import {
   attrs,
   createRenderFn,
   Scope,
-  destructureSources,
-  setSource,
-  source,
+  value,
 } from "@marko/runtime-fluurt/src/dom";
 import { get, over } from "../../utils/walks";
 import type { steps } from "./test";
@@ -16,28 +14,26 @@ const enum INDEX {
   value = "value",
 }
 
-type ComponentScope = Scope<{
-  [INDEX.div]: HTMLDivElement;
-  [INDEX.value]: Input["value"];
-}>;
+// type ComponentScope = Scope<{
+//   [INDEX.div]: HTMLDivElement;
+//   [INDEX.value]: Input["value"];
+// }>;
 
 // <attrs/{ value }/>
 // <div ...value/>
 export const template = `<div></div>`;
 export const walks = get + over(1);
 
-export const value_subscribers = [];
-export const value_action = (scope: ComponentScope, value: Input["value"]) => {
+const _value = value(INDEX.value, (scope: Scope, value: Input["value"]) => {
   value && attrs(scope, INDEX.div, value);
+});
+
+export const _attrs = (scope: Scope, input: Input, dirty?: boolean | null) => {
+  let value: Input["value"];
+  if (dirty) {
+    ({ value } = input);
+  }
+  _value(scope, value!, dirty);
 };
 
-const _value = source(INDEX.value, value_subscribers, value_action);
-
-export const _attrs = destructureSources(
-  [_value],
-  (scope: ComponentScope, { value }: Input) => {
-    setSource(scope, _value, value);
-  }
-);
-
-export default createRenderFn(template, walks, undefined, _attrs);
+export default createRenderFn<Input>(template, walks, undefined, _attrs);

--- a/packages/translator/src/__tests__/fixtures/update-html/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/update-html/__snapshots__/dom.expected/template.js
@@ -1,10 +1,12 @@
-import { html as _html, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _value = /* @__PURE__ */_source("value", [], (_scope, value) => _html(_scope, value, "#text/0"));
-export const attrs = /* @__PURE__ */_destructureSources([_value], (_scope, {
-  value
-}) => {
-  _setSource(_scope, _value, value);
-});
+import { html as _html, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _value = /* @__PURE__ */_value2("value", (_scope, value) => _html(_scope, value, "#text/0"));
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let value;
+  if (_dirty) ({
+    value
+  } = _destructure);
+  _value(_scope, value, _dirty);
+};
 export { _value as _apply_value };
 export const template = "<em>Testing</em> <!>";
 export const walks = /* over(2), replace, over(1) */"c%b";

--- a/packages/translator/src/__tests__/fixtures/update-text/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/update-text/__snapshots__/dom.expected/template.js
@@ -1,10 +1,12 @@
-import { data as _data, source as _source, setSource as _setSource, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _value = /* @__PURE__ */_source("value", [], (_scope, value) => _data(_scope["#text/0"], value));
-export const attrs = /* @__PURE__ */_destructureSources([_value], (_scope, {
-  value
-}) => {
-  _setSource(_scope, _value, value);
-});
+import { data as _data, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _value = /* @__PURE__ */_value2("value", (_scope, value) => _data(_scope["#text/0"], value));
+export const attrs = (_scope, _destructure, _dirty = true) => {
+  let value;
+  if (_dirty) ({
+    value
+  } = _destructure);
+  _value(_scope, value, _dirty);
+};
 export { _value as _apply_value };
 export const template = "Static <!>";
 export const walks = /* over(1), replace, over(1) */"b%b";

--- a/packages/translator/src/__tests__/fixtures/user-effect-cleanup/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/user-effect-cleanup/__snapshots__/dom.expected/template.js
@@ -1,20 +1,22 @@
-import { setSource as _setSource, data as _data, queueSource as _queueSource, userEffect as _userEffect, subscriber as _subscriber, source as _source, register as _register, queueHydrate as _queueHydrate, destructureSources as _destructureSources, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _expr_a_b = /* @__PURE__ */_subscriber([], 2, (_scope, a = _scope["a"], b = _scope["b"]) => _data(_scope["#text/0"], "" + a + b));
-const _b = /* @__PURE__ */_source("b", [_expr_a_b]);
-const _a = /* @__PURE__ */_source("a", [_expr_a_b]);
+import { data as _data, queueSource as _queueSource, userEffect as _userEffect, intersection as _intersection, value as _value, register as _register, queueHydrate as _queueHydrate, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _expr_a_b = /* @__PURE__ */_intersection(2, _scope => {
+  const a = _scope["a"],
+    b = _scope["b"];
+  _data(_scope["#text/0"], "" + a + b);
+});
+const _b = /* @__PURE__ */_value("b", (_scope, b, _dirty) => _expr_a_b(_scope, _dirty));
+const _a = /* @__PURE__ */_value("a", (_scope, a, _dirty) => _expr_a_b(_scope, _dirty));
 const _hydrate_input = _register("packages/translator/src/__tests__/fixtures/user-effect-cleanup/template.marko_0_input", _scope => _userEffect(_scope, "cleanup", function () {
   const input = _scope["input"];
   const previousValue = _queueSource(_scope, _a, input.value + 1);
   return () => _queueSource(_scope, _b, previousValue);
 }));
-const _input = /* @__PURE__ */_source("input", [], (_scope, input) => _queueHydrate(_scope, _hydrate_input));
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _queueHydrate(_scope, _hydrate_input));
 const _setup = _scope => {
-  _setSource(_scope, _a, 0);
-  _setSource(_scope, _b, 0);
+  _a(_scope, 0);
+  _b(_scope, 0);
 };
-export const attrs = /* @__PURE__ */_destructureSources([_input], (_scope, input) => {
-  _setSource(_scope, _input, input);
-});
+export const attrs = _input;
 export { _input as _apply_input };
 export const template = "<div> </div>";
 export const walks = /* next(1), get, out(1) */"D l";

--- a/packages/translator/src/__tests__/main.test.ts
+++ b/packages/translator/src/__tests__/main.test.ts
@@ -73,10 +73,26 @@ describe("translator", () => {
             return `virtual:${virtualPath} ${code}`;
           },
         };
+        const errors: Error[] = [];
 
         for (const file of additionalMarkoFiles) {
-          const name = path.relative(fixtureDir, file).replace(".marko", ".js");
-          await snap(() => compileCode(file, finalConfig), name, fixtureDir);
+          try {
+            const name = path
+              .relative(fixtureDir, file)
+              .replace(".marko", ".js");
+            await snap(() => compileCode(file, finalConfig), name, fixtureDir);
+          } catch (e) {
+            errors.push(e as Error);
+          }
+        }
+
+        if (errors.length === 1) {
+          throw errors[0];
+        } else if (errors.length > 1) {
+          throw new AggregateError(
+            errors,
+            "\n" + errors.map((e) => e.toString()).join("\n")
+          );
         }
       };
 

--- a/packages/translator/src/core/attrs.ts
+++ b/packages/translator/src/core/attrs.ts
@@ -7,7 +7,7 @@ import {
 import { ReserveType } from "../util/reserve";
 import { getOrCreateSectionId } from "../util/sections";
 import { currentProgramPath } from "../visitors/program";
-import { initSource } from "../util/signals";
+import { initValue } from "../util/signals";
 
 declare module "@marko/compiler/dist/types" {
   export interface ProgramExtra {
@@ -47,7 +47,7 @@ export default {
     const bindings = currentProgramPath.node.extra?.attrs?.bindings;
     if (bindings) {
       for (const key in bindings) {
-        initSource(bindings[key].extra!.reserve!);
+        initValue(bindings[key].extra!.reserve!);
       }
     }
 

--- a/packages/translator/src/core/id.ts
+++ b/packages/translator/src/core/id.ts
@@ -8,7 +8,8 @@ import {
 import { assertNoBodyContent } from "../util/assert";
 import { callRuntime } from "../util/runtime";
 import { isOutputHTML } from "../util/marko-config";
-import { initDerivation } from "../util/signals";
+import { addValue, initValue } from "../util/signals";
+import { getSectionId } from "../util/sections";
 
 export default {
   translate(tag) {
@@ -38,7 +39,8 @@ export default {
         t.variableDeclaration("const", [t.variableDeclarator(node.var, id)])
       );
     } else {
-      initDerivation(tagVar.extra.reserve!, undefined, id);
+      const source = initValue(tagVar.extra.reserve!);
+      addValue(getSectionId(tag), undefined, source, id);
       tag.remove();
     }
   },

--- a/packages/translator/src/core/let.ts
+++ b/packages/translator/src/core/let.ts
@@ -3,11 +3,9 @@ import { Tag, assertNoParams } from "@marko/babel-utils";
 import { assertNoBodyContent } from "../util/assert";
 import translateVar from "../util/translate-var";
 import { isOutputDOM } from "../util/marko-config";
-import { initSource, queueSource, addStatement } from "../util/signals";
-import { callRuntime } from "../util/runtime";
+import { initValue, queueSource, addValue } from "../util/signals";
 import { registerAssignmentReplacer } from "../util/replace-assignments";
 import { getSectionId } from "../util/sections";
-import { scopeIdentifier } from "../visitors/program";
 
 export default {
   translate(tag) {
@@ -37,21 +35,15 @@ export default {
     if (isOutputDOM()) {
       const sectionId = getSectionId(tag);
       const binding = tagVar.extra.reserve!;
-      const source = initSource(binding);
-      // TODO: add defined guard if bindings exist.
-      addStatement(
-        "apply",
-        sectionId,
-        defaultAttr.extra?.valueReferences,
-        t.expressionStatement(
-          callRuntime(
-            "setSource",
-            scopeIdentifier,
-            source.identifier,
-            defaultAttr.value
-          )
-        )
-      );
+      const source = initValue(binding);
+      const references = defaultAttr.extra?.valueReferences;
+      const isSetup = !references;
+
+      if (!isSetup) {
+        // TODO: add defined guard if bindings exist.
+      } else {
+        addValue(sectionId, references, source, defaultAttr.value);
+      }
 
       registerAssignmentReplacer(
         tag.scope.getBinding(binding.name)!,

--- a/packages/translator/src/core/put.ts
+++ b/packages/translator/src/core/put.ts
@@ -84,7 +84,7 @@ export default {
         initContextProvider(
           tag.hub.file.metadata.marko.id,
           node.extra.reserve!,
-          defaultAttr.extra?.valueReferences?.references,
+          defaultAttr.extra?.valueReferences,
           defaultAttr.value,
           rendererId
         );

--- a/packages/translator/src/core/return.ts
+++ b/packages/translator/src/core/return.ts
@@ -3,10 +3,9 @@ import { assertNoVar, assertNoParams, Tag } from "@marko/babel-utils";
 import * as writer from "../util/writer";
 import { assertNoBodyContent, assertNoSpreadAttrs } from "../util/assert";
 import { isOutputHTML } from "../util/marko-config";
-import { addStatement, getSignal } from "../util/signals";
+import { addValue } from "../util/signals";
 import { createSectionState, getSectionId } from "../util/sections";
-import { callRuntime, importRuntime } from "../util/runtime";
-import { scopeIdentifier } from "../visitors/program";
+import { importRuntime } from "../util/runtime";
 
 const [returnId, _setReturnId] = createSectionState<t.Identifier | undefined>(
   "returnId"
@@ -65,27 +64,16 @@ export default {
         )[0]
         .skip();
     } else {
-      const signal = getSignal(
-        sectionId,
-        defaultAttr.extra?.valueReferences?.references
-      );
-
-      const tagVarSignalIdentifier = importRuntime("tagVarSignal");
-      signal.subscribers.push(tagVarSignalIdentifier);
-
-      addStatement(
-        "apply",
+      addValue(
         sectionId,
         defaultAttr.extra?.valueReferences,
-        t.expressionStatement(
-          callRuntime(
-            "setSource",
-            scopeIdentifier,
-            t.identifier(tagVarSignalIdentifier.name),
-            defaultAttr.value
-          )
-        )
+        {
+          identifier: importRuntime("tagVarSignal"),
+          hasDownstreamIntersections: () => true,
+        },
+        defaultAttr.value
       );
+
       tag.remove();
     }
   },

--- a/packages/translator/src/util/runtime.ts
+++ b/packages/translator/src/util/runtime.ts
@@ -22,17 +22,15 @@ const pureFunctions: Array<
 > = [
   "createRenderFn",
   "createRenderer",
-  "source",
-  "derivation",
-  "subscriber",
+  "value",
+  "intersection",
   "closure",
+  "dynamicClosure",
+  "contextClosure",
   "loop",
   "conditional",
-  "destructureSources",
-  "bind",
+  "bindFunction",
   "bindRenderer",
-  "inLoopScope",
-  "inConditionalScope",
 ];
 
 export function importRuntime(

--- a/packages/translator/src/util/signals.ts
+++ b/packages/translator/src/util/signals.ts
@@ -3,7 +3,6 @@ import type { ReferenceGroup } from "./references";
 import {
   getSectionId,
   createSectionState,
-  forEachSectionIdReverse,
   getOrCreateSectionId,
   getScopeIdIdentifier,
   getScopeIdentifier,
@@ -608,12 +607,6 @@ export function getHydrateRegisterId(
     }
   }
   return getTemplateId(optimize, `${filename}_${sectionId}${name}`);
-}
-
-export function writeAllStatementGroups() {
-  forEachSectionIdReverse((sectionId) => {
-    writeSignals(sectionId);
-  });
 }
 
 export function writeSignals(sectionId: number) {

--- a/packages/translator/src/util/signals.ts
+++ b/packages/translator/src/util/signals.ts
@@ -151,7 +151,6 @@ export function getSignal(sectionId: number, reserve?: Reserve | Reserve[]) {
       const provider = getSignal(reserve.sectionId, reserve);
       getClosures(sectionId).push(signal.identifier);
       provider.closures.set(sectionId, signal);
-      signal.hasDownstreamIntersections = () => true;
       signal.build = () => {
         // TODO: subscribe to an owner multiple levels up
         const builder = getSubscribeBuilder(sectionId);

--- a/packages/translator/src/util/signals.ts
+++ b/packages/translator/src/util/signals.ts
@@ -9,25 +9,39 @@ import {
   getScopeIdentifier,
 } from "./sections";
 import { Reserve, insertReserve, getNodeLiteral, ReserveType } from "./reserve";
-import { currentProgramPath, scopeIdentifier } from "../visitors/program";
+import {
+  currentProgramPath,
+  dirtyIdentifier,
+  scopeIdentifier,
+} from "../visitors/program";
 import { callRuntime, callRead } from "./runtime";
 import { getTemplateId } from "@marko/babel-utils";
 import type { NodePath } from "@marko/compiler/babel-types";
 import { returnId } from "../core/return";
+import { isOutputHTML } from "./marko-config";
 
-export type subscribeBuilder = (subscriber: t.Expression) => t.Expression;
+export type subscribeBuilder = (subscriber: t.Expression) => t.Statement;
 
-type Signal = {
+export type Signal = {
   identifier: t.Identifier;
   reserve: undefined | Reserve | Reserve[];
   sectionId: number;
   build: () => t.Expression;
   register?: boolean;
+  values: Array<{
+    signal: {
+      identifier: t.Identifier;
+      hasDownstreamIntersections: () => boolean;
+    };
+    value: t.Expression;
+    scope: t.Expression;
+  }>;
+  intersection: t.Statement[];
   render: t.Statement[];
   hydrate: t.Statement[];
   hydrateInlineReferences: undefined | Reserve | Reserve[];
-  subscribers: t.Expression[];
   closures: Map<number /* sectionId */, Signal>;
+  hasDownstreamIntersections: () => boolean;
   hasDynamicSubscribers?: true;
 };
 
@@ -96,22 +110,20 @@ export function getSignal(sectionId: number, reserve?: Reserve | Reserve[]) {
         identifier: t.identifier(generateSignalName(sectionId, reserve)),
         reserve,
         sectionId,
+        values: [],
+        intersection: [],
         render: [],
         hydrate: [],
         hydrateInlineReferences: undefined,
         subscribers: [],
+        hasDownstreamIntersections: () => signal.intersection.length > 0,
       } as any as Signal)
     );
 
-    if (!reserve) {
+    if (isOutputHTML()) {
+      return signal;
+    } else if (!reserve) {
       signal.build = () => {
-        for (const subscriber of signal.subscribers) {
-          signal.render.push(
-            t.expressionStatement(
-              callRuntime("notifySignal", scopeIdentifier, subscriber)
-            )
-          );
-        }
         return t.arrowFunctionExpression(
           [scopeIdentifier],
           t.blockStatement(signal.render)
@@ -121,10 +133,9 @@ export function getSignal(sectionId: number, reserve?: Reserve | Reserve[]) {
       subscribe(reserve, signal);
       signal.build = () => {
         return callRuntime(
-          "subscriber",
-          t.arrayExpression(signal.subscribers),
+          "intersection",
           t.numericLiteral(reserve.length),
-          getComputeFn(sectionId, t.blockStatement(signal.render), reserve)
+          getSignalFn(signal, [scopeIdentifier], reserve)
         );
       };
     } else if (reserve.sectionId !== sectionId) {
@@ -134,11 +145,23 @@ export function getSignal(sectionId: number, reserve?: Reserve | Reserve[]) {
         const builder = getSubscribeBuilder(sectionId);
         const provider = getSignal(reserve.sectionId, reserve);
         if (builder) {
-          provider.subscribers.push(builder(signal.identifier));
+          provider.intersection.push(builder(signal.identifier));
         } else if (!provider.hasDynamicSubscribers) {
+          const dynamicSubscribersKey = getNodeLiteral(reserve);
+          dynamicSubscribersKey.value += AccessorChars.SUBSCRIBERS;
           provider.hasDynamicSubscribers = true;
-          provider.subscribers.push(
-            callRuntime("dynamicSubscribers", getNodeLiteral(reserve))
+          provider.intersection.push(
+            t.expressionStatement(
+              callRuntime(
+                "dynamicSubscribers",
+                t.memberExpression(
+                  scopeIdentifier,
+                  dynamicSubscribersKey,
+                  true
+                ),
+                dirtyIdentifier
+              )
+            )
           );
         }
 
@@ -146,13 +169,8 @@ export function getSignal(sectionId: number, reserve?: Reserve | Reserve[]) {
           // TODO: this should use `closure` for <if> and <for>
           builder ? "closure" : "dynamicClosure",
           // TODO: read from an owner multiple levels up
-          t.numericLiteral(1),
           getNodeLiteral(reserve),
-          t.arrayExpression(signal.subscribers),
-          t.arrowFunctionExpression(
-            [scopeIdentifier, t.identifier(reserve.name)],
-            t.blockStatement(signal.render)
-          )
+          getSignalFn(signal, [scopeIdentifier, t.identifier(reserve.name)])
         );
       };
     } else {
@@ -164,51 +182,30 @@ export function getSignal(sectionId: number, reserve?: Reserve | Reserve[]) {
   return signal;
 }
 
-export function initSource(reserve: Reserve) {
-  const sectionId = reserve.sectionId;
-  const signal = getSignal(sectionId, reserve);
-  signal.build = () => {
-    return callRuntime(
-      "source",
-      getNodeLiteral(reserve),
-      t.arrayExpression(signal.subscribers),
-      t.arrowFunctionExpression(
-        [scopeIdentifier, t.identifier(reserve.name)],
-        t.blockStatement(signal.render)
-      )
-    );
-  };
-  return signal;
-}
-
-export function initDerivation(
+export function initValue(
   reserve: Reserve,
-  providers: undefined | Reserve | Reserve[],
-  compute: t.Expression
+  valueAccessor = getNodeLiteral(reserve)
 ) {
   const sectionId = reserve.sectionId;
   const signal = getSignal(sectionId, reserve);
   signal.build = () => {
-    return callRuntime(
-      "derivation",
-      getNodeLiteral(reserve),
-      t.numericLiteral(Array.isArray(providers) ? providers.length : 1),
-      t.arrayExpression(signal.subscribers),
-      getComputeFn(sectionId, compute, providers),
-      t.arrowFunctionExpression(
-        [scopeIdentifier, t.identifier(reserve.name)],
-        t.blockStatement(signal.render)
-      )
-    );
+    const fn = getSignalFn(signal, [
+      scopeIdentifier,
+      t.identifier(reserve.name),
+    ]);
+    if ((fn.body as t.BlockStatement).body.length > 0) {
+      return callRuntime("value", valueAccessor, fn);
+    } else {
+      return fn;
+    }
   };
-  subscribe(providers, signal);
   return signal;
 }
 
 export function initContextProvider(
   templateId: string,
   reserve: Reserve,
-  providers: undefined | Reserve | Reserve[],
+  providers: ReferenceGroup | undefined,
   compute: t.Expression,
   renderer: t.Identifier
 ) {
@@ -217,23 +214,21 @@ export function initContextProvider(
   const valueAccessor = t.stringLiteral(
     `${reserve.id}${AccessorChars.CONTEXT_VALUE}`
   );
+  const subscribersAccessor = t.stringLiteral(
+    `${reserve.id}${AccessorChars.CONTEXT_VALUE}${AccessorChars.SUBSCRIBERS}`
+  );
 
-  const signal = getSignal(sectionId, reserve);
-  signal.build = () => {
-    return callRuntime(
-      "derivation",
-      valueAccessor,
-      t.numericLiteral(Array.isArray(providers) ? providers.length : 1),
-      t.arrayExpression(signal.subscribers),
-      getComputeFn(sectionId, compute, providers),
-      t.arrowFunctionExpression(
-        [scopeIdentifier, t.identifier(reserve.name)],
-        t.blockStatement(signal.render)
+  const signal = initValue(reserve, valueAccessor);
+  addValue(sectionId, providers, signal, compute);
+  signal.intersection.push(
+    t.expressionStatement(
+      callRuntime(
+        "dynamicSubscribers",
+        t.memberExpression(scopeIdentifier, subscribersAccessor, true),
+        dirtyIdentifier
       )
-    );
-  };
-  subscribe(providers, signal);
-  signal.subscribers.push(callRuntime("dynamicSubscribers", valueAccessor));
+    )
+  );
 
   addStatement(
     "apply",
@@ -263,41 +258,131 @@ export function initContextConsumer(templateId: string, reserve: Reserve) {
       "contextClosure",
       getNodeLiteral(reserve),
       t.stringLiteral(templateId),
-      t.arrayExpression(signal.subscribers),
-      t.arrowFunctionExpression(
-        [scopeIdentifier, t.identifier(reserve.name)],
-        t.blockStatement(signal.render)
-      )
+      getSignalFn(signal, [scopeIdentifier, t.identifier(reserve.name)])
     );
   };
 
   return signal;
 }
 
-export function getComputeFn(
-  sectionId: number,
-  body: t.Expression | t.BlockStatement,
-  references: undefined | Reserve | Reserve[]
+export function getSignalFn(
+  signal: Signal,
+  params: Array<t.Identifier | t.Pattern>,
+  references?: undefined | Reserve | Reserve[]
 ) {
-  const params: Array<t.Identifier | t.Pattern> = [scopeIdentifier];
+  const sectionId = signal.sectionId;
+  const needsDirty = signal.intersection.length > 0;
+  let statements;
+
   if (Array.isArray(references)) {
-    references.forEach((binding) =>
-      params.push(
-        t.assignmentPattern(
-          t.identifier(binding.name),
-          callRead(binding, sectionId)
+    signal.render.unshift(
+      t.variableDeclaration(
+        "const",
+        references.map((binding) =>
+          t.variableDeclarator(
+            t.identifier(binding.name),
+            callRead(binding, sectionId)
+          )
         )
       )
     );
   } else if (references) {
-    params.push(
-      t.assignmentPattern(
-        t.identifier(references.name),
-        callRead(references, sectionId)
-      )
+    signal.render.unshift(
+      t.variableDeclaration("const", [
+        t.variableDeclarator(
+          t.identifier(references.name),
+          callRead(references, sectionId)
+        ),
+      ])
     );
   }
-  return t.arrowFunctionExpression(params, body);
+
+  if (needsDirty) {
+    params.push(dirtyIdentifier);
+    if (signal.render.length) {
+      statements = [
+        t.ifStatement(dirtyIdentifier, t.blockStatement(signal.render)),
+        ...signal.intersection,
+      ];
+    } else {
+      statements = signal.intersection;
+    }
+  } else {
+    statements = signal.render;
+  }
+
+  return t.arrowFunctionExpression(params, t.blockStatement(statements));
+}
+
+// const destructureAttrs = (scope, value, dirty) => {
+//   let a, c;
+//   if (dirty) {
+//     ({ a, b: { c } } = value);
+//   }
+//   _a(scope, a, dirty);
+//   _c(scope, c, dirty);
+// }
+export function getDestructureSignalFromPaths(
+  path: t.NodePath<t.Identifier | t.Pattern | t.RestElement>[]
+) {
+  const bindings = path.reduce((bindingsLookup, path) => {
+    return Object.assign(bindingsLookup, path.getBindingIdentifiers());
+  }, {});
+  const destructurePattern = t.arrayPattern(path.map((p) => p.node));
+
+  return getDestructureSignal(bindings, destructurePattern);
+}
+
+export function getDestructureSignalFromPath(path: t.NodePath<t.Pattern>) {
+  return getDestructureSignal(
+    path.getBindingIdentifiers() as any as Record<string, t.Identifier>,
+    path.node
+  );
+}
+
+export function getDestructureSignal(
+  bindingsByName: Record<string, t.Identifier>,
+  destructurePattern: t.LVal
+) {
+  const bindings = Object.values(bindingsByName);
+  if (bindings.length) {
+    const valueIdentifier =
+      currentProgramPath.scope.generateUidIdentifier("destructure");
+    const bindingSignals = bindings.map((binding) =>
+      initValue(binding.extra?.reserve as Reserve)
+    );
+
+    const declarations = t.variableDeclaration(
+      "let",
+      bindings.map((binding) => t.variableDeclarator(binding))
+    );
+
+    return t.arrowFunctionExpression(
+      [
+        scopeIdentifier,
+        valueIdentifier,
+        t.assignmentPattern(dirtyIdentifier, t.booleanLiteral(true)),
+      ],
+      t.blockStatement([
+        declarations,
+        t.ifStatement(
+          dirtyIdentifier,
+          t.expressionStatement(
+            t.assignmentExpression("=", destructurePattern, valueIdentifier)
+          )
+        ),
+        ...bindingSignals.map((signal, i) =>
+          t.expressionStatement(
+            t.callExpression(signal.identifier, [
+              scopeIdentifier,
+              bindings[i],
+              dirtyIdentifier,
+            ])
+          )
+        ),
+      ])
+    );
+  }
 }
 
 export function subscribe(
@@ -309,7 +394,14 @@ export function subscribe(
     return;
   }
   const providerSignal = getSignal(subscriber.sectionId, provider);
-  providerSignal.subscribers.push(subscriber.identifier);
+  providerSignal.intersection.push(
+    t.expressionStatement(
+      t.callExpression(subscriber.identifier, [
+        scopeIdentifier,
+        dirtyIdentifier,
+      ])
+    )
+  );
 }
 
 function generateSignalName(
@@ -388,14 +480,14 @@ export function addStatement(
   isInlined?: boolean
 ): void;
 export function addStatement(
-  type: "apply",
+  type: "apply" | "intersection",
   targetSectionId: number,
   references: ReferenceGroup | undefined,
   statement: t.Statement | t.Statement[]
 ): void;
 export function addStatement(
   // TODO: rename "apply" to "render"
-  type: "apply" | "hydrate",
+  type: "apply" | "hydrate" | "intersection",
   targetSectionId: number,
   references: ReferenceGroup | undefined,
   statement: t.Statement | t.Statement[],
@@ -404,7 +496,7 @@ export function addStatement(
 ): void {
   const reserve = references?.references;
   const signal = getSignal(targetSectionId, reserve);
-  const statements = (signal[type === "apply" ? "render" : "hydrate"] ??= []);
+  const statements = (signal[type === "apply" ? "render" : type] ??= []);
 
   if (Array.isArray(statement)) {
     statements.push(...statement);
@@ -425,6 +517,18 @@ export function addStatement(
       }
     }
   }
+}
+
+export function addValue(
+  targetSectionId: number,
+  references: ReferenceGroup | undefined,
+  signal: Signal["values"][number]["signal"],
+  value: t.Expression,
+  scope: t.Expression = scopeIdentifier
+) {
+  const reserve = references?.references;
+  const targetSignal = getSignal(targetSectionId, reserve);
+  targetSignal.values.push({ signal, value, scope });
 }
 
 export function addHydrateReferences(signal: Signal, expression: t.Expression) {
@@ -482,15 +586,46 @@ export function writeSignals(sectionId: number) {
   const declarations = Array.from(signals.values())
     .sort(sortSignals)
     .flatMap((signal) => {
-      let value = signal.build();
-      if (signal.register) {
-        value = callRuntime(
-          "register",
-          t.stringLiteral(getHydrateRegisterId(sectionId, signal.reserve)),
-          value
-        );
+      const isSetup = !signal.reserve;
+      for (const value of signal.values) {
+        const callee = value.signal.identifier;
+        const needsDirty =
+          !isSetup && value.signal.hasDownstreamIntersections();
+        if (needsDirty) {
+          const valueIdentifier =
+            currentProgramPath.scope.generateUidIdentifier(
+              callee.name + "_value"
+            );
+          signal.render.push(
+            t.expressionStatement(
+              t.assignmentExpression("=", valueIdentifier, value.value)
+            )
+          );
+          // TODO: we unshift here because we if closures are called before other intersections
+          // that also intersect with the closure, the marking system breaks down (closures don't execute)
+          // however this is insufficient, because this isn't the only place where we add intersections
+          // we should fix this by making sure that closures are always called last
+          signal.intersection.unshift(
+            t.variableDeclaration("var", [
+              t.variableDeclarator(valueIdentifier),
+            ]),
+            t.expressionStatement(
+              t.callExpression(callee, [
+                value.scope,
+                valueIdentifier,
+                dirtyIdentifier,
+              ])
+            )
+          );
+        } else {
+          signal.render.push(
+            t.expressionStatement(
+              t.callExpression(callee, [value.scope, value.value])
+            )
+          );
+        }
       }
-      const signalDeclarator = t.variableDeclarator(signal.identifier, value);
+
       let hydrateDeclarator;
       if (signal.hydrate.length) {
         const hydrateIdentifier = t.identifier(
@@ -535,9 +670,18 @@ export function writeSignals(sectionId: number) {
         );
       }
 
+      let value = signal.build();
+      if (signal.register) {
+        value = callRuntime(
+          "register",
+          t.stringLiteral(getHydrateRegisterId(sectionId, signal.reserve)),
+          value
+        );
+      }
       if (t.isCallExpression(value)) {
         finalizeSignalArgs(value.arguments as any as t.Expression[]);
       }
+      const signalDeclarator = t.variableDeclarator(signal.identifier, value);
       return hydrateDeclarator
         ? [
             t.variableDeclaration("const", [hydrateDeclarator]),
@@ -726,7 +870,9 @@ function bindFunction(
   );
 
   node.params.unshift(scopeIdentifier);
-  fn.replaceWith(callRuntime("bind", scopeIdentifier, functionIdentifier));
+  fn.replaceWith(
+    callRuntime("bindFunction", scopeIdentifier, functionIdentifier)
+  );
 }
 
 export function getSetup(sectionId: number) {

--- a/packages/translator/src/util/signals.ts
+++ b/packages/translator/src/util/signals.ts
@@ -314,32 +314,6 @@ export function getSignalFn(
   return t.arrowFunctionExpression(params, t.blockStatement(statements));
 }
 
-// const destructureAttrs = (scope, value, dirty) => {
-//   let a, c;
-//   if (dirty) {
-//     ({ a, b: { c } } = value);
-//   }
-//   _a(scope, a, dirty);
-//   _c(scope, c, dirty);
-// }
-export function getDestructureSignalFromPaths(
-  path: t.NodePath<t.Identifier | t.Pattern | t.RestElement>[]
-) {
-  const bindings = path.reduce((bindingsLookup, path) => {
-    return Object.assign(bindingsLookup, path.getBindingIdentifiers());
-  }, {});
-  const destructurePattern = t.arrayPattern(path.map((p) => p.node));
-
-  return getDestructureSignal(bindings, destructurePattern);
-}
-
-export function getDestructureSignalFromPath(path: t.NodePath<t.Pattern>) {
-  return getDestructureSignal(
-    path.getBindingIdentifiers() as any as Record<string, t.Identifier>,
-    path.node
-  );
-}
-
 export function getDestructureSignal(
   bindingsByName: Record<string, t.Identifier>,
   destructurePattern: t.LVal
@@ -575,11 +549,6 @@ export function writeAllStatementGroups() {
     writeSignals(sectionId);
   });
 }
-
-// const [getClosurePriorities] = createSectionState<Array<t.NumericLiteral>>(
-//   "closurePriorities",
-//   () => []
-// );
 
 export function writeSignals(sectionId: number) {
   const signals = getSignals(sectionId);

--- a/packages/translator/src/visitors/program/index.ts
+++ b/packages/translator/src/visitors/program/index.ts
@@ -13,6 +13,7 @@ import { callRuntime } from "../../util/runtime";
 
 export let currentProgramPath: t.NodePath<t.Program>;
 export let scopeIdentifier: t.Identifier;
+export let dirtyIdentifier: t.Identifier;
 
 const previousProgramPath: WeakMap<
   t.NodePath<t.Program>,
@@ -50,6 +51,9 @@ export default {
       currentProgramPath = program;
       scopeIdentifier = isOutputDOM()
         ? program.scope.generateUidIdentifier("scope")
+        : (null as any as t.Identifier);
+      dirtyIdentifier = isOutputDOM()
+        ? program.scope.generateUidIdentifier("dirty")
         : (null as any as t.Identifier);
       if (getMarkoOpts().output === ("hydrate" as "html")) {
         program.skip();

--- a/packages/translator/src/visitors/tag/dynamic-tag.ts
+++ b/packages/translator/src/visitors/tag/dynamic-tag.ts
@@ -13,13 +13,12 @@ import {
 } from "../../util/sections";
 import {
   addStatement,
-  getComputeFn,
+  getSignalFn,
   getSerializedScopeProperties,
   getSignal,
-  subscribe,
+  addValue,
 } from "../../util/signals";
 import {
-  countReserves,
   getNodeLiteral,
   Reserve,
   reserveScope,
@@ -31,7 +30,11 @@ import {
   updateReferenceGroup,
 } from "../../util/references";
 import customTag from "./custom-tag";
-import { currentProgramPath, scopeIdentifier } from "../program";
+import {
+  currentProgramPath,
+  dirtyIdentifier,
+  scopeIdentifier,
+} from "../program";
 
 export default {
   analyze: {
@@ -126,44 +129,53 @@ export default {
         const renderBodyIdentifier =
           hasBody && writer.getRenderer(bodySectionId);
         const tagNameReserve = node.extra?.reserve as Reserve;
-        const references = (node.extra?.nameReferences as ReferenceGroup)
-          ?.references;
         const signal = getSignal(sectionId, tagNameReserve);
         signal.build = () => {
           return callRuntime(
             "conditional",
             getNodeLiteral(tagNameReserve),
-            t.numericLiteral(countReserves(references) || 1),
-            getComputeFn(
-              sectionId,
-              renderBodyIdentifier
-                ? t.logicalExpression("||", node.name, renderBodyIdentifier)
-                : node.name,
-              references
-            ),
-            signal.subscribers[0],
-            t.arrowFunctionExpression(
-              [scopeIdentifier],
-              t.blockStatement(signal.render)
-            )
+            getSignalFn(signal, [scopeIdentifier])
           );
         };
-
-        subscribe(references, signal);
+        addValue(
+          sectionId,
+          node.extra?.nameReferences as ReferenceGroup,
+          signal,
+          renderBodyIdentifier
+            ? t.logicalExpression("||", node.name, renderBodyIdentifier)
+            : node.name
+        );
 
         const attrsObject = attrsToObject(tag, true);
         if (attrsObject || renderBodyIdentifier) {
-          const attrsSignal = getSignal(
-            sectionId,
-            node.extra?.attrsReferences.references
-          );
-
-          attrsSignal.subscribers.push(
-            callRuntime("dynamicAttrsProxy", getNodeLiteral(tagNameReserve))
-          );
-
+          const name = currentProgramPath.node.extra.sectionNames![sectionId];
+          const attrsIdentifier =
+            currentProgramPath.scope.generateUidIdentifier(name + "_attrs");
           addStatement(
             "apply",
+            sectionId,
+            node.extra?.attrsReferences,
+            t.expressionStatement(
+              t.assignmentExpression(
+                "=",
+                attrsIdentifier,
+                t.arrowFunctionExpression(
+                  [],
+                  attrsObject ?? t.objectExpression([])
+                )
+              )
+            )
+          );
+          addStatement(
+            "intersection",
+            sectionId,
+            node.extra?.attrsReferences,
+            t.variableDeclaration("var", [
+              t.variableDeclarator(attrsIdentifier),
+            ])
+          );
+          addStatement(
+            "intersection",
             sectionId,
             node.extra?.attrsReferences,
             t.expressionStatement(
@@ -171,11 +183,9 @@ export default {
                 "dynamicTagAttrs",
                 scopeIdentifier,
                 getNodeLiteral(tagNameReserve),
-                t.arrowFunctionExpression(
-                  [],
-                  attrsObject ?? t.objectExpression([])
-                ),
-                renderBodyIdentifier
+                attrsIdentifier,
+                renderBodyIdentifier,
+                dirtyIdentifier
               )
             )
           );

--- a/packages/translator/src/visitors/tag/native-tag.ts
+++ b/packages/translator/src/visitors/tag/native-tag.ts
@@ -110,7 +110,7 @@ export default {
               createElFunction ??= t.identifier(varName + "_getter");
               reference.replaceWith(
                 callRuntime(
-                  "bind",
+                  "bindFunction",
                   getScopeExpression(extra.reserve!, referenceSectionId),
                   createElFunction
                 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->

Switches away from our object-based signals (`source`, `derivation`, etc.) to function-based signals (`value`, `intersection`, etc.).  The propagation method (mark/notify) remains the same, but can be short-circuited for sub graphs that have no intersections.

In some ways this is more similar to our original output, but handles all edge cases around propagation order by still using the marking system where necessary.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
