### PR TITLE
refactor: invert dirty to clean, intersections as arguments

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -7,81 +7,81 @@
     {
       "name": "*",
       "total": {
-        "min": 12186,
-        "gzip": 5280,
-        "brotli": 4782
+        "min": 12483,
+        "gzip": 5399,
+        "brotli": 4901
       }
     },
     {
       "name": "counter",
       "user": {
         "min": 357,
-        "gzip": 280,
+        "gzip": 279,
         "brotli": 241
       },
       "runtime": {
-        "min": 2997,
-        "gzip": 1448,
-        "brotli": 1296
+        "min": 2986,
+        "gzip": 1442,
+        "brotli": 1294
       },
       "total": {
-        "min": 3354,
-        "gzip": 1728,
-        "brotli": 1537
+        "min": 3343,
+        "gzip": 1721,
+        "brotli": 1535
       }
     },
     {
       "name": "counter 💧",
       "user": {
         "min": 204,
-        "gzip": 181,
-        "brotli": 152
+        "gzip": 180,
+        "brotli": 153
       },
       "runtime": {
-        "min": 2451,
-        "gzip": 1276,
-        "brotli": 1137
+        "min": 2449,
+        "gzip": 1280,
+        "brotli": 1142
       },
       "total": {
-        "min": 2655,
-        "gzip": 1457,
-        "brotli": 1289
+        "min": 2653,
+        "gzip": 1460,
+        "brotli": 1295
       }
     },
     {
       "name": "comments",
       "user": {
-        "min": 1284,
-        "gzip": 702,
-        "brotli": 646
+        "min": 1137,
+        "gzip": 681,
+        "brotli": 626
       },
       "runtime": {
-        "min": 6831,
-        "gzip": 3149,
-        "brotli": 2852
+        "min": 6927,
+        "gzip": 3201,
+        "brotli": 2883
       },
       "total": {
-        "min": 8115,
-        "gzip": 3851,
-        "brotli": 3498
+        "min": 8064,
+        "gzip": 3882,
+        "brotli": 3509
       }
     },
     {
       "name": "comments 💧",
       "user": {
-        "min": 1089,
-        "gzip": 601,
-        "brotli": 568
+        "min": 944,
+        "gzip": 575,
+        "brotli": 543
       },
       "runtime": {
-        "min": 7823,
-        "gzip": 3591,
-        "brotli": 3246
+        "min": 7876,
+        "gzip": 3621,
+        "brotli": 3269
       },
       "total": {
-        "min": 8912,
-        "gzip": 4192,
-        "brotli": 3814
+        "min": 8820,
+        "gzip": 4196,
+        "brotli": 3812
       }
     }
   ]

--- a/packages/runtime/src/dom/index.ts
+++ b/packages/runtime/src/dom/index.ts
@@ -52,4 +52,7 @@ export {
   setTagVar,
   tagVarSignal,
   nextTagId,
+  inChild,
+  values,
+  intersections,
 } from "./signals";

--- a/packages/runtime/src/dom/queue.ts
+++ b/packages/runtime/src/dom/queue.ts
@@ -22,7 +22,7 @@ let currentEffects: unknown[] = [];
 
 export function queueSource<T>(scope: Scope, signal: ValueSignal, value: T) {
   schedule();
-  signal(scope, null, null);
+  signal(scope, 0, 1);
   currentBatch.push(scope, signal, value);
   return value;
 }

--- a/packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/dom.expected/template.js
@@ -5,16 +5,16 @@ const _ifBody = _register("packages/translator/src/__tests__/fixtures/at-tag-ins
 const _if$customTagBody = /* @__PURE__ */_conditional("#text/0");
 const _x$customTagBody = /* @__PURE__ */_dynamicClosure("x", (_scope, x) => _if$customTagBody(_scope, x ? _ifBody : null));
 const _customTagBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_x$customTagBody]);
-const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => _dynamicSubscribers(_scope["x*"], _dirty));
+const _x = /* @__PURE__ */_value("x", null, _dynamicSubscribers("x"));
 const _setup = _scope => {
   _customTag(_scope["#childScope/0"]);
 };
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let x;
-  if (_dirty) ({
+  if (!_clean) ({
     x
   } = _destructure);
-  _x(_scope, x, _dirty);
+  _x(_scope, x, _clean);
 };
 export { _x };
 export const template = `${_customTag_template}`;

--- a/packages/translator/src/__tests__/fixtures/at-tags-dynamic-tag-parent/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags-dynamic-tag-parent/__snapshots__/dom.expected/template.js
@@ -1,38 +1,27 @@
-import { write as _write, dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { write as _write, createRenderer as _createRenderer, dynamicTagAttrs as _dynamicTagAttrs, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _xBody = /* @__PURE__ */_createRenderer("Body content", "");
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => {
-  let _x_input;
-  if (_dirty) {
-    _x_input = () => ({
-      header: {
-        class: "my-header",
-        renderBody() {
-          _write("Header content");
-        }
-      },
-      footer: {
-        class: "my-footer",
-        renderBody() {
-          _write("Footer content");
-        }
-      }
-    });
+const _x_input = _dynamicTagAttrs("#text/0", _xBody);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", _scope => _x_input(_scope, () => ({
+  header: {
+    class: "my-header",
+    renderBody() {
+      _write("Header content");
+    }
+  },
+  footer: {
+    class: "my-footer",
+    renderBody() {
+      _write("Footer content");
+    }
   }
-  _dynamicTagAttrs(_scope, "#text/0", _x_input, _xBody, _dirty);
-});
-const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
-  let _dynamicTagName_value;
-  if (_dirty) {
-    _dynamicTagName_value = x || _xBody;
-  }
-  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
-});
-export const attrs = (_scope, _destructure, _dirty = true) => {
+})), null, _x_input);
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _dynamicTagName(_scope, x || _xBody), null, _dynamicTagName);
+export const attrs = (_scope, _destructure, _clean) => {
   let x;
-  if (_dirty) ({
+  if (!_clean) ({
     x
   } = _destructure);
-  _x(_scope, x, _dirty);
+  _x(_scope, x, _clean);
 };
 export { _x };
 export const template = "<!>";

--- a/packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected/template.js
@@ -9,16 +9,16 @@ const _ifBody = _register("packages/translator/src/__tests__/fixtures/at-tags-dy
 const _if$helloBody = /* @__PURE__ */_conditional("#text/0");
 const _x$helloBody = /* @__PURE__ */_dynamicClosure("x", (_scope, x) => _if$helloBody(_scope, x ? _ifBody : null));
 const _helloBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_x$helloBody]);
-const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => _dynamicSubscribers(_scope["x*"], _dirty));
+const _x = /* @__PURE__ */_value("x", null, _dynamicSubscribers("x"));
 const _setup = _scope => {
   _hello(_scope["#childScope/0"]);
 };
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let x;
-  if (_dirty) ({
+  if (!_clean) ({
     x
   } = _destructure);
-  _x(_scope, x, _dirty);
+  _x(_scope, x, _clean);
 };
 export { _x };
 export const template = `${_hello_template}`;

--- a/packages/translator/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/template.js
@@ -1,40 +1,46 @@
-import { classAttr as _classAttr, write as _write, dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, intersection as _intersection, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { classAttr as _classAttr, write as _write, createRenderer as _createRenderer, dynamicTagAttrs as _dynamicTagAttrs, intersection as _intersection, conditional as _conditional, intersections as _intersections, value as _value, values as _values, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _customTag, template as _customTag_template, walks as _customTag_walks } from "./components/custom-tag.marko";
 const _inputTestBody = /* @__PURE__ */_createRenderer("", "");
-const _destructure2 = (_scope, _destructure, _dirty = true) => {
+const _inputTest_input = _dynamicTagAttrs("#text/3", _inputTestBody);
+const _destructure2 = (_scope, _destructure, _clean) => {
   let c, d;
-  if (_dirty) ({
+  if (!_clean) ({
     c,
     d
   } = _destructure);
-  _c(_scope, c, _dirty);
-  _d(_scope, d, _dirty);
+  _c(_scope, c, _clean);
+  _d(_scope, d, _clean);
 };
-const _expr_dynamicTagName_c_d = /* @__PURE__ */_intersection(3, (_scope, _dirty) => {
-  let _inputTest_input;
-  if (_dirty) {
-    const {
-      "#text/3": dynamicTagName,
-      c,
+const _destructure3 = (_scope, _destructure, _clean) => {
+  let c, d;
+  if (!_clean) ({
+    c,
+    d
+  } = _destructure);
+  _c(_scope, c, _clean);
+  _d(_scope, d, _clean);
+};
+const _expr_dynamicTagName_c_d = /* @__PURE__ */_intersection(3, _scope => {
+  const {
+    "#text/3": dynamicTagName,
+    c,
+    d
+  } = _scope;
+  _inputTest_input(_scope, () => ({
+    class: ["a", {
+      b: c,
       d
-    } = _scope;
-    _inputTest_input = () => ({
+    }],
+    test: {
       class: ["a", {
         b: c,
         d
       }],
-      test: {
-        class: ["a", {
-          b: c,
-          d
-        }],
-        renderBody() {
-          _write("Hello");
-        }
+      renderBody() {
+        _write("Hello");
       }
-    });
-  }
-  _dynamicTagAttrs(_scope, "#text/3", _inputTest_input, _inputTestBody, _dirty);
+    }
+  }));
 });
 const _expr_c_d = /* @__PURE__ */_intersection(2, _scope => {
   const {
@@ -46,24 +52,13 @@ const _expr_c_d = /* @__PURE__ */_intersection(2, _scope => {
     d
   }]);
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/3", (_scope, _dirty) => _expr_dynamicTagName_c_d(_scope, _dirty));
-const _d = /* @__PURE__ */_value("d", (_scope, d, _dirty) => {
-  _expr_c_d(_scope, _dirty);
-  _expr_dynamicTagName_c_d(_scope, _dirty);
-});
-const _c = /* @__PURE__ */_value("c", (_scope, c, _dirty) => {
-  _expr_c_d(_scope, _dirty);
-  _expr_dynamicTagName_c_d(_scope, _dirty);
-});
-const _input = /* @__PURE__ */_value("input", (_scope, input, _dirty) => {
-  let _destructure2_value, _dynamicTagName_value;
-  if (_dirty) {
-    _destructure2_value = input;
-    _dynamicTagName_value = input.test || _inputTestBody;
-  }
-  _destructure2(_scope, _destructure2_value, _dirty);
-  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
-});
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/3", null, _expr_dynamicTagName_c_d);
+const _d = /* @__PURE__ */_value("d", null, _intersections([_expr_c_d, _expr_dynamicTagName_c_d]));
+const _c = /* @__PURE__ */_value("c", null, _intersections([_expr_c_d, _expr_dynamicTagName_c_d]));
+const _input = /* @__PURE__ */_value("input", (_scope, input) => {
+  _destructure2(_scope, input);
+  _dynamicTagName(_scope, input.test || _inputTestBody);
+}, null, _values([_destructure3, _dynamicTagName]));
 const _setup = _scope => {
   _customTag(_scope["#childScope/1"]);
   _customTag(_scope["#childScope/2"]);

--- a/packages/translator/src/__tests__/fixtures/attr-style/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/attr-style/__snapshots__/dom.expected/template.js
@@ -1,32 +1,21 @@
-import { styleAttr as _styleAttr, write as _write, dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { styleAttr as _styleAttr, write as _write, createRenderer as _createRenderer, dynamicTagAttrs as _dynamicTagAttrs, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _customTag, template as _customTag_template, walks as _customTag_walks } from "./components/custom-tag.marko";
 const _testBody = /* @__PURE__ */_createRenderer("", "");
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/4", (_scope, _dirty) => {
-  let _test_input;
-  if (_dirty) {
-    _test_input = () => ({
-      style: {
-        color: "green"
-      },
-      test: {
-        style: {
-          color: "green"
-        },
-        renderBody() {
-          _write("Hello");
-        }
-      }
-    });
+const _test_input = _dynamicTagAttrs("#text/4", _testBody);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/4", _scope => _test_input(_scope, () => ({
+  style: {
+    color: "green"
+  },
+  test: {
+    style: {
+      color: "green"
+    },
+    renderBody() {
+      _write("Hello");
+    }
   }
-  _dynamicTagAttrs(_scope, "#text/4", _test_input, _testBody, _dirty);
-});
-const _test = /* @__PURE__ */_value("test", (_scope, test, _dirty) => {
-  let _dynamicTagName_value;
-  if (_dirty) {
-    _dynamicTagName_value = test || _testBody;
-  }
-  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
-});
+})), null, _test_input);
+const _test = /* @__PURE__ */_value("test", (_scope, test) => _dynamicTagName(_scope, test || _testBody), null, _dynamicTagName);
 const _color = /* @__PURE__ */_value("color", (_scope, color) => _styleAttr(_scope["#div/0"], {
   color: color
 }));
@@ -35,14 +24,14 @@ const _setup = _scope => {
   _customTag(_scope["#childScope/2"]);
   _customTag(_scope["#childScope/3"]);
 };
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let color, test;
-  if (_dirty) ({
+  if (!_clean) ({
     color,
     test
   } = _destructure);
-  _color(_scope, color, _dirty);
-  _test(_scope, test, _dirty);
+  _color(_scope, color, _clean);
+  _test(_scope, test, _clean);
 };
 export { _color, _test };
 export const template = `<div></div><div style=width:100px></div><div style="color: green"></div>${_customTag_template}${_customTag_template}${_customTag_template}<!>`;

--- a/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/components/my-button.js
@@ -7,14 +7,14 @@ const _onClick_effect = _register("packages/translator/src/__tests__/fixtures/ba
   _on(_scope["#button/0"], "click", onClick);
 });
 const _onClick = /* @__PURE__ */_value("onClick", (_scope, onClick) => _queueEffect(_scope, _onClick_effect));
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let onClick, text;
-  if (_dirty) ({
+  if (!_clean) ({
     onClick,
     text
   } = _destructure);
-  _onClick(_scope, onClick, _dirty);
-  _text(_scope, text, _dirty);
+  _onClick(_scope, onClick, _clean);
+  _text(_scope, text, _clean);
 };
 export { _onClick, _text };
 export const template = "<button> </button>";

--- a/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.js
@@ -1,20 +1,14 @@
-import { queueSource as _queueSource, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queueSource as _queueSource, inChild as _inChild, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _myButton, attrs as _myButton_attrs, template as _myButton_template, walks as _myButton_walks } from "./components/my-button.marko";
-const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount, _dirty) => {
-  let _myButton_attrs_value;
-  if (_dirty) {
-    _myButton_attrs_value = {
-      text: clickCount,
-      onClick: function () {
-        const {
-          clickCount
-        } = _scope;
-        _queueSource(_scope, _clickCount, clickCount + 1);
-      }
-    };
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => _myButton_attrs(_scope["#childScope/0"], {
+  text: clickCount,
+  onClick: function () {
+    const {
+      clickCount
+    } = _scope;
+    _queueSource(_scope, _clickCount, clickCount + 1);
   }
-  _myButton_attrs(_scope["#childScope/0"], _myButton_attrs_value, _dirty);
-});
+}), null, _inChild("#childScope/0", _myButton_attrs));
 const _setup = _scope => {
   _myButton(_scope["#childScope/0"]);
   _clickCount(_scope, 0);

--- a/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/components/my-button.js
@@ -1,6 +1,6 @@
 import { on as _on, conditional as _conditional, value as _value, register as _register, queueEffect as _queueEffect, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/1");
-const _renderBody = /* @__PURE__ */_value("renderBody", (_scope, renderBody) => _dynamicTagName(_scope, renderBody));
+const _renderBody = /* @__PURE__ */_value("renderBody", (_scope, renderBody) => _dynamicTagName(_scope, renderBody), null, _dynamicTagName);
 const _onClick_effect = _register("packages/translator/src/__tests__/fixtures/basic-component-renderBody/components/my-button.marko_0_onClick", _scope => {
   const {
     onClick
@@ -8,14 +8,14 @@ const _onClick_effect = _register("packages/translator/src/__tests__/fixtures/ba
   _on(_scope["#button/0"], "click", onClick);
 });
 const _onClick = /* @__PURE__ */_value("onClick", (_scope, onClick) => _queueEffect(_scope, _onClick_effect));
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let onClick, renderBody;
-  if (_dirty) ({
+  if (!_clean) ({
     onClick,
     renderBody
   } = _destructure);
-  _onClick(_scope, onClick, _dirty);
-  _renderBody(_scope, renderBody, _dirty);
+  _onClick(_scope, onClick, _clean);
+  _renderBody(_scope, renderBody, _clean);
 };
 export { _onClick, _renderBody };
 export const template = "<button><!></button>";

--- a/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
@@ -1,23 +1,16 @@
-import { queueSource as _queueSource, data as _data, bindRenderer as _bindRenderer, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { queueSource as _queueSource, data as _data, bindRenderer as _bindRenderer, inChild as _inChild, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _myButton, attrs as _myButton_attrs, template as _myButton_template, walks as _myButton_walks } from "./components/my-button.marko";
 const _clickCount$myButtonBody = /* @__PURE__ */_dynamicClosure("clickCount", (_scope, clickCount) => _data(_scope["#text/0"], clickCount));
 const _myButtonBody = /* @__PURE__ */_createRenderer(" ", /* get */" ", null, [_clickCount$myButtonBody]);
-const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount, _dirty) => {
-  let _myButton_attrs_value;
-  if (_dirty) {
-    _myButton_attrs_value = {
-      onClick: function () {
-        const {
-          clickCount
-        } = _scope;
-        _queueSource(_scope, _clickCount, clickCount + 1);
-      },
-      renderBody: /* @__PURE__ */_bindRenderer(_scope, _myButtonBody)
-    };
-  }
-  _myButton_attrs(_scope["#childScope/0"], _myButton_attrs_value, _dirty);
-  _dynamicSubscribers(_scope["clickCount*"], _dirty);
-});
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => _myButton_attrs(_scope["#childScope/0"], {
+  onClick: function () {
+    const {
+      clickCount
+    } = _scope;
+    _queueSource(_scope, _clickCount, clickCount + 1);
+  },
+  renderBody: /* @__PURE__ */_bindRenderer(_scope, _myButtonBody)
+}), _dynamicSubscribers("clickCount"), _inChild("#childScope/0", _myButton_attrs));
 const _setup = _scope => {
   _myButton(_scope["#childScope/0"]);
   _clickCount(_scope, 0);

--- a/packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
@@ -8,26 +8,17 @@ const _count_effect = _register("packages/translator/src/__tests__/fixtures/basi
   } = _scope;
   _queueSource(_scope, _count, count + 1);
 }));
-const _count = /* @__PURE__ */_value("count", (_scope, count, _dirty) => {
-  if (_dirty) {
-    _queueEffect(_scope, _count_effect);
-  }
-  _inConditionalScope(_scope, _dirty, _count$ifBody, "#text/2");
-});
+const _count = /* @__PURE__ */_value("count", (_scope, count) => _queueEffect(_scope, _count_effect), _inConditionalScope(_count$ifBody, "#text/2"));
 const _show_effect = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/template.marko_0_show", _scope => _on(_scope["#button/1"], "click", function () {
   const {
     show
   } = _scope;
   _queueSource(_scope, _show, !show);
 }));
-const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
-  let _if_value;
-  if (_dirty) {
-    _queueEffect(_scope, _show_effect);
-    _if_value = show ? _ifBody : null;
-  }
-  _if(_scope, _if_value, _dirty);
-});
+const _show = /* @__PURE__ */_value("show", (_scope, show) => {
+  _queueEffect(_scope, _show_effect);
+  _if(_scope, show ? _ifBody : null);
+}, null, _if);
 const _setup = _scope => {
   _show(_scope, true);
   _count(_scope, 0);

--- a/packages/translator/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
@@ -8,26 +8,17 @@ const _count_effect = _register("packages/translator/src/__tests__/fixtures/basi
   } = _scope;
   _queueSource(_scope, _count, count + 1);
 }));
-const _count = /* @__PURE__ */_value("count", (_scope, count, _dirty) => {
-  if (_dirty) {
-    _queueEffect(_scope, _count_effect);
-  }
-  _inConditionalScope(_scope, _dirty, _count$ifBody, "#text/2");
-});
+const _count = /* @__PURE__ */_value("count", (_scope, count) => _queueEffect(_scope, _count_effect), _inConditionalScope(_count$ifBody, "#text/2"));
 const _show_effect = _register("packages/translator/src/__tests__/fixtures/basic-conditional-counter/template.marko_0_show", _scope => _on(_scope["#button/1"], "click", function () {
   const {
     show
   } = _scope;
   _queueSource(_scope, _show, !show);
 }));
-const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
-  let _if_value;
-  if (_dirty) {
-    _queueEffect(_scope, _show_effect);
-    _if_value = show ? _ifBody : null;
-  }
-  _if(_scope, _if_value, _dirty);
-});
+const _show = /* @__PURE__ */_value("show", (_scope, show) => {
+  _queueEffect(_scope, _show_effect);
+  _if(_scope, show ? _ifBody : null);
+}, null, _if);
 const _setup = _scope => {
   _show(_scope, true);
   _count(_scope, 0);

--- a/packages/translator/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/dom.expected/template.js
@@ -8,12 +8,12 @@ const _expr_a_b$ifBody = /* @__PURE__ */_intersection(2, _scope => {
   } = _scope;
   _data(_scope["#text/0"], a + b);
 });
-const _b$ifBody = /* @__PURE__ */_closure("b", (_scope, b, _dirty) => _expr_a_b$ifBody(_scope, _dirty));
-const _a$ifBody = /* @__PURE__ */_closure("a", (_scope, a, _dirty) => _expr_a_b$ifBody(_scope, _dirty));
+const _b$ifBody = /* @__PURE__ */_closure("b", null, null, _expr_a_b$ifBody);
+const _a$ifBody = /* @__PURE__ */_closure("a", null, null, _expr_a_b$ifBody);
 const _ifBody = /* @__PURE__ */_createRenderer(" ", /* get */" ", null, [_a$ifBody, _b$ifBody]);
 const _if = /* @__PURE__ */_conditional("#text/0");
-const _b = /* @__PURE__ */_value("b", (_scope, b, _dirty) => _inConditionalScope(_scope, _dirty, _b$ifBody, "#text/0"));
-const _a = /* @__PURE__ */_value("a", (_scope, a, _dirty) => _inConditionalScope(_scope, _dirty, _a$ifBody, "#text/0"));
+const _b = /* @__PURE__ */_value("b", null, _inConditionalScope(_b$ifBody, "#text/0"));
+const _a = /* @__PURE__ */_value("a", null, _inConditionalScope(_a$ifBody, "#text/0"));
 const _setup = _scope => {
   _a(_scope, 0);
   _b(_scope, 0);

--- a/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.js
@@ -13,25 +13,17 @@ const _multiplier_effect = _register("packages/translator/src/__tests__/fixtures
   } = _scope;
   _queueSource(_scope, _multiplier, multiplier + 1);
 }));
-const _multiplier = /* @__PURE__ */_value("multiplier", (_scope, multiplier, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/1"], multiplier);
-    _queueEffect(_scope, _multiplier_effect);
-  }
-  _expr_count_multiplier(_scope, _dirty);
-});
+const _multiplier = /* @__PURE__ */_value("multiplier", (_scope, multiplier) => {
+  _data(_scope["#text/1"], multiplier);
+  _queueEffect(_scope, _multiplier_effect);
+}, _expr_count_multiplier);
 const _count_effect = _register("packages/translator/src/__tests__/fixtures/basic-counter-multiplier/template.marko_0_count", _scope => _on(_scope["#button/2"], "click", function () {
   const {
     count
   } = _scope;
   _queueSource(_scope, _count, count + 1);
 }));
-const _count = /* @__PURE__ */_value("count", (_scope, count, _dirty) => {
-  if (_dirty) {
-    _queueEffect(_scope, _count_effect);
-  }
-  _expr_count_multiplier(_scope, _dirty);
-});
+const _count = /* @__PURE__ */_value("count", (_scope, count) => _queueEffect(_scope, _count_effect), _expr_count_multiplier);
 const _setup = _scope => {
   _count(_scope, 0);
   _multiplier(_scope, 1);

--- a/packages/translator/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/dom.expected/template.js
@@ -1,27 +1,16 @@
-import { dynamicTagAttrs as _dynamicTagAttrs, createRenderer as _createRenderer, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { createRenderer as _createRenderer, dynamicTagAttrs as _dynamicTagAttrs, conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _tagNameBody = /* @__PURE__ */_createRenderer("Hello World", "");
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => {
-  let _tagName_input;
-  if (_dirty) {
-    _tagName_input = () => ({
-      class: ["a", "b"]
-    });
-  }
-  _dynamicTagAttrs(_scope, "#text/0", _tagName_input, _tagNameBody, _dirty);
-});
-const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
-  let _dynamicTagName_value;
-  if (_dirty) {
-    _dynamicTagName_value = tagName || _tagNameBody;
-  }
-  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
-});
-export const attrs = (_scope, _destructure, _dirty = true) => {
+const _tagName_input = _dynamicTagAttrs("#text/0", _tagNameBody);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", _scope => _tagName_input(_scope, () => ({
+  class: ["a", "b"]
+})), null, _tagName_input);
+const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName) => _dynamicTagName(_scope, tagName || _tagNameBody), null, _dynamicTagName);
+export const attrs = (_scope, _destructure, _clean) => {
   let tagName;
-  if (_dirty) ({
+  if (!_clean) ({
     tagName
   } = _destructure);
-  _tagName(_scope, tagName, _dirty);
+  _tagName(_scope, tagName, _clean);
 };
 export { _tagName };
 export const template = "<!>";

--- a/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.js
@@ -2,14 +2,8 @@ import { on as _on, queueSource as _queueSource, data as _data, closure as _clos
 const _message$ifBody = /* @__PURE__ */_closure("message", (_scope, message) => _data(_scope["#text/0"], message.text));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-execution-order/template.marko_1_renderer", /* @__PURE__ */_createRenderer(" ", /* get */" ", null, [_message$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/1");
-const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
-  let _if_value;
-  if (_dirty) {
-    _if_value = show ? _ifBody : null;
-  }
-  _if(_scope, _if_value, _dirty);
-});
-const _message = /* @__PURE__ */_value("message", (_scope, message, _dirty) => _inConditionalScope(_scope, _dirty, _message$ifBody, "#text/1"));
+const _show = /* @__PURE__ */_value("show", (_scope, show) => _if(_scope, show ? _ifBody : null), null, _if);
+const _message = /* @__PURE__ */_value("message", null, _inConditionalScope(_message$ifBody, "#text/1"));
 const _setup_effect = _register("packages/translator/src/__tests__/fixtures/basic-execution-order/template.marko_0", _scope => _on(_scope["#button/0"], "click", function () {
   _queueSource(_scope, _message, null);
   _queueSource(_scope, _show, false);

--- a/packages/translator/src/__tests__/fixtures/basic-export/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-export/__snapshots__/dom.expected/template.js
@@ -1,12 +1,12 @@
 export const v = 123;
 import { data as _data, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _value = /* @__PURE__ */_value2("value", (_scope, value) => _data(_scope["#text/0"], value));
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let value;
-  if (_dirty) ({
+  if (!_clean) ({
     value
   } = _destructure);
-  _value(_scope, value, _dirty);
+  _value(_scope, value, _clean);
 };
 export { _value };
 export const template = "<div> </div>";

--- a/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.js
@@ -17,13 +17,8 @@ const _expr_a_b = /* @__PURE__ */_intersection(2, _scope => {
   } = _scope;
   _queueEffect(_scope, _expr_a_b_effect);
 });
-const _b = /* @__PURE__ */_value("b", (_scope, b, _dirty) => _expr_a_b(_scope, _dirty));
-const _a = /* @__PURE__ */_value("a", (_scope, a, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/1"], a.join(""));
-  }
-  _expr_a_b(_scope, _dirty);
-});
+const _b = /* @__PURE__ */_value("b", null, _expr_a_b);
+const _a = /* @__PURE__ */_value("a", (_scope, a) => _data(_scope["#text/1"], a.join("")), _expr_a_b);
 const _setup = _scope => {
   _a(_scope, [0]);
   _b(_scope, 1);

--- a/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/components/comments.js
+++ b/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/components/comments.js
@@ -1,39 +1,31 @@
-import { attr as _attr, data as _data, on as _on, queueSource as _queueSource, intersection as _intersection, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueEffect as _queueEffect, value as _value, inConditionalScope as _inConditionalScope, loop as _loop, inLoopScope as _inLoopScope, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { attr as _attr, data as _data, on as _on, queueSource as _queueSource, inChild as _inChild, intersection as _intersection, closure as _closure, createRenderer as _createRenderer, register as _register, conditional as _conditional, queueEffect as _queueEffect, value as _value, inConditionalScope as _inConditionalScope, loop as _loop, inLoopScope as _inLoopScope, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _comments2, attrs as _comments_attrs, template as _comments_template, walks as _comments_walks } from "./comments.marko";
-const _expr_comment_id$ifBody = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
-  let _comments_attrs_value;
-  if (_dirty) {
-    const {
-      _: {
-        comment,
-        id
-      }
-    } = _scope;
-    _comments_attrs_value = {
-      comments: comment.comments,
-      path: id
-    };
-  }
-  _comments_attrs(_scope["#childScope/0"], _comments_attrs_value, _dirty);
+const _expr_comment_id$ifBody = /* @__PURE__ */_intersection(2, _scope => {
+  const {
+    _: {
+      comment,
+      id
+    }
+  } = _scope;
+  _comments_attrs(_scope["#childScope/0"], {
+    comments: comment.comments,
+    path: id
+  });
 });
-const _id$ifBody = /* @__PURE__ */_closure("id", (_scope, id, _dirty) => _expr_comment_id$ifBody(_scope, _dirty));
-const _comment$ifBody = /* @__PURE__ */_closure("comment", (_scope, comment, _dirty) => _expr_comment_id$ifBody(_scope, _dirty));
+const _id$ifBody = /* @__PURE__ */_closure("id", null, null, _expr_comment_id$ifBody);
+const _comment$ifBody = /* @__PURE__ */_closure("comment", null, null, _expr_comment_id$ifBody);
 const _setup$ifBody = _scope => {
   _comments2(_scope["#childScope/0"]);
 };
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko_2_renderer", /* @__PURE__ */_createRenderer(`${_comments_template}`, /* beginChild, _comments_walks, endChild */`/${_comments_walks}&`, _setup$ifBody, [_comment$ifBody, _id$ifBody]));
-const _expr_path_i$forBody = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
-  let _id$forBody_value;
-  if (_dirty) {
-    const {
-      _: {
-        path
-      },
-      i
-    } = _scope;
-    _id$forBody_value = `${path}-${i}`;
-  }
-  _id$forBody(_scope, _id$forBody_value, _dirty);
+const _expr_path_i$forBody = /* @__PURE__ */_intersection(2, _scope => {
+  const {
+    _: {
+      path
+    },
+    i
+  } = _scope;
+  _id$forBody(_scope, `${path}-${i}`);
 });
 const _if$forBody = /* @__PURE__ */_conditional("#text/4");
 const _open$forBody_effect = _register("packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko_1_open", _scope => _on(_scope["#button/2"], "click", function () {
@@ -47,49 +39,33 @@ const _open$forBody = /* @__PURE__ */_value("open", (_scope, open) => {
   _data(_scope["#text/3"], open ? "[-]" : "[+]");
   _queueEffect(_scope, _open$forBody_effect);
 });
-const _id$forBody = /* @__PURE__ */_value("id", (_scope, id, _dirty) => {
-  if (_dirty) {
-    _attr(_scope["#li/0"], "id", id);
-  }
-  _inConditionalScope(_scope, _dirty, _id$ifBody, "#text/4");
-});
-const _i$forBody = /* @__PURE__ */_value("i", (_scope, i, _dirty) => _expr_path_i$forBody(_scope, _dirty));
-const _comment$forBody = /* @__PURE__ */_value("comment", (_scope, comment, _dirty) => {
-  let _if$forBody_value;
-  if (_dirty) {
-    _data(_scope["#text/1"], comment.text);
-    _if$forBody_value = comment.comments ? _ifBody : null;
-  }
-  _if$forBody(_scope, _if$forBody_value, _dirty);
-  _inConditionalScope(_scope, _dirty, _comment$ifBody, "#text/4");
-});
-const _path$forBody = /* @__PURE__ */_closure("path", (_scope, path, _dirty) => _expr_path_i$forBody(_scope, _dirty));
+const _id$forBody = /* @__PURE__ */_value("id", (_scope, id) => _attr(_scope["#li/0"], "id", id), _inConditionalScope(_id$ifBody, "#text/4"));
+const _i$forBody = /* @__PURE__ */_value("i", null, _expr_path_i$forBody);
+const _comment$forBody = /* @__PURE__ */_value("comment", (_scope, comment) => {
+  _data(_scope["#text/1"], comment.text);
+  _if$forBody(_scope, comment.comments ? _ifBody : null);
+}, _inConditionalScope(_comment$ifBody, "#text/4"), _if$forBody);
+const _path$forBody = /* @__PURE__ */_closure("path", null, null, _expr_path_i$forBody);
 const _setup$forBody = _scope => {
   _open$forBody(_scope, true);
 };
 const _forBody = /* @__PURE__ */_createRenderer("<li><span> </span><button> </button><!></li>", /* get, next(2), get, out(1), get, next(1), get, out(1), replace */" E l D l%", _setup$forBody, [_path$forBody]);
-const _for = /* @__PURE__ */_loop("#ul/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _for = /* @__PURE__ */_loop("#ul/0", _forBody, (_scope, _destructure, _clean) => {
   let comment, i;
-  if (_dirty) [comment, i] = _destructure;
-  _comment$forBody(_scope, comment, _dirty);
-  _i$forBody(_scope, i, _dirty);
+  if (!_clean) [comment, i] = _destructure;
+  _comment$forBody(_scope, comment, _clean);
+  _i$forBody(_scope, i, _clean);
 });
-const _path = /* @__PURE__ */_value("path", (_scope, path, _dirty) => _inLoopScope(_scope, _dirty, _path$forBody, "#ul/0"));
-const _comments = /* @__PURE__ */_value("comments", (_scope, comments, _dirty) => {
-  let _for_value;
-  if (_dirty) {
-    _for_value = [comments, null];
-  }
-  _for(_scope, _for_value, _dirty);
-});
-export const attrs = (_scope, _destructure2, _dirty = true) => {
+const _path = /* @__PURE__ */_value("path", null, _inLoopScope(_path$forBody, "#ul/0"));
+const _comments = /* @__PURE__ */_value("comments", (_scope, comments) => _for(_scope, [comments, null]), null, _for);
+export const attrs = (_scope, _destructure2, _clean) => {
   let comments, path;
-  if (_dirty) ({
+  if (!_clean) ({
     comments,
     path = "c"
   } = _destructure2);
-  _comments(_scope, comments, _dirty);
-  _path(_scope, path, _dirty);
+  _comments(_scope, comments, _clean);
+  _path(_scope, path, _clean);
 };
 export { _comments, _path };
 export const template = "<ul></ul>";

--- a/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/template.js
@@ -1,12 +1,6 @@
 import { setup as _comments, attrs as _comments_attrs, template as _comments_template, walks as _comments_walks } from "./components/comments.marko";
-import { value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _input = /* @__PURE__ */_value("input", (_scope, input, _dirty) => {
-  let _comments_attrs_value;
-  if (_dirty) {
-    _comments_attrs_value = input;
-  }
-  _comments_attrs(_scope["#childScope/0"], _comments_attrs_value, _dirty);
-});
+import { inChild as _inChild, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _comments_attrs(_scope["#childScope/0"], input), null, _inChild("#childScope/0", _comments_attrs));
 const _setup = _scope => {
   _comments(_scope["#childScope/0"]);
 };

--- a/packages/translator/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/components/layout.js
+++ b/packages/translator/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/components/layout.js
@@ -1,12 +1,12 @@
 import { conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/0");
-const _renderBody = /* @__PURE__ */_value("renderBody", (_scope, renderBody) => _dynamicTagName(_scope, renderBody));
-export const attrs = (_scope, _destructure, _dirty = true) => {
+const _renderBody = /* @__PURE__ */_value("renderBody", (_scope, renderBody) => _dynamicTagName(_scope, renderBody), null, _dynamicTagName);
+export const attrs = (_scope, _destructure, _clean) => {
   let renderBody;
-  if (_dirty) ({
+  if (!_clean) ({
     renderBody
   } = _destructure);
-  _renderBody(_scope, renderBody, _dirty);
+  _renderBody(_scope, renderBody, _clean);
 };
 export { _renderBody };
 export const template = "<body><!></body>";

--- a/packages/translator/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.js
@@ -1,20 +1,20 @@
-import { data as _data, bindRenderer as _bindRenderer, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { data as _data, bindRenderer as _bindRenderer, inChild as _inChild, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _layout, attrs as _layout_attrs, template as _layout_template, walks as _layout_walks } from "./components/layout.marko";
 const _name$layoutBody = /* @__PURE__ */_dynamicClosure("name", (_scope, name) => _data(_scope["#text/0"], name));
 const _layoutBody = /* @__PURE__ */_createRenderer("<h1>Hello <!></h1>", /* next(1), over(1), replace */"Db%", null, [_name$layoutBody]);
-const _name = /* @__PURE__ */_value("name", (_scope, name, _dirty) => _dynamicSubscribers(_scope["name*"], _dirty));
+const _name = /* @__PURE__ */_value("name", null, _dynamicSubscribers("name"));
 const _setup = _scope => {
   _layout(_scope["#childScope/0"]);
   _layout_attrs(_scope["#childScope/0"], {
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _layoutBody)
   });
 };
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let name;
-  if (_dirty) ({
+  if (!_clean) ({
     name
   } = _destructure);
-  _name(_scope, name, _dirty);
+  _name(_scope, name, _clean);
 };
 export { _name };
 export const template = `${_layout_template}`;

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
@@ -15,21 +15,18 @@ const _num$forBody_effect = _register("packages/translator/src/__tests__/fixture
   } = _scope;
   _queueSource(_scope._, _selected, num);
 }));
-const _num$forBody = /* @__PURE__ */_value("num", (_scope, num, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/1"], num);
-    _queueEffect(_scope, _num$forBody_effect);
-  }
-  _expr_selected_num$forBody(_scope, _dirty);
-});
-const _selected$forBody = /* @__PURE__ */_closure("selected", (_scope, selected, _dirty) => _expr_selected_num$forBody(_scope, _dirty));
+const _num$forBody = /* @__PURE__ */_value("num", (_scope, num) => {
+  _data(_scope["#text/1"], num);
+  _queueEffect(_scope, _num$forBody_effect);
+}, _expr_selected_num$forBody);
+const _selected$forBody = /* @__PURE__ */_closure("selected", null, null, _expr_selected_num$forBody);
 const _forBody = /* @__PURE__ */_createRenderer("<button> </button>", /* get, next(1), get */" D ", null, [_selected$forBody]);
-const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _clean) => {
   let num;
-  if (_dirty) [num] = _destructure;
-  _num$forBody(_scope, num, _dirty);
+  if (!_clean) [num] = _destructure;
+  _num$forBody(_scope, num, _clean);
 });
-const _selected = /* @__PURE__ */_value("selected", (_scope, selected, _dirty) => _inLoopScope(_scope, _dirty, _selected$forBody, "#text/0"));
+const _selected = /* @__PURE__ */_value("selected", null, _inLoopScope(_selected$forBody, "#text/0"));
 const _setup = _scope => {
   _selected(_scope, 0);
   _for(_scope, [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], null]);

--- a/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { on as _on, queueSource as _queueSource, data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, queueEffect as _queueEffect, conditional as _conditional, inConditionalScope as _inConditionalScope, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, data as _data, closure as _closure, createRenderer as _createRenderer, register as _register, queueEffect as _queueEffect, conditional as _conditional, inConditionalScope as _inConditionalScope, intersections as _intersections, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _clickCount$elseBody = /* @__PURE__ */_closure("clickCount", (_scope, clickCount) => _data(_scope["#text/0"], clickCount));
 const _elseBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_2_renderer", /* @__PURE__ */_createRenderer("<span>The button was clicked <!> times.</span>", /* next(1), over(1), replace */"Db%", null, [_clickCount$elseBody]));
 const _clickCount$ifBody_effect = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_1_clickCount", _scope => _on(_scope["#button/0"], "click", function () {
@@ -15,15 +15,7 @@ const _clickCount$ifBody = /* @__PURE__ */_closure("clickCount", (_scope, clickC
 });
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/basic-nested-scope-if/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<button> </button>", /* get, next(1), get */" D ", null, [_clickCount$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/0");
-const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount, _dirty) => {
-  let _if_value;
-  if (_dirty) {
-    _if_value = clickCount < 3 ? _ifBody : _elseBody;
-  }
-  _if(_scope, _if_value, _dirty);
-  _inConditionalScope(_scope, _dirty, _clickCount$ifBody, "#text/0");
-  _inConditionalScope(_scope, _dirty, _clickCount$elseBody, "#text/0");
-});
+const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => _if(_scope, clickCount < 3 ? _ifBody : _elseBody), _intersections([_inConditionalScope(_clickCount$ifBody, "#text/0"), _inConditionalScope(_clickCount$elseBody, "#text/0")]), _if);
 const _setup = _scope => {
   _clickCount(_scope, 0);
 };

--- a/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
@@ -18,10 +18,10 @@ const _expr_id_items = /* @__PURE__ */_intersection(2, _scope => {
   } = _scope;
   _queueEffect(_scope, _expr_id_items_effect);
 });
-const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _clean) => {
   let item;
-  if (_dirty) [item] = _destructure;
-  _item$forBody(_scope, item, _dirty);
+  if (!_clean) [item] = _destructure;
+  _item$forBody(_scope, item, _clean);
 });
 const _items_effect = _register("packages/translator/src/__tests__/fixtures/basic-push-pop-list/template.marko_0_items", _scope => _on(_scope["#button/2"], "click", function () {
   const {
@@ -29,14 +29,11 @@ const _items_effect = _register("packages/translator/src/__tests__/fixtures/basi
   } = _scope;
   _queueSource(_scope, _items, items.slice(0, -1));
 }));
-const _items = /* @__PURE__ */_value("items", (_scope, items, _dirty) => {
-  if (_dirty) {
-    _queueEffect(_scope, _items_effect);
-    _for(_scope, [items, null]);
-  }
-  _expr_id_items(_scope, _dirty);
-});
-const _id = /* @__PURE__ */_value("id", (_scope, id, _dirty) => _expr_id_items(_scope, _dirty));
+const _items = /* @__PURE__ */_value("items", (_scope, items) => {
+  _queueEffect(_scope, _items_effect);
+  _for(_scope, [items, null]);
+}, _expr_id_items);
+const _id = /* @__PURE__ */_value("id", null, _expr_id_items);
 const _setup = _scope => {
   _id(_scope, 0);
   _items(_scope, []);

--- a/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
@@ -1,10 +1,10 @@
 import { attr as _attr, data as _data, on as _on, queueSource as _queueSource, value as _value, createRenderer as _createRenderer, loop as _loop, register as _register, queueEffect as _queueEffect, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _x$forBody = /* @__PURE__ */_value("x", (_scope, x) => _data(_scope["#text/0"], x));
 const _forBody = /* @__PURE__ */_createRenderer("<li> </li>", /* next(1), get */"D ");
-const _ul_for = /* @__PURE__ */_loop("#ul/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _ul_for = /* @__PURE__ */_loop("#ul/0", _forBody, (_scope, _destructure, _clean) => {
   let x;
-  if (_dirty) [x] = _destructure;
-  _x$forBody(_scope, x, _dirty);
+  if (!_clean) [x] = _destructure;
+  _x$forBody(_scope, x, _clean);
 });
 const _list_effect = _register("packages/translator/src/__tests__/fixtures/basic-shared-node-ref/template.marko_0_list", _scope => _on(_scope["#button/2"], "click", function () {
   const {

--- a/packages/translator/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
@@ -2,7 +2,7 @@ import { on as _on, queueSource as _queueSource, data as _data, closure as _clos
 const _message$ifBody = /* @__PURE__ */_closure("message", (_scope, message) => _data(_scope["#text/0"], message));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/batched-updates-cleanup/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_message$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/1");
-const _message = /* @__PURE__ */_value("message", (_scope, message, _dirty) => _inConditionalScope(_scope, _dirty, _message$ifBody, "#text/1"));
+const _message = /* @__PURE__ */_value("message", null, _inConditionalScope(_message$ifBody, "#text/1"));
 const _show_effect = _register("packages/translator/src/__tests__/fixtures/batched-updates-cleanup/template.marko_0_show", _scope => _on(_scope["#button/0"], "click", function () {
   const {
     show
@@ -10,14 +10,10 @@ const _show_effect = _register("packages/translator/src/__tests__/fixtures/batch
   _queueSource(_scope, _message, "bye");
   _queueSource(_scope, _show, !show);
 }));
-const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
-  let _if_value;
-  if (_dirty) {
-    _queueEffect(_scope, _show_effect);
-    _if_value = show ? _ifBody : null;
-  }
-  _if(_scope, _if_value, _dirty);
-});
+const _show = /* @__PURE__ */_value("show", (_scope, show) => {
+  _queueEffect(_scope, _show_effect);
+  _if(_scope, show ? _ifBody : null);
+}, null, _if);
 const _setup = _scope => {
   _show(_scope, true);
   _message(_scope, "hi");

--- a/packages/translator/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.js
@@ -15,8 +15,8 @@ const _expr_a_b = /* @__PURE__ */_intersection(2, _scope => {
   _data(_scope["#text/1"], a + b);
   _queueEffect(_scope, _expr_a_b_effect);
 });
-const _b = /* @__PURE__ */_value("b", (_scope, b, _dirty) => _expr_a_b(_scope, _dirty));
-const _a = /* @__PURE__ */_value("a", (_scope, a, _dirty) => _expr_a_b(_scope, _dirty));
+const _b = /* @__PURE__ */_value("b", null, _expr_a_b);
+const _a = /* @__PURE__ */_value("a", null, _expr_a_b);
 const _setup = _scope => {
   _a(_scope, 0);
   _b(_scope, 0);

--- a/packages/translator/src/__tests__/fixtures/body-content/__snapshots__/resume.expected.md
+++ b/packages/translator/src/__tests__/fixtures/body-content/__snapshots__/resume.expected.md
@@ -9,7 +9,7 @@
     </button>
     <!--M#1 #button/0-->
     <script>
-      (M$h=[]).push((b,s,h)=&gt;({0:h={clickCount:0},1:{onClick:b("clickHandler",h)},2:{_:h}}),[2,"subscribe_clickCount$renderBody",1,"FancyButton$onclick_resume",])
+      (M$h=[]).push((b,s,h)=&gt;({0:h={clickCount:0},1:{onClick:b("clickHandler",h)},2:{_:h}}),[2,"subscribe_clickCount$renderBody",1,"FancyButton$onclick_effect",])
     </script>
   </body>
 </html>
@@ -34,7 +34,7 @@ container.querySelector("button").click();
     </button>
     <!--M#1 #button/0-->
     <script>
-      (M$h=[]).push((b,s,h)=&gt;({0:h={clickCount:0},1:{onClick:b("clickHandler",h)},2:{_:h}}),[2,"subscribe_clickCount$renderBody",1,"FancyButton$onclick_resume",])
+      (M$h=[]).push((b,s,h)=&gt;({0:h={clickCount:0},1:{onClick:b("clickHandler",h)},2:{_:h}}),[2,"subscribe_clickCount$renderBody",1,"FancyButton$onclick_effect",])
     </script>
   </body>
 </html>
@@ -59,7 +59,7 @@ container.querySelector("button").click();
     </button>
     <!--M#1 #button/0-->
     <script>
-      (M$h=[]).push((b,s,h)=&gt;({0:h={clickCount:0},1:{onClick:b("clickHandler",h)},2:{_:h}}),[2,"subscribe_clickCount$renderBody",1,"FancyButton$onclick_resume",])
+      (M$h=[]).push((b,s,h)=&gt;({0:h={clickCount:0},1:{onClick:b("clickHandler",h)},2:{_:h}}),[2,"subscribe_clickCount$renderBody",1,"FancyButton$onclick_effect",])
     </script>
   </body>
 </html>
@@ -84,7 +84,7 @@ container.querySelector("button").click();
     </button>
     <!--M#1 #button/0-->
     <script>
-      (M$h=[]).push((b,s,h)=&gt;({0:h={clickCount:0},1:{onClick:b("clickHandler",h)},2:{_:h}}),[2,"subscribe_clickCount$renderBody",1,"FancyButton$onclick_resume",])
+      (M$h=[]).push((b,s,h)=&gt;({0:h={clickCount:0},1:{onClick:b("clickHandler",h)},2:{_:h}}),[2,"subscribe_clickCount$renderBody",1,"FancyButton$onclick_effect",])
     </script>
   </body>
 </html>

--- a/packages/translator/src/__tests__/fixtures/body-content/__snapshots__/ssr.expected.md
+++ b/packages/translator/src/__tests__/fixtures/body-content/__snapshots__/ssr.expected.md
@@ -1,5 +1,5 @@
 # Write
-  <body><button>0<!M#2 #text/0></button><!M#1 #button/0></body><script>(M$h=[]).push((b,s,h)=>({0:h={clickCount:0},1:{onClick:b("clickHandler",h)},2:{_:h}}),[2,"subscribe_clickCount$renderBody",1,"FancyButton$onclick_resume",])</script>
+  <body><button>0<!M#2 #text/0></button><!M#1 #button/0></body><script>(M$h=[]).push((b,s,h)=>({0:h={clickCount:0},1:{onClick:b("clickHandler",h)},2:{_:h}}),[2,"subscribe_clickCount$renderBody",1,"FancyButton$onclick_effect",])</script>
 
 
 # Render "End"
@@ -13,7 +13,7 @@
     </button>
     <!--M#1 #button/0-->
     <script>
-      (M$h=[]).push((b,s,h)=&gt;({0:h={clickCount:0},1:{onClick:b("clickHandler",h)},2:{_:h}}),[2,"subscribe_clickCount$renderBody",1,"FancyButton$onclick_resume",])
+      (M$h=[]).push((b,s,h)=&gt;({0:h={clickCount:0},1:{onClick:b("clickHandler",h)},2:{_:h}}),[2,"subscribe_clickCount$renderBody",1,"FancyButton$onclick_effect",])
     </script>
   </body>
 </html>

--- a/packages/translator/src/__tests__/fixtures/body-content/resume.ts
+++ b/packages/translator/src/__tests__/fixtures/body-content/resume.ts
@@ -1,11 +1,11 @@
 import {
-  FancyButton$onclick_resume,
+  FancyButton$onclick_effect,
   subscribe_clickCount$renderBody,
   clickHandler,
 } from "./browser";
 import { init, register } from "@marko/runtime-fluurt/src/dom";
 
-register("FancyButton$onclick_resume", FancyButton$onclick_resume);
+register("FancyButton$onclick_effect", FancyButton$onclick_effect);
 register("subscribe_clickCount$renderBody", subscribe_clickCount$renderBody);
 register("clickHandler", clickHandler);
 init();

--- a/packages/translator/src/__tests__/fixtures/body-content/server.ts
+++ b/packages/translator/src/__tests__/fixtures/body-content/server.ts
@@ -60,5 +60,5 @@ const FancyButton = ({
   write(`</button>${markResumeNode(scopeId, "#button/0")}`);
 
   writeScope(scopeId, { onClick });
-  writeEffect(scopeId, "FancyButton$onclick_resume");
+  writeEffect(scopeId, "FancyButton$onclick_effect");
 };

--- a/packages/translator/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/components/display-intersection.js
+++ b/packages/translator/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/components/display-intersection.js
@@ -6,17 +6,17 @@ const _expr_value_dummy = /* @__PURE__ */_intersection(2, _scope => {
   } = _scope;
   _data(_scope["#text/0"], (dummy, value));
 });
-const _dummy = /* @__PURE__ */_value2("dummy", (_scope, dummy, _dirty) => _expr_value_dummy(_scope, _dirty));
-const _value = /* @__PURE__ */_value2("value", (_scope, value, _dirty) => _expr_value_dummy(_scope, _dirty));
+const _dummy = /* @__PURE__ */_value2("dummy", null, _expr_value_dummy);
+const _value = /* @__PURE__ */_value2("value", null, _expr_value_dummy);
 const _setup = _scope => {
   _dummy(_scope, {});
 };
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let value;
-  if (_dirty) ({
+  if (!_clean) ({
     value
   } = _destructure);
-  _value(_scope, value, _dirty);
+  _value(_scope, value, _clean);
 };
 export { _value };
 export const template = "<div> </div>";

--- a/packages/translator/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.js
@@ -1,21 +1,17 @@
 import { setup as _displayIntersection, attrs as _displayIntersection_attrs, template as _displayIntersection_template, walks as _displayIntersection_walks } from "./components/display-intersection.marko";
-import { on as _on, queueSource as _queueSource, register as _register, queueEffect as _queueEffect, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { inChild as _inChild, on as _on, queueSource as _queueSource, register as _register, queueEffect as _queueEffect, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _count_effect = _register("packages/translator/src/__tests__/fixtures/component-attrs-intersection/template.marko_0_count", _scope => _on(_scope["#button/1"], "click", function () {
   const {
     count
   } = _scope;
   _queueSource(_scope, _count, count + 1);
 }));
-const _count = /* @__PURE__ */_value("count", (_scope, count, _dirty) => {
-  let _displayIntersection_attrs_value;
-  if (_dirty) {
-    _queueEffect(_scope, _count_effect);
-    _displayIntersection_attrs_value = {
-      value: count
-    };
-  }
-  _displayIntersection_attrs(_scope["#childScope/0"], _displayIntersection_attrs_value, _dirty);
-});
+const _count = /* @__PURE__ */_value("count", (_scope, count) => {
+  _queueEffect(_scope, _count_effect);
+  _displayIntersection_attrs(_scope["#childScope/0"], {
+    value: count
+  });
+}, null, _inChild("#childScope/0", _displayIntersection_attrs));
 const _setup = _scope => {
   _displayIntersection(_scope["#childScope/0"]);
   _count(_scope, 0);

--- a/packages/translator/src/__tests__/fixtures/context-tag-derivation/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-derivation/__snapshots__/dom.expected/template.js
@@ -1,10 +1,10 @@
-import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, childClosures as _childClosures, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { initContextProvider as _initContextProvider, childClosures as _childClosures, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _child, template as _child_template, walks as _child_walks, closures as _child_closures } from "./components/child.marko";
 const _setup$putBody = _scope => {
   _child(_scope["#childScope/0"]);
 };
 const _putBody = /* @__PURE__ */_createRenderer(`${_child_template}`, /* beginChild, _child_walks, endChild */`/${_child_walks}&`, _setup$putBody, [_childClosures(_child_closures, "#childScope/0")]);
-const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
+const _put = /* @__PURE__ */_value("0:", null, _dynamicSubscribers("0:"));
 const _setup = _scope => {
   _initContextProvider(_scope, "#text/0", "0:", "packages/translator/src/__tests__/fixtures/context-tag-derivation/template.marko", _putBody);
   _put(_scope, 123);

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-self/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-self/__snapshots__/dom.expected/template.js
@@ -1,7 +1,7 @@
-import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, data as _data, contextClosure as _contextClosure, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { initContextProvider as _initContextProvider, data as _data, contextClosure as _contextClosure, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _x$putBody = /* @__PURE__ */_contextClosure("x", "packages/translator/src/__tests__/fixtures/context-tag-from-self/template.marko", (_scope, x) => _data(_scope["#text/0"], x));
 const _putBody = /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_x$putBody]);
-const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
+const _put = /* @__PURE__ */_value("0:", null, _dynamicSubscribers("0:"));
 const _setup = _scope => {
   _initContextProvider(_scope, "#text/0", "0:", "packages/translator/src/__tests__/fixtures/context-tag-from-self/template.marko", _putBody);
   _put(_scope, 1);

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected/components/other.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected/components/other.js
@@ -1,9 +1,9 @@
-import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, conditional as _conditional, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { initContextProvider as _initContextProvider, conditional as _conditional, dynamicClosure as _dynamicClosure, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _dynamicTagName$putBody = /* @__PURE__ */_conditional("#text/0");
-const _input$putBody = /* @__PURE__ */_dynamicClosure("input", (_scope, input) => _dynamicTagName$putBody(_scope, input.renderBody));
+const _input$putBody = /* @__PURE__ */_dynamicClosure("input", (_scope, input) => _dynamicTagName$putBody(_scope, input.renderBody), null, null, _dynamicTagName$putBody);
 const _putBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_input$putBody]);
-const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
-const _input = /* @__PURE__ */_value("input", (_scope, input, _dirty) => _dynamicSubscribers(_scope["input*"], _dirty));
+const _put = /* @__PURE__ */_value("0:", null, _dynamicSubscribers("0:"));
+const _input = /* @__PURE__ */_value("input", null, _dynamicSubscribers("input"));
 const _setup = _scope => {
   _initContextProvider(_scope, "#text/0", "0:", "packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/components/other.marko", _putBody);
   _put(_scope, "Hello");

--- a/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { data as _data, bindRenderer as _bindRenderer, contextClosure as _contextClosure, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { data as _data, bindRenderer as _bindRenderer, inChild as _inChild, contextClosure as _contextClosure, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _other, attrs as _other_attrs, template as _other_template, walks as _other_walks } from "./components/other.marko";
 const _message$otherBody = /* @__PURE__ */_contextClosure("message", "packages/translator/src/__tests__/fixtures/context-tag-from-tag-name/components/other.marko", (_scope, message) => _data(_scope["#text/0"], message));
 const _otherBody = /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_message$otherBody]);

--- a/packages/translator/src/__tests__/fixtures/context-tag-in-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-in-if/__snapshots__/dom.expected/template.js
@@ -1,28 +1,17 @@
-import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, data as _data, on as _on, queueSource as _queueSource, contextClosure as _contextClosure, createRenderer as _createRenderer, register as _register, conditional as _conditional, dynamicClosure as _dynamicClosure, value as _value, queueEffect as _queueEffect, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { initContextProvider as _initContextProvider, data as _data, on as _on, queueSource as _queueSource, contextClosure as _contextClosure, createRenderer as _createRenderer, register as _register, conditional as _conditional, dynamicClosure as _dynamicClosure, dynamicSubscribers as _dynamicSubscribers, value as _value, queueEffect as _queueEffect, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _x$ifBody = /* @__PURE__ */_contextClosure("x", "packages/translator/src/__tests__/fixtures/context-tag-in-if/template.marko", (_scope, x) => _data(_scope["#text/0"], x));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/context-tag-in-if/template.marko_2_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_x$ifBody]));
 const _if$putBody = /* @__PURE__ */_conditional("#text/0");
-const _show$putBody = /* @__PURE__ */_dynamicClosure("show", (_scope, show, _dirty) => {
-  let _if$putBody_value;
-  if (_dirty) {
-    _if$putBody_value = show ? _ifBody : null;
-  }
-  _if$putBody(_scope, _if$putBody_value, _dirty);
-});
+const _show$putBody = /* @__PURE__ */_dynamicClosure("show", (_scope, show) => _if$putBody(_scope, show ? _ifBody : null), null, null, _if$putBody);
 const _putBody = /* @__PURE__ */_createRenderer("<!>", /* replace */"%", null, [_show$putBody]);
-const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
+const _put = /* @__PURE__ */_value("0:", null, _dynamicSubscribers("0:"));
 const _show_effect = _register("packages/translator/src/__tests__/fixtures/context-tag-in-if/template.marko_0_show", _scope => _on(_scope["#button/1"], "click", function () {
   const {
     show
   } = _scope;
   _queueSource(_scope, _show, !show);
 }));
-const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
-  if (_dirty) {
-    _queueEffect(_scope, _show_effect);
-  }
-  _dynamicSubscribers(_scope["show*"], _dirty);
-});
+const _show = /* @__PURE__ */_value("show", (_scope, show) => _queueEffect(_scope, _show_effect), _dynamicSubscribers("show"));
 const _setup = _scope => {
   _initContextProvider(_scope, "#text/0", "0:", "packages/translator/src/__tests__/fixtures/context-tag-in-if/template.marko", _putBody);
   _show(_scope, true);

--- a/packages/translator/src/__tests__/fixtures/context-tag-reactive/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-reactive/__snapshots__/dom.expected/template.js
@@ -1,25 +1,21 @@
-import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, childClosures as _childClosures, on as _on, queueSource as _queueSource, data as _data, createRenderer as _createRenderer, value as _value, register as _register, queueEffect as _queueEffect, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { initContextProvider as _initContextProvider, childClosures as _childClosures, on as _on, queueSource as _queueSource, data as _data, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, register as _register, queueEffect as _queueEffect, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _child, template as _child_template, walks as _child_walks, closures as _child_closures } from "./components/child.marko";
 const _setup$putBody = _scope => {
   _child(_scope["#childScope/0"]);
 };
 const _putBody = /* @__PURE__ */_createRenderer(`${_child_template}`, /* beginChild, _child_walks, endChild */`/${_child_walks}&`, _setup$putBody, [_childClosures(_child_closures, "#childScope/0")]);
-const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
+const _put = /* @__PURE__ */_value("0:", null, _dynamicSubscribers("0:"));
 const _x_effect = _register("packages/translator/src/__tests__/fixtures/context-tag-reactive/template.marko_0_x", _scope => _on(_scope["#button/1"], "click", function () {
   const {
     x
   } = _scope;
   _queueSource(_scope, _x, x + 1);
 }));
-const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
-  let _put_value;
-  if (_dirty) {
-    _data(_scope["#text/2"], x);
-    _queueEffect(_scope, _x_effect);
-    _put_value = x;
-  }
-  _put(_scope, _put_value, _dirty);
-});
+const _x = /* @__PURE__ */_value("x", (_scope, x) => {
+  _data(_scope["#text/2"], x);
+  _queueEffect(_scope, _x_effect);
+  _put(_scope, x);
+}, null, _put);
 const _setup = _scope => {
   _initContextProvider(_scope, "#text/0", "0:", "packages/translator/src/__tests__/fixtures/context-tag-reactive/template.marko", _putBody);
   _x(_scope, 123);

--- a/packages/translator/src/__tests__/fixtures/context-tag-static/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/context-tag-static/__snapshots__/dom.expected/template.js
@@ -1,10 +1,10 @@
-import { dynamicSubscribers as _dynamicSubscribers, initContextProvider as _initContextProvider, childClosures as _childClosures, createRenderer as _createRenderer, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { initContextProvider as _initContextProvider, childClosures as _childClosures, createRenderer as _createRenderer, dynamicSubscribers as _dynamicSubscribers, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 import { setup as _child, template as _child_template, walks as _child_walks, closures as _child_closures } from "./components/child.marko";
 const _setup$putBody = _scope => {
   _child(_scope["#childScope/0"]);
 };
 const _putBody = /* @__PURE__ */_createRenderer(`${_child_template}`, /* beginChild, _child_walks, endChild */`/${_child_walks}&`, _setup$putBody, [_childClosures(_child_closures, "#childScope/0")]);
-const _put = /* @__PURE__ */_value("0:", (_scope, put, _dirty) => _dynamicSubscribers(_scope["0:*"], _dirty));
+const _put = /* @__PURE__ */_value("0:", null, _dynamicSubscribers("0:"));
 const _setup = _scope => {
   _initContextProvider(_scope, "#text/0", "0:", "packages/translator/src/__tests__/fixtures/context-tag-static/template.marko", _putBody);
   _put(_scope, 123);

--- a/packages/translator/src/__tests__/fixtures/counter-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/counter-intersection/__snapshots__/dom.expected/template.js
@@ -6,18 +6,8 @@ const _expr_a_b = /* @__PURE__ */_intersection(2, _scope => {
   } = _scope;
   _data(_scope["#text/4"], a + b);
 });
-const _b = /* @__PURE__ */_value("b", (_scope, b, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/3"], b);
-  }
-  _expr_a_b(_scope, _dirty);
-});
-const _a = /* @__PURE__ */_value("a", (_scope, a, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/1"], a);
-  }
-  _expr_a_b(_scope, _dirty);
-});
+const _b = /* @__PURE__ */_value("b", (_scope, b) => _data(_scope["#text/3"], b), _expr_a_b);
+const _a = /* @__PURE__ */_value("a", (_scope, a) => _data(_scope["#text/1"], a), _expr_a_b);
 const _setup_effect = _register("packages/translator/src/__tests__/fixtures/counter-intersection/template.marko_0", _scope => {
   _on(_scope["#button/0"], "click", function () {
     _queueSource(_scope, _a, 10);

--- a/packages/translator/src/__tests__/fixtures/create-and-clear-rows-loop-from/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/create-and-clear-rows-loop-from/__snapshots__/dom.expected/template.js
@@ -1,10 +1,10 @@
 import { data as _data, computeLoopToFrom as _computeLoopToFrom, value as _value, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _n$forBody = /* @__PURE__ */_value("n", (_scope, n) => _data(_scope["#text/0"], n));
 const _forBody = /* @__PURE__ */_createRenderer("<!>, ", /* replace */"%");
-const _for = /* @__PURE__ */_loop("#div/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _for = /* @__PURE__ */_loop("#div/0", _forBody, (_scope, _destructure, _clean) => {
   let n;
-  if (_dirty) [n] = _destructure;
-  _n$forBody(_scope, n, _dirty);
+  if (!_clean) [n] = _destructure;
+  _n$forBody(_scope, n, _clean);
 });
 const _input = /* @__PURE__ */_value("input", (_scope, input) => _for(_scope, _computeLoopToFrom(input.to, input.from, input.step)));
 export const attrs = _input;

--- a/packages/translator/src/__tests__/fixtures/create-and-clear-rows-loop-in/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/create-and-clear-rows-loop-in/__snapshots__/dom.expected/template.js
@@ -4,16 +4,16 @@ const _forBody2 = /* @__PURE__ */_createRenderer("<p> </p>", /* next(1), get */"
 const _text$forBody = /* @__PURE__ */_value("text", (_scope, text) => _data(_scope["#text/1"], text));
 const _key$forBody = /* @__PURE__ */_value("key", (_scope, key) => _data(_scope["#text/0"], key));
 const _forBody = /* @__PURE__ */_createRenderer("<p><!>: <!></p>", /* next(1), replace, over(2), replace */"D%c%");
-const _for2 = /* @__PURE__ */_loop("#text/1", _forBody2, (_scope, _destructure2, _dirty = true) => {
+const _for2 = /* @__PURE__ */_loop("#text/1", _forBody2, (_scope, _destructure2, _clean) => {
   let key;
-  if (_dirty) [[key]] = _destructure2;
-  _key$forBody2(_scope, key, _dirty);
+  if (!_clean) [[key]] = _destructure2;
+  _key$forBody2(_scope, key, _clean);
 });
-const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _clean) => {
   let key, text;
-  if (_dirty) [[key, text]] = _destructure;
-  _key$forBody(_scope, key, _dirty);
-  _text$forBody(_scope, text, _dirty);
+  if (!_clean) [[key, text]] = _destructure;
+  _key$forBody(_scope, key, _clean);
+  _text$forBody(_scope, text, _clean);
 });
 const _input = /* @__PURE__ */_value("input", (_scope, input) => {
   _for(_scope, _computeLoopIn(input.children));

--- a/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/template.js
@@ -1,14 +1,8 @@
 import { setup as _child, attrs as _child_attrs, template as _child_template, walks as _child_walks } from "./components/child.marko";
-import { value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
-  let _child_attrs_value;
-  if (_dirty) {
-    _child_attrs_value = {
-      value: x
-    };
-  }
-  _child_attrs(_scope["#childScope/1"], _child_attrs_value, _dirty);
-});
+import { inChild as _inChild, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _child_attrs(_scope["#childScope/1"], {
+  value: x
+}), null, _inChild("#childScope/1", _child_attrs));
 const _setup = _scope => {
   _child(_scope["#childScope/0"]);
   _child(_scope["#childScope/1"]);

--- a/packages/translator/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/components/child/index.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/components/child/index.js
@@ -1,6 +1,6 @@
 import { conditional as _conditional, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/0");
-const _input = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.renderBody));
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.renderBody), null, _dynamicTagName);
 export const attrs = _input;
 export { _input };
 export const template = "<!>";

--- a/packages/translator/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/template.js
@@ -1,5 +1,5 @@
 import { setup as _child, attrs as _child_attrs, template as _child_template, walks as _child_walks } from "./components/child/index.marko";
-import { bindRenderer as _bindRenderer, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { bindRenderer as _bindRenderer, inChild as _inChild, createRenderer as _createRenderer, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _childBody = /* @__PURE__ */_createRenderer("This is the body content", "");
 const _setup = _scope => {
   _child(_scope["#childScope/0"]);

--- a/packages/translator/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.expected/template.js
@@ -1,4 +1,5 @@
 import { setup as _hello, attrs as _hello_attrs, template as _hello_template, walks as _hello_walks } from "./hello.marko";
+import { inChild as _inChild, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _setup = _scope => {
   _hello(_scope["#childScope/0"]);
   _hello_attrs(_scope["#childScope/0"], {
@@ -8,5 +9,4 @@ const _setup = _scope => {
 export const template = `${_hello_template}`;
 export const walks = /* beginChild, _hello_walks, endChild */`/${_hello_walks}&`;
 export const setup = _setup;
-import { createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 export default /* @__PURE__ */_createRenderFn(template, walks, setup, null, null, "packages/translator/src/__tests__/fixtures/custom-tag-template/template.marko");

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/components/child.js
@@ -1,11 +1,5 @@
 import { tagVarSignal as _tagVarSignal, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
-  let _tagVarSignal_value;
-  if (_dirty) {
-    _tagVarSignal_value = x + 3;
-  }
-  _tagVarSignal(_scope, _tagVarSignal_value, _dirty);
-});
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _tagVarSignal(_scope, x + 3), null, _tagVarSignal);
 const _setup = _scope => {
   _x(_scope, 1);
 };

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/components/child.js
@@ -1,17 +1,13 @@
 import { tagVarSignal as _tagVarSignal, intersection as _intersection, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _expr_x_y = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
-  let _tagVarSignal_value;
-  if (_dirty) {
-    const {
-      x,
-      y
-    } = _scope;
-    _tagVarSignal_value = x + y;
-  }
-  _tagVarSignal(_scope, _tagVarSignal_value, _dirty);
+const _expr_x_y = /* @__PURE__ */_intersection(2, _scope => {
+  const {
+    x,
+    y
+  } = _scope;
+  _tagVarSignal(_scope, x + y);
 });
-const _y = /* @__PURE__ */_value("y", (_scope, y, _dirty) => _expr_x_y(_scope, _dirty));
-const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => _expr_x_y(_scope, _dirty));
+const _y = /* @__PURE__ */_value("y", null, _expr_x_y);
+const _x = /* @__PURE__ */_value("x", null, _expr_x_y);
 const _setup = _scope => {
   _x(_scope, 1);
   _y(_scope, 2);

--- a/packages/translator/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/components/child.js
@@ -5,15 +5,11 @@ const _x_effect = _register("packages/translator/src/__tests__/fixtures/custom-t
   } = _scope;
   _queueSource(_scope, _x, x + 1);
 }));
-const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
-  let _tagVarSignal_value;
-  if (_dirty) {
-    _data(_scope["#text/1"], x);
-    _queueEffect(_scope, _x_effect);
-    _tagVarSignal_value = x;
-  }
-  _tagVarSignal(_scope, _tagVarSignal_value, _dirty);
-});
+const _x = /* @__PURE__ */_value("x", (_scope, x) => {
+  _data(_scope["#text/1"], x);
+  _queueEffect(_scope, _x_effect);
+  _tagVarSignal(_scope, x);
+}, null, _tagVarSignal);
 const _setup = _scope => {
   _x(_scope, 1);
 };

--- a/packages/translator/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
@@ -1,34 +1,27 @@
-import { dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, intersection as _intersection, conditional as _conditional, value as _value, register as _register, queueEffect as _queueEffect, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, createRenderer as _createRenderer, dynamicTagAttrs as _dynamicTagAttrs, intersection as _intersection, conditional as _conditional, value as _value, register as _register, queueEffect as _queueEffect, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _tagNameBody = /* @__PURE__ */_createRenderer("body content", "");
-const _expr_dynamicTagName_className = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
-  let _tagName_input;
-  if (_dirty) {
-    const {
-      "#text/0": dynamicTagName,
-      className
-    } = _scope;
-    _tagName_input = () => ({
-      class: className
-    });
-  }
-  _dynamicTagAttrs(_scope, "#text/0", _tagName_input, _tagNameBody, _dirty);
+const _tagName_input = _dynamicTagAttrs("#text/0", _tagNameBody);
+const _expr_dynamicTagName_className = /* @__PURE__ */_intersection(2, _scope => {
+  const {
+    "#text/0": dynamicTagName,
+    className
+  } = _scope;
+  _tagName_input(_scope, () => ({
+    class: className
+  }));
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => _expr_dynamicTagName_className(_scope, _dirty));
-const _className = /* @__PURE__ */_value("className", (_scope, className, _dirty) => _expr_dynamicTagName_className(_scope, _dirty));
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", null, _expr_dynamicTagName_className);
+const _className = /* @__PURE__ */_value("className", null, _expr_dynamicTagName_className);
 const _tagName_effect = _register("packages/translator/src/__tests__/fixtures/dynamic-native-dynamic-tag/template.marko_0_tagName", _scope => _on(_scope["#button/1"], "click", function () {
   const {
     tagName
   } = _scope;
   _queueSource(_scope, _tagName, tagName === "span" ? "div" : "span");
 }));
-const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
-  let _dynamicTagName_value;
-  if (_dirty) {
-    _queueEffect(_scope, _tagName_effect);
-    _dynamicTagName_value = tagName || _tagNameBody;
-  }
-  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
-});
+const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName) => {
+  _queueEffect(_scope, _tagName_effect);
+  _dynamicTagName(_scope, tagName || _tagNameBody);
+}, null, _dynamicTagName);
 const _setup = _scope => {
   _tagName(_scope, "span");
   _className(_scope, "A");

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/components/child.js
@@ -1,11 +1,11 @@
 import { data as _data, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _id = /* @__PURE__ */_value("id", (_scope, id) => _data(_scope["#text/0"], id));
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let id;
-  if (_dirty) ({
+  if (!_clean) ({
     id
   } = _destructure);
-  _id(_scope, id, _dirty);
+  _id(_scope, id, _clean);
 };
 export { _id };
 export const template = "<div>Id is <!></div>";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.js
@@ -1,28 +1,19 @@
 import child from "./components/child.marko";
 import { on as _on, queueSource as _queueSource, dynamicTagAttrs as _dynamicTagAttrs, conditional as _conditional, register as _register, queueEffect as _queueEffect, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/1", (_scope, _dirty) => {
-  let _tagName_input;
-  if (_dirty) {
-    _tagName_input = () => ({
-      id: "dynamic"
-    });
-  }
-  _dynamicTagAttrs(_scope, "#text/1", _tagName_input, null, _dirty);
-});
+const _tagName_input = _dynamicTagAttrs("#text/1");
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/1", _scope => _tagName_input(_scope, () => ({
+  id: "dynamic"
+})), null, _tagName_input);
 const _tagName_effect = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-custom-native/template.marko_0_tagName", _scope => _on(_scope["#button/0"], "click", function () {
   const {
     tagName
   } = _scope;
   _queueSource(_scope, _tagName, tagName === child ? "div" : child);
 }));
-const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
-  let _dynamicTagName_value;
-  if (_dirty) {
-    _queueEffect(_scope, _tagName_effect);
-    _dynamicTagName_value = tagName;
-  }
-  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
-});
+const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName) => {
+  _queueEffect(_scope, _tagName_effect);
+  _dynamicTagName(_scope, tagName);
+}, null, _dynamicTagName);
 const _setup = _scope => {
   _tagName(_scope, child);
 };

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/components/child1.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/components/child1.js
@@ -1,11 +1,11 @@
 import { data as _data, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _value = /* @__PURE__ */_value2("value", (_scope, value) => _data(_scope["#text/0"], value));
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let value;
-  if (_dirty) ({
+  if (!_clean) ({
     value
   } = _destructure);
-  _value(_scope, value, _dirty);
+  _value(_scope, value, _clean);
 };
 export { _value };
 export const template = "<div>Child 1 has <!></div>";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/components/child2.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/components/child2.js
@@ -1,11 +1,11 @@
 import { data as _data, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _value = /* @__PURE__ */_value2("value", (_scope, value) => _data(_scope["#text/0"], value));
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let value;
-  if (_dirty) ({
+  if (!_clean) ({
     value
   } = _destructure);
-  _value(_scope, value, _dirty);
+  _value(_scope, value, _clean);
 };
 export { _value };
 export const template = "<div>Child 2 has <!></div>";

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
@@ -1,35 +1,28 @@
 import child1 from "./components/child1.marko";
 import child2 from "./components/child2.marko";
-import { dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, intersection as _intersection, conditional as _conditional, value as _value, register as _register, queueEffect as _queueEffect, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _expr_dynamicTagName_val = /* @__PURE__ */_intersection(2, (_scope, _dirty) => {
-  let _tagName_input;
-  if (_dirty) {
-    const {
-      "#text/0": dynamicTagName,
-      val
-    } = _scope;
-    _tagName_input = () => ({
-      value: val
-    });
-  }
-  _dynamicTagAttrs(_scope, "#text/0", _tagName_input, null, _dirty);
+import { on as _on, queueSource as _queueSource, dynamicTagAttrs as _dynamicTagAttrs, intersection as _intersection, conditional as _conditional, value as _value, register as _register, queueEffect as _queueEffect, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+const _tagName_input = _dynamicTagAttrs("#text/0");
+const _expr_dynamicTagName_val = /* @__PURE__ */_intersection(2, _scope => {
+  const {
+    "#text/0": dynamicTagName,
+    val
+  } = _scope;
+  _tagName_input(_scope, () => ({
+    value: val
+  }));
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => _expr_dynamicTagName_val(_scope, _dirty));
-const _val = /* @__PURE__ */_value("val", (_scope, val, _dirty) => _expr_dynamicTagName_val(_scope, _dirty));
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", null, _expr_dynamicTagName_val);
+const _val = /* @__PURE__ */_value("val", null, _expr_dynamicTagName_val);
 const _tagName_effect = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-custom-tags/template.marko_0_tagName", _scope => _on(_scope["#button/1"], "click", function () {
   const {
     tagName
   } = _scope;
   _queueSource(_scope, _tagName, tagName === child1 ? child2 : child1);
 }));
-const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
-  let _dynamicTagName_value;
-  if (_dirty) {
-    _queueEffect(_scope, _tagName_effect);
-    _dynamicTagName_value = tagName;
-  }
-  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
-});
+const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName) => {
+  _queueEffect(_scope, _tagName_effect);
+  _dynamicTagName(_scope, tagName);
+}, null, _dynamicTagName);
 const _setup = _scope => {
   _tagName(_scope, child1);
   _val(_scope, 3);

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.js
@@ -1,26 +1,17 @@
-import { dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, conditional as _conditional, register as _register, queueEffect as _queueEffect, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, createRenderer as _createRenderer, dynamicTagAttrs as _dynamicTagAttrs, conditional as _conditional, register as _register, queueEffect as _queueEffect, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _xBody = /* @__PURE__ */_createRenderer("Body Content", "");
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => {
-  let _x_input;
-  if (_dirty) {
-    _x_input = () => ({});
-  }
-  _dynamicTagAttrs(_scope, "#text/0", _x_input, _xBody, _dirty);
-});
+const _x_input = _dynamicTagAttrs("#text/0", _xBody);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", _scope => _x_input(_scope, () => ({})), null, _x_input);
 const _x_effect = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-sometimes-null/template.marko_0_x", _scope => _on(_scope["#button/1"], "click", function () {
   const {
     x
   } = _scope;
   _queueSource(_scope, _x, x ? null : "div");
 }));
-const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
-  let _dynamicTagName_value;
-  if (_dirty) {
-    _queueEffect(_scope, _x_effect);
-    _dynamicTagName_value = x || _xBody;
-  }
-  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
-});
+const _x = /* @__PURE__ */_value("x", (_scope, x) => {
+  _queueEffect(_scope, _x_effect);
+  _dynamicTagName(_scope, x || _xBody);
+}, null, _dynamicTagName);
 const _setup = _scope => {
   _x(_scope, null);
 };

--- a/packages/translator/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.js
@@ -1,30 +1,21 @@
 import { setup as _counter, template as _counter_template, walks as _counter_walks } from "./components/counter.marko";
-import { dynamicTagAttrs as _dynamicTagAttrs, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, conditional as _conditional, register as _register, queueEffect as _queueEffect, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { on as _on, queueSource as _queueSource, createRenderer as _createRenderer, dynamicTagAttrs as _dynamicTagAttrs, conditional as _conditional, register as _register, queueEffect as _queueEffect, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _setup$tagNameBody = _scope => {
   _counter(_scope["#childScope/0"]);
 };
 const _tagNameBody = /* @__PURE__ */_createRenderer(`${_counter_template}`, /* beginChild, _counter_walks, endChild */`/${_counter_walks}&`, _setup$tagNameBody);
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", (_scope, _dirty) => {
-  let _tagName_input;
-  if (_dirty) {
-    _tagName_input = () => ({});
-  }
-  _dynamicTagAttrs(_scope, "#text/0", _tagName_input, _tagNameBody, _dirty);
-});
+const _tagName_input = _dynamicTagAttrs("#text/0", _tagNameBody);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", _scope => _tagName_input(_scope, () => ({})), null, _tagName_input);
 const _tagName_effect = _register("packages/translator/src/__tests__/fixtures/dynamic-tag-with-updating-body/template.marko_0_tagName", _scope => _on(_scope["#button/1"], "click", function () {
   const {
     tagName
   } = _scope;
   _queueSource(_scope, _tagName, tagName === "span" ? "div" : "span");
 }));
-const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName, _dirty) => {
-  let _dynamicTagName_value;
-  if (_dirty) {
-    _queueEffect(_scope, _tagName_effect);
-    _dynamicTagName_value = tagName || _tagNameBody;
-  }
-  _dynamicTagName(_scope, _dynamicTagName_value, _dirty);
-});
+const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName) => {
+  _queueEffect(_scope, _tagName_effect);
+  _dynamicTagName(_scope, tagName || _tagNameBody);
+}, null, _dynamicTagName);
 const _setup = _scope => {
   _tagName(_scope, "div");
 };

--- a/packages/translator/src/__tests__/fixtures/for-destructure/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/for-destructure/__snapshots__/dom.expected/template.js
@@ -2,14 +2,14 @@ import { data as _data, on as _on, queueSource as _queueSource, value as _value,
 const _description$forBody = /* @__PURE__ */_value("description", (_scope, description) => _data(_scope["#text/1"], description));
 const _name$forBody = /* @__PURE__ */_value("name", (_scope, name) => _data(_scope["#text/0"], name));
 const _forBody = /* @__PURE__ */_createRenderer("<div><!>: <!></div>", /* next(1), replace, over(2), replace */"D%c%");
-const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _clean) => {
   let name, description;
-  if (_dirty) [{
+  if (!_clean) [{
     name,
     description
   }] = _destructure;
-  _name$forBody(_scope, name, _dirty);
-  _description$forBody(_scope, description, _dirty);
+  _name$forBody(_scope, name, _clean);
+  _description$forBody(_scope, description, _clean);
 });
 const _items_effect = _register("packages/translator/src/__tests__/fixtures/for-destructure/template.marko_0_items", _scope => {
   _on(_scope["#button/1"], "click", function () {

--- a/packages/translator/src/__tests__/fixtures/for-tag-siblings/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag-siblings/__snapshots__/dom.expected/template.js
@@ -3,15 +3,15 @@ const _val$forBody2 = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope
 const _forBody2 = /* @__PURE__ */_createRenderer("<div> </div>", /* next(1), get */"D ");
 const _val$forBody = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope["#text/0"], val));
 const _forBody = /* @__PURE__ */_createRenderer("<div> </div>", /* next(1), get */"D ");
-const _for2 = /* @__PURE__ */_loop("#text/1", _forBody2, (_scope, _destructure2, _dirty = true) => {
+const _for2 = /* @__PURE__ */_loop("#text/1", _forBody2, (_scope, _destructure2, _clean) => {
   let val;
-  if (_dirty) [val] = _destructure2;
-  _val$forBody2(_scope, val, _dirty);
+  if (!_clean) [val] = _destructure2;
+  _val$forBody2(_scope, val, _clean);
 });
-const _for = /* @__PURE__ */_loop("#div/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _for = /* @__PURE__ */_loop("#div/0", _forBody, (_scope, _destructure, _clean) => {
   let val;
-  if (_dirty) [val] = _destructure;
-  _val$forBody(_scope, val, _dirty);
+  if (!_clean) [val] = _destructure;
+  _val$forBody(_scope, val, _clean);
 });
 const _arrA = /* @__PURE__ */_value("arrA", (_scope, arrA) => {
   _for(_scope, [arrA, null]);

--- a/packages/translator/src/__tests__/fixtures/for-tag-with-state/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag-with-state/__snapshots__/dom.expected/template.js
@@ -5,17 +5,17 @@ const _forBody2 = /* @__PURE__ */_createRenderer("<div><!>: <!></div>", /* next(
 const _i$forBody = /* @__PURE__ */_value("i", (_scope, i) => _data(_scope["#text/0"], i));
 const _val$forBody = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope["#text/1"], val));
 const _forBody = /* @__PURE__ */_createRenderer("<div><!>: <!></div>", /* next(1), replace, over(2), replace */"D%c%");
-const _for2 = /* @__PURE__ */_loop("#text/1", _forBody2, (_scope, _destructure2, _dirty = true) => {
+const _for2 = /* @__PURE__ */_loop("#text/1", _forBody2, (_scope, _destructure2, _clean) => {
   let val, i;
-  if (_dirty) [val, i] = _destructure2;
-  _val$forBody2(_scope, val, _dirty);
-  _i$forBody2(_scope, i, _dirty);
+  if (!_clean) [val, i] = _destructure2;
+  _val$forBody2(_scope, val, _clean);
+  _i$forBody2(_scope, i, _clean);
 });
-const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _clean) => {
   let val, i;
-  if (_dirty) [val, i] = _destructure;
-  _val$forBody(_scope, val, _dirty);
-  _i$forBody(_scope, i, _dirty);
+  if (!_clean) [val, i] = _destructure;
+  _val$forBody(_scope, val, _clean);
+  _i$forBody(_scope, i, _clean);
 });
 const _arrB = /* @__PURE__ */_value("arrB", (_scope, arrB) => _for2(_scope, [arrB, null]));
 const _arrA = /* @__PURE__ */_value("arrA", (_scope, arrA) => _for(_scope, [arrA, null]));

--- a/packages/translator/src/__tests__/fixtures/for-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/for-tag/__snapshots__/dom.expected/template.js
@@ -13,10 +13,10 @@ const _i$forBody6 = /* @__PURE__ */_value("i", (_scope, i) => {
   _attr(_scope["#div/2"], "key", `other-${i}`);
 });
 const _forBody8 = /* @__PURE__ */_createRenderer("<div> </div><div></div><div></div>", /* get, next(1), get, out(1), over(1), get */" D lb ");
-const _for$forBody = /* @__PURE__ */_loop("#text/3", _forBody8, (_scope, _destructure7, _dirty = true) => {
+const _for$forBody = /* @__PURE__ */_loop("#text/3", _forBody8, (_scope, _destructure7, _clean) => {
   let i;
-  if (_dirty) [i] = _destructure7;
-  _i$forBody6(_scope, i, _dirty);
+  if (!_clean) [i] = _destructure7;
+  _i$forBody6(_scope, i, _clean);
 });
 const _i$forBody5 = /* @__PURE__ */_value("i", (_scope, i) => {
   _attr(_scope["#div/0"], "key", i);
@@ -55,51 +55,51 @@ const _val$forBody = /* @__PURE__ */_value("val", (_scope, val) => _data(_scope[
 const _forBody = /* @__PURE__ */_createRenderer("<div><!>: <!></div><div></div><div></div>", /* next(1), replace, over(2), replace */"D%c%");
 const _for10 = /* @__PURE__ */_loop("#text/9", _forBody11);
 const _for9 = /* @__PURE__ */_loop("#text/8", _forBody10);
-const _for8 = /* @__PURE__ */_loop("#text/7", _forBody9, (_scope, _destructure9, _dirty = true) => {
+const _for8 = /* @__PURE__ */_loop("#text/7", _forBody9, (_scope, _destructure9, _clean) => {
   let i;
-  if (_dirty) [i] = _destructure9;
-  _i$forBody7(_scope, i, _dirty);
+  if (!_clean) [i] = _destructure9;
+  _i$forBody7(_scope, i, _clean);
 });
-const _for7 = /* @__PURE__ */_loop("#text/6", _forBody7, (_scope, _destructure8, _dirty = true) => {
+const _for7 = /* @__PURE__ */_loop("#text/6", _forBody7, (_scope, _destructure8, _clean) => {
   let i;
-  if (_dirty) [i] = _destructure8;
-  _i$forBody5(_scope, i, _dirty);
+  if (!_clean) [i] = _destructure8;
+  _i$forBody5(_scope, i, _clean);
 });
-const _for6 = /* @__PURE__ */_loop("#text/5", _forBody6, (_scope, _destructure6, _dirty = true) => {
+const _for6 = /* @__PURE__ */_loop("#text/5", _forBody6, (_scope, _destructure6, _clean) => {
   let key, val;
-  if (_dirty) [[key, val]] = _destructure6;
-  _key$forBody2(_scope, key, _dirty);
-  _val$forBody5(_scope, val, _dirty);
+  if (!_clean) [[key, val]] = _destructure6;
+  _key$forBody2(_scope, key, _clean);
+  _val$forBody5(_scope, val, _clean);
 });
-const _for5 = /* @__PURE__ */_loop("#text/4", _forBody5, (_scope, _destructure5, _dirty = true) => {
+const _for5 = /* @__PURE__ */_loop("#text/4", _forBody5, (_scope, _destructure5, _clean) => {
   let val, i, list;
-  if (_dirty) [val, i, list] = _destructure5;
-  _val$forBody4(_scope, val, _dirty);
-  _i$forBody4(_scope, i, _dirty);
-  _list$forBody(_scope, list, _dirty);
+  if (!_clean) [val, i, list] = _destructure5;
+  _val$forBody4(_scope, val, _clean);
+  _i$forBody4(_scope, i, _clean);
+  _list$forBody(_scope, list, _clean);
 });
-const _for4 = /* @__PURE__ */_loop("#text/3", _forBody4, (_scope, _destructure4, _dirty = true) => {
+const _for4 = /* @__PURE__ */_loop("#text/3", _forBody4, (_scope, _destructure4, _clean) => {
   let val, i;
-  if (_dirty) [val, i] = _destructure4;
-  _val$forBody3(_scope, val, _dirty);
-  _i$forBody3(_scope, i, _dirty);
+  if (!_clean) [val, i] = _destructure4;
+  _val$forBody3(_scope, val, _clean);
+  _i$forBody3(_scope, i, _clean);
 });
-const _for3 = /* @__PURE__ */_loop("#text/2", _forBody3, (_scope, _destructure3, _dirty = true) => {
+const _for3 = /* @__PURE__ */_loop("#text/2", _forBody3, (_scope, _destructure3, _clean) => {
   let i;
-  if (_dirty) [i] = _destructure3;
-  _i$forBody2(_scope, i, _dirty);
+  if (!_clean) [i] = _destructure3;
+  _i$forBody2(_scope, i, _clean);
 });
-const _for2 = /* @__PURE__ */_loop("#text/1", _forBody2, (_scope, _destructure2, _dirty = true) => {
+const _for2 = /* @__PURE__ */_loop("#text/1", _forBody2, (_scope, _destructure2, _clean) => {
   let key, val;
-  if (_dirty) [[key, val]] = _destructure2;
-  _key$forBody(_scope, key, _dirty);
-  _val$forBody2(_scope, val, _dirty);
+  if (!_clean) [[key, val]] = _destructure2;
+  _key$forBody(_scope, key, _clean);
+  _val$forBody2(_scope, val, _clean);
 });
-const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _clean) => {
   let val, i;
-  if (_dirty) [val, i] = _destructure;
-  _val$forBody(_scope, val, _dirty);
-  _i$forBody(_scope, i, _dirty);
+  if (!_clean) [val, i] = _destructure;
+  _val$forBody(_scope, val, _clean);
+  _i$forBody(_scope, i, _clean);
 });
 const _obj = /* @__PURE__ */_value("obj", (_scope, obj) => {
   _for2(_scope, _computeLoopIn(obj));

--- a/packages/translator/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.js
@@ -13,18 +13,8 @@ const _expr_x_y = /* @__PURE__ */_intersection(2, _scope => {
   } = _scope;
   _queueEffect(_scope, _expr_x_y_effect);
 });
-const _y = /* @__PURE__ */_value("y", (_scope, y, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/2"], y);
-  }
-  _expr_x_y(_scope, _dirty);
-});
-const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
-  if (_dirty) {
-    _data(_scope["#text/1"], x);
-  }
-  _expr_x_y(_scope, _dirty);
-});
+const _y = /* @__PURE__ */_value("y", (_scope, y) => _data(_scope["#text/2"], y), _expr_x_y);
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _data(_scope["#text/1"], x), _expr_x_y);
 const _setup = _scope => {
   _x(_scope, 1);
   _y(_scope, 1);

--- a/packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
@@ -29,26 +29,17 @@ const _show_effect = _register("packages/translator/src/__tests__/fixtures/lifec
   } = _scope;
   _queueSource(_scope, _show, !show);
 }));
-const _show = /* @__PURE__ */_value("show", (_scope, show, _dirty) => {
-  let _if_value;
-  if (_dirty) {
-    _queueEffect(_scope, _show_effect);
-    _if_value = show ? _ifBody : null;
-  }
-  _if(_scope, _if_value, _dirty);
-});
+const _show = /* @__PURE__ */_value("show", (_scope, show) => {
+  _queueEffect(_scope, _show_effect);
+  _if(_scope, show ? _ifBody : null);
+}, null, _if);
 const _x_effect = _register("packages/translator/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_0_x", _scope => _on(_scope["#button/1"], "click", function () {
   const {
     x
   } = _scope;
   _queueSource(_scope, _x, x + 1);
 }));
-const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
-  if (_dirty) {
-    _queueEffect(_scope, _x_effect);
-  }
-  _inConditionalScope(_scope, _dirty, _x$ifBody, "#text/0");
-});
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _queueEffect(_scope, _x_effect), _inConditionalScope(_x$ifBody, "#text/0"));
 const _setup = _scope => {
   _x(_scope, 0);
   _show(_scope, true);

--- a/packages/translator/src/__tests__/fixtures/move-and-clear-children/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/move-and-clear-children/__snapshots__/dom.expected/template.js
@@ -1,20 +1,20 @@
 import { data as _data, value as _value, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _child$forBody = /* @__PURE__ */_value("child", (_scope, child) => _data(_scope["#text/0"], child.text));
 const _forBody = /* @__PURE__ */_createRenderer(" ", /* get */" ");
-const _for = /* @__PURE__ */_loop("#div/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _for = /* @__PURE__ */_loop("#div/0", _forBody, (_scope, _destructure, _clean) => {
   let child;
-  if (_dirty) [child] = _destructure;
-  _child$forBody(_scope, child, _dirty);
+  if (!_clean) [child] = _destructure;
+  _child$forBody(_scope, child, _clean);
 });
 const _children = /* @__PURE__ */_value("children", (_scope, children) => _for(_scope, [children, function (c) {
   return c.id;
 }]));
-export const attrs = (_scope, _destructure2, _dirty = true) => {
+export const attrs = (_scope, _destructure2, _clean) => {
   let children;
-  if (_dirty) ({
+  if (!_clean) ({
     children
   } = _destructure2);
-  _children(_scope, children, _dirty);
+  _children(_scope, children, _clean);
 };
 export { _children };
 export const template = "<div></div>";

--- a/packages/translator/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/dom.expected/template.js
@@ -1,10 +1,10 @@
 import { data as _data, value as _value, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _child$forBody = /* @__PURE__ */_value("child", (_scope, child) => _data(_scope["#text/0"], child.text));
 const _forBody = /* @__PURE__ */_createRenderer(" ", /* get */" ");
-const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _for = /* @__PURE__ */_loop("#text/0", _forBody, (_scope, _destructure, _clean) => {
   let child;
-  if (_dirty) [child] = _destructure;
-  _child$forBody(_scope, child, _dirty);
+  if (!_clean) [child] = _destructure;
+  _child$forBody(_scope, child, _clean);
 });
 const _input = /* @__PURE__ */_value("input", (_scope, input) => _for(_scope, [input.children, function (c) {
   return c.id;

--- a/packages/translator/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/components/hello-setter.js
+++ b/packages/translator/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/components/hello-setter.js
@@ -6,12 +6,12 @@ const _el_effect = _register("packages/translator/src/__tests__/fixtures/native-
   el().textContent = "hello";
 });
 const _el = /* @__PURE__ */_value("el", (_scope, el) => _queueEffect(_scope, _el_effect));
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let el;
-  if (_dirty) ({
+  if (!_clean) ({
     el
   } = _destructure);
-  _el(_scope, el, _dirty);
+  _el(_scope, el, _clean);
 };
 export { _el };
 export const template = "";

--- a/packages/translator/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/template.js
@@ -1,4 +1,4 @@
-import { bindFunction as _bindFunction, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
+import { bindFunction as _bindFunction, inChild as _inChild, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const el_getter = _scope => _scope["#div/0"];
 import { setup as _helloSetter, attrs as _helloSetter_attrs, template as _helloSetter_template, walks as _helloSetter_walks } from "./components/hello-setter.marko";
 const _setup = _scope => {

--- a/packages/translator/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/dom.expected/template.js
@@ -1,20 +1,20 @@
 import { data as _data, value as _value, createRenderer as _createRenderer, loop as _loop, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _child$forBody = /* @__PURE__ */_value("child", (_scope, child) => _data(_scope["#text/0"], child.text));
 const _forBody = /* @__PURE__ */_createRenderer(" ", /* get */" ");
-const _for = /* @__PURE__ */_loop("#div/0", _forBody, (_scope, _destructure, _dirty = true) => {
+const _for = /* @__PURE__ */_loop("#div/0", _forBody, (_scope, _destructure, _clean) => {
   let child;
-  if (_dirty) [child] = _destructure;
-  _child$forBody(_scope, child, _dirty);
+  if (!_clean) [child] = _destructure;
+  _child$forBody(_scope, child, _clean);
 });
 const _children = /* @__PURE__ */_value("children", (_scope, children) => _for(_scope, [children, function (c) {
   return c.id;
 }]));
-export const attrs = (_scope, _destructure2, _dirty = true) => {
+export const attrs = (_scope, _destructure2, _clean) => {
   let children;
-  if (_dirty) ({
+  if (!_clean) ({
     children
   } = _destructure2);
-  _children(_scope, children, _dirty);
+  _children(_scope, children, _clean);
 };
 export { _children };
 export const template = "<div></div>";

--- a/packages/translator/src/__tests__/fixtures/return-tag-no-var/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator/src/__tests__/fixtures/return-tag-no-var/__snapshots__/dom.expected/components/child.js
@@ -1,11 +1,5 @@
 import { tagVarSignal as _tagVarSignal, value as _value, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
-const _x = /* @__PURE__ */_value("x", (_scope, x, _dirty) => {
-  let _tagVarSignal_value;
-  if (_dirty) {
-    _tagVarSignal_value = x;
-  }
-  _tagVarSignal(_scope, _tagVarSignal_value, _dirty);
-});
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _tagVarSignal(_scope, x), null, _tagVarSignal);
 const _setup = _scope => {
   _x(_scope, 1);
 };

--- a/packages/translator/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.expected/template.js
@@ -2,20 +2,13 @@ import { data as _data, closure as _closure, createRenderer as _createRenderer, 
 const _value$ifBody = /* @__PURE__ */_closure("value", (_scope, value) => _data(_scope["#text/0"], value));
 const _ifBody = _register("packages/translator/src/__tests__/fixtures/toggle-first-child/template.marko_1_renderer", /* @__PURE__ */_createRenderer("<span> </span>", /* next(1), get */"D ", null, [_value$ifBody]));
 const _if = /* @__PURE__ */_conditional("#text/0");
-const _value = /* @__PURE__ */_value2("value", (_scope, value, _dirty) => {
-  let _if_value;
-  if (_dirty) {
-    _if_value = value ? _ifBody : null;
-  }
-  _if(_scope, _if_value, _dirty);
-  _inConditionalScope(_scope, _dirty, _value$ifBody, "#text/0");
-});
-export const attrs = (_scope, _destructure, _dirty = true) => {
+const _value = /* @__PURE__ */_value2("value", (_scope, value) => _if(_scope, value ? _ifBody : null), _inConditionalScope(_value$ifBody, "#text/0"), _if);
+export const attrs = (_scope, _destructure, _clean) => {
   let value;
-  if (_dirty) ({
+  if (!_clean) ({
     value
   } = _destructure);
-  _value(_scope, value, _dirty);
+  _value(_scope, value, _clean);
 };
 export { _value };
 export const template = "<div><!><span></span><span></span></div>";

--- a/packages/translator/src/__tests__/fixtures/toggle-nested/browser.ts
+++ b/packages/translator/src/__tests__/fixtures/toggle-nested/browser.ts
@@ -76,37 +76,26 @@ const enum INDEX_IF2 {
 export const template = `<div></div>`;
 export const walks = get + over(1);
 
-export const attrs = (scope: Scope, input: Input, dirty?: null | boolean) => {
+export const attrs = (scope: Scope, input: Input, clean?: 1 | boolean) => {
   let show, value1, value2;
-  if (dirty) {
+  if (!clean) {
     ({ show, value1, value2 } = input);
   }
-  _show(scope, show, dirty);
-  _value1(scope, value1, dirty);
-  _value2(scope, value2, dirty);
+  _show(scope, show, clean);
+  _value1(scope, value1, clean);
+  _value2(scope, value2, clean);
 };
-
-const _show = value(INDEX.show, (scope, value, dirty) => {
-  _if0(scope, value ? ifBody0 : undefined, dirty);
-});
-const _value1 = value(INDEX.value1, (scope, _value, dirty) => {
-  inConditionalScope(scope, dirty!, value1$if0, INDEX.conditional);
-});
-const _value2 = value(INDEX.value2, (scope, _value, dirty) => {
-  inConditionalScope(scope, dirty!, value2$if0, INDEX.conditional);
-});
 
 const _if0 = conditionalOnlyChild(INDEX.conditional);
 
-const value1$if0 = closure(INDEX.value1, (scope, value, dirty) => {
-  _if1(scope, value ? ifBody1 : undefined, dirty);
-  inConditionalScope(scope, dirty!, value1$if1, INDEX_IF0.conditional0);
-});
-
-const value2$if0 = closure(INDEX.value2, (scope, value, dirty) => {
-  _if2(scope, value ? ifBody2 : undefined, dirty);
-  inConditionalScope(scope, dirty!, value2$if2, INDEX_IF0.conditional1);
-});
+const _show = value(
+  INDEX.show,
+  (scope, value) => {
+    _if0(scope, value ? ifBody0 : undefined);
+  },
+  undefined,
+  _if0
+);
 
 const _if1 = conditional(INDEX_IF0.conditional0);
 
@@ -130,6 +119,37 @@ const value2$if2 = closure(
   (scope) => {
     return (scope as If1Scope)._._;
   }
+);
+
+const value1$if0 = closure(
+  INDEX.value1,
+  (scope, value) => {
+    _if1(scope, value ? ifBody1 : undefined);
+  },
+  undefined,
+  inConditionalScope(value1$if1, INDEX_IF0.conditional0),
+  _if1
+);
+
+const value2$if0 = closure(
+  INDEX.value2,
+  (scope, value) => {
+    _if2(scope, value ? ifBody2 : undefined);
+  },
+  undefined,
+  inConditionalScope(value2$if2, INDEX_IF0.conditional1),
+  _if2
+);
+
+const _value1 = value(
+  INDEX.value1,
+  undefined,
+  inConditionalScope(value1$if0, INDEX.conditional)
+);
+const _value2 = value(
+  INDEX.value2,
+  undefined,
+  inConditionalScope(value2$if0, INDEX.conditional)
 );
 
 export default createRenderFn(template, walks, undefined, attrs);

--- a/packages/translator/src/__tests__/fixtures/toggle-only-child/browser.ts
+++ b/packages/translator/src/__tests__/fixtures/toggle-only-child/browser.ts
@@ -51,17 +51,21 @@ const value$if = closure(INDEX.value, (scope: Scope, value: string) => {
 
 const _if = conditionalOnlyChild(INDEX.conditional);
 
-const _value = value(INDEX.value, (scope, value, dirty) => {
-  _if(scope, value ? _ifBody : undefined, dirty);
-  inConditionalScope(scope, dirty, value$if, INDEX.conditional);
-});
+const _value = value(
+  INDEX.value,
+  (scope, value) => {
+    _if(scope, value ? _ifBody : undefined);
+  },
+  inConditionalScope(value$if, INDEX.conditional),
+  _if
+);
 
-export const attrs = (scope: Scope, input: Input, dirty?: boolean | null) => {
+export const attrs = (scope: Scope, input: Input, clean?: boolean | 1) => {
   let value;
-  if (dirty) {
+  if (!clean) {
     ({ value } = input);
   }
-  _value(scope, value, dirty);
+  _value(scope, value, clean);
 };
 
 export default createRenderFn<Input>(template, walks, undefined, attrs);

--- a/packages/translator/src/__tests__/fixtures/update-dynamic-attrs/browser.ts
+++ b/packages/translator/src/__tests__/fixtures/update-dynamic-attrs/browser.ts
@@ -28,12 +28,12 @@ const _value = value(INDEX.value, (scope: Scope, value: Input["value"]) => {
   value && attrs(scope, INDEX.div, value);
 });
 
-export const _attrs = (scope: Scope, input: Input, dirty?: boolean | null) => {
+export const _attrs = (scope: Scope, input: Input, clean?: boolean | 1) => {
   let value: Input["value"];
-  if (dirty) {
+  if (!clean) {
     ({ value } = input);
   }
-  _value(scope, value!, dirty);
+  _value(scope, value!, clean);
 };
 
 export default createRenderFn<Input>(template, walks, undefined, _attrs);

--- a/packages/translator/src/__tests__/fixtures/update-html/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/update-html/__snapshots__/dom.expected/template.js
@@ -1,11 +1,11 @@
 import { html as _html, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _value = /* @__PURE__ */_value2("value", (_scope, value) => _html(_scope, value, "#text/0"));
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let value;
-  if (_dirty) ({
+  if (!_clean) ({
     value
   } = _destructure);
-  _value(_scope, value, _dirty);
+  _value(_scope, value, _clean);
 };
 export { _value };
 export const template = "<em>Testing</em> <!>";

--- a/packages/translator/src/__tests__/fixtures/update-text/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/update-text/__snapshots__/dom.expected/template.js
@@ -1,11 +1,11 @@
 import { data as _data, value as _value2, createRenderFn as _createRenderFn } from "@marko/runtime-fluurt/src/dom";
 const _value = /* @__PURE__ */_value2("value", (_scope, value) => _data(_scope["#text/0"], value));
-export const attrs = (_scope, _destructure, _dirty = true) => {
+export const attrs = (_scope, _destructure, _clean) => {
   let value;
-  if (_dirty) ({
+  if (!_clean) ({
     value
   } = _destructure);
-  _value(_scope, value, _dirty);
+  _value(_scope, value, _clean);
 };
 export { _value };
 export const template = "Static <!>";

--- a/packages/translator/src/__tests__/fixtures/user-effect-cleanup/__snapshots__/dom.expected/template.js
+++ b/packages/translator/src/__tests__/fixtures/user-effect-cleanup/__snapshots__/dom.expected/template.js
@@ -6,8 +6,8 @@ const _expr_a_b = /* @__PURE__ */_intersection(2, _scope => {
   } = _scope;
   _data(_scope["#text/0"], "" + a + b);
 });
-const _b = /* @__PURE__ */_value("b", (_scope, b, _dirty) => _expr_a_b(_scope, _dirty));
-const _a = /* @__PURE__ */_value("a", (_scope, a, _dirty) => _expr_a_b(_scope, _dirty));
+const _b = /* @__PURE__ */_value("b", null, _expr_a_b);
+const _a = /* @__PURE__ */_value("a", null, _expr_a_b);
 const _input_effect = _register("packages/translator/src/__tests__/fixtures/user-effect-cleanup/template.marko_0_input", _scope => _userEffect(_scope, "cleanup", function () {
   const {
     input

--- a/packages/translator/src/core/condition/if.ts
+++ b/packages/translator/src/core/condition/if.ts
@@ -32,7 +32,7 @@ import { isOutputDOM, isOutputHTML } from "../../util/marko-config";
 import analyzeAttributeTags from "../../util/nested-attribute-tags";
 import customTag from "../../visitors/tag/custom-tag";
 import { mergeReferences, References } from "../../util/references";
-import { dirtyIdentifier, scopeIdentifier } from "../../visitors/program";
+import { scopeIdentifier } from "../../visitors/program";
 
 export default {
   analyze: {
@@ -195,15 +195,11 @@ export function exitBranchTranslate(tag: t.NodePath<t.MarkoTag>) {
         const id = writer.getRenderer(section);
 
         setSubscriberBuilder(tag, (subscriber) => {
-          return t.expressionStatement(
-            callRuntime(
-              "inConditionalScope",
-              scopeIdentifier,
-              dirtyIdentifier,
-              subscriber,
-              getScopeAccessorLiteral(extra.reserve!)
-              /*writer.getRenderer(section)*/
-            )
+          return callRuntime(
+            "inConditionalScope",
+            subscriber,
+            getScopeAccessorLiteral(extra.reserve!)
+            /*writer.getRenderer(section)*/
           );
         });
 

--- a/packages/translator/src/core/for.ts
+++ b/packages/translator/src/core/for.ts
@@ -33,11 +33,7 @@ import { callRuntime, importRuntime } from "../util/runtime";
 import analyzeAttributeTags from "../util/nested-attribute-tags";
 import customTag from "../visitors/tag/custom-tag";
 import { mergeReferences } from "../util/references";
-import {
-  currentProgramPath,
-  dirtyIdentifier,
-  scopeIdentifier,
-} from "../visitors/program";
+import { currentProgramPath } from "../visitors/program";
 
 export default {
   analyze: {
@@ -189,14 +185,10 @@ const translateDOM = {
     } = isOnlyChild ? (tag.parentPath.parent as t.MarkoTag) : tag.node;
 
     setSubscriberBuilder(tag, (signal: t.Expression) => {
-      return t.expressionStatement(
-        callRuntime(
-          "inLoopScope",
-          scopeIdentifier,
-          dirtyIdentifier,
-          signal,
-          getScopeAccessorLiteral(reserve!)
-        )
+      return callRuntime(
+        "inLoopScope",
+        signal,
+        getScopeAccessorLiteral(reserve!)
       );
     });
 

--- a/packages/translator/src/visitors/program/index.ts
+++ b/packages/translator/src/visitors/program/index.ts
@@ -13,7 +13,7 @@ import { callRuntime } from "../../util/runtime";
 
 export let currentProgramPath: t.NodePath<t.Program>;
 export let scopeIdentifier: t.Identifier;
-export let dirtyIdentifier: t.Identifier;
+export let cleanIdentifier: t.Identifier;
 
 const previousProgramPath: WeakMap<
   t.NodePath<t.Program>,
@@ -52,8 +52,8 @@ export default {
       scopeIdentifier = isOutputDOM()
         ? program.scope.generateUidIdentifier("scope")
         : (null as any as t.Identifier);
-      dirtyIdentifier = isOutputDOM()
-        ? program.scope.generateUidIdentifier("dirty")
+      cleanIdentifier = isOutputDOM()
+        ? program.scope.generateUidIdentifier("clean")
         : (null as any as t.Identifier);
       if (getMarkoOpts().output === ("hydrate" as "html")) {
         program.skip();

--- a/packages/translator/src/visitors/tag/custom-tag.ts
+++ b/packages/translator/src/visitors/tag/custom-tag.ts
@@ -283,7 +283,12 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
         hasDownstreamIntersections: () => true,
       },
       attrsObject,
-      createScopeReadExpression(tagSection, binding)
+      createScopeReadExpression(tagSection, binding),
+      callRuntime(
+        "inChild",
+        getScopeAccessorLiteral(binding),
+        t.identifier(tagAttrsIdentifier.name)
+      )
     );
   }
   tag.remove();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Switch from `dirty` to `clean` internally
- Alternative signal api that doesn't require `dirty`/`clean` checks in the compiled code (for the most part)

<!--- Describe your changes in detail.  Include the package name if applicable. -->

OLD:
```js
const _multiplier = /* @__PURE__ */_value("multiplier", (_scope, multiplier, _dirty) => {
  if (_dirty) {
    _data(_scope["#text/1"], multiplier);
    _queueEffect(_scope, _multiplier_effect);
  }
  _expr_count_multiplier(_scope, _dirty);
});
```

NEW:
```js
const _multiplier = /* @__PURE__ */_value("multiplier", (_scope, multiplier) => {
  _data(_scope["#text/1"], multiplier);
  _queueEffect(_scope, _multiplier_effect);
}, _expr_count_multiplier);
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Smaller compiled output

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
